### PR TITLE
Add .NET CLI to build your first app page

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -14,7 +14,7 @@
       ],
       "type_mapping": {
         "Conceptual": "Content",
-        "ZonePivotGoups": "Toc"
+        "ZonePivotGroups": "Toc"
       },
       "build_entry_point": "docs",
       "template_folder": "_themes"

--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -13,7 +13,8 @@
         "/uwp/api"
       ],
       "type_mapping": {
-        "Conceptual": "Content"
+        "Conceptual": "Content",
+        "ZonePivotGoups": "Toc"
       },
       "build_entry_point": "docs",
       "template_folder": "_themes"
@@ -26,7 +27,7 @@
   "git_repository_branch_open_to_public_contributors": "main",
   "skip_source_output_uploading": false,
   "need_preview_pull_request": true,
-  "need_pr_comments": false,  
+  "need_pr_comments": false,
   "contribution_branch_mappings": {},
   "dependent_repositories": [
     {

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -49,7 +49,8 @@
       "feedback_github_repo": "dotnet/docs-maui",
       "ms.author": "dabritch",
       "ms.prod": "dotnet-mobile",
-      "ms.technology": "dotnet-maui"
+      "ms.technology": "dotnet-maui",
+      "zone_pivot_group_filename": "maui/zone-pivot-groups.json"
     },
     "fileMetadata": {},
     "template": [],

--- a/docs/fundamentals/app-startup.md
+++ b/docs/fundamentals/app-startup.md
@@ -1,7 +1,7 @@
 ---
 title: ".NET MAUI app startup"
 description: ".NET MAUI apps are bootstrapped using HostBuilder from the Microsoft.Extensions library, enabling apps to be initialized from a single location."
-ms.date: 06/10/2021
+ms.date: 06/18/2021
 ---
 
 # .NET MAUI app startup

--- a/docs/fundamentals/app-startup.md
+++ b/docs/fundamentals/app-startup.md
@@ -131,28 +131,6 @@ public class Startup : IStartup
 
 In this example, the `MyEntryHandler` handler is registered against the `MyEntry` control. Therefore, any instances of the `MyEntry` control will be handled by the `MyEntryHandler`.
 
-## Configure compatibility
-
-To use Xamarin.Forms compatibility features, including controls backed by Xamarin.Forms renderers instead of .NET MAUI handlers, call the `UseFormsCompatibility` method on the `IAppHostBuilder` object:
-
-```csharp
-using Microsoft.Maui;
-using Microsoft.Maui.Hosting;
-using Microsoft.Maui.Controls.Compatibility;
-
-public class Startup : IStartup
-{
-    public void Configure(IAppHostBuilder appBuilder)
-    {
-        appBuilder
-            .UseFormsCompatibility()
-            .UseMauiApp<App>();
-    }
-}
-```
-
-The `UseCompatibility` method also accepts an optional `bool` argument that specifies whether to register renderers. By passing `false` to this method you can use all Xamarin.Forms compatibility features except for renderers.
-
 ### Register renderers
 
 To use controls backed by .NET MAUI handlers, with specific controls backed by Xamarin.Forms renderers, call the `ConfigureMauiHandlers` method on the `IAppHostBuilder` object. Then, on the `IMauiHandlersCollection` object, call the `AddCompatibilityRenderer` method to add the required renderer:
@@ -166,8 +144,7 @@ public class Startup : IStartup
 {
     public void Configure(IAppHostBuilder appBuilder)
     {
-        appBuilder
-            .UseFormsCompatibility(false)          
+        appBuilder   
             .UseMauiApp<App>()
             #if __ANDROID__
             .ConfigureMauiHandlers(handlers =>

--- a/docs/get-started/first-app.md
+++ b/docs/get-started/first-app.md
@@ -1,15 +1,18 @@
 ---
 title: "Build your first .NET MAUI app in Visual Studio"
 description: "How to create and run your first .NET MAUI app."
+zone_pivot_groups: platform
 ms.date: 06/17/2021
 ---
 
 # Build your first .NET MAUI app
 
-In this tutorial, you'll learn how to create your first .NET Multi-platform App UI (MAUI) app, and run it in an Android emulator.
+In this tutorial, you'll learn how to create and run your first .NET Multi-platform App UI (MAUI) app.
 
 > [!NOTE]
 > Visual Studio for Mac support will arrive in a future release.
+
+::: zone pivot="windows"
 
 ## Prerequisites
 
@@ -19,7 +22,9 @@ In this tutorial, you'll learn how to create your first .NET Multi-platform App 
 
 ## Get started with Visual Studio 2019
 
-1. Launch VS2019 build 16.11 (Preview 2 or greater), and in the start window click **Create a new project** to create a new project:
+In this tutorial, you'll learn how to create your first .NET MAUI app in Visual Studio 2019, and run it on an Android emulator:
+
+1. Launch Visual Studio 2019 build 16.11 (Preview 2 or greater), and in the start window click **Create a new project** to create a new project:
 
     :::image type="content" source="first-app-images/new-solution.png" alt-text="New solution":::
 
@@ -44,3 +49,73 @@ In this tutorial, you'll learn how to create your first .NET Multi-platform App 
 1. In the running app in the Android emulator, press the **CLICK ME** button several times and observe that the count of the number of button clicks is incremented.
 
     [![App running in the Android emulator](first-app-images/running-app.png)](first-app-images/running-app-large.png#lightbox)
+
+### Build and debug iOS apps
+
+To build and debug .NET 6 iOS apps from Visual Studio 2019 you must manually install the .NET 6 SDK and iOS workloads on both Windows and macOS (your Mac build host).
+
+If, while connecting Visual Studio to your Mac through Xamarin Mac Agent (XMA), you are prompted to install a different version of the SDK, you can ignore the prompt since it refers to a legacy version of XMA.
+
+> [!NOTE]
+> Visual Studio 2019 can only currently deploy .NET MAUI iOS apps to the iOS simulator, and not to physical devices.
+
+::: zone-end
+::: zone pivot="dotnet-cli"
+
+## Prerequisites
+
+- An environment that has been configured for .NET MAUI development, using the maui-check tool. For more information, see [Install .NET 6 Preview 5](installation.md#install-net-6-preview-5).
+- Simulators and emulators for your chosen platforms.
+
+## Get started with .NET command-line interface
+
+In this tutorial, you'll learn how to create and run your first .NET MAUI app using the .NET command-line interface (CLI):
+
+1. In the .NET CLI, create a new .NET MAUI app:
+
+    ```dotnetcli
+    dotnet new maui -n HelloMauiPreview
+    ```
+
+1. In the .NET CLI, change directory to the newly created project:
+
+    ```dotnetcli
+    cd HelloMauiPreview
+    ```
+
+1. In the .NET CLI, change directory to the single project and restore its dependencies:
+
+    ```dotnetcli
+    cd HelloMauiPreview
+    dotnet restore
+    ```
+
+1. In the .NET CLI, build and launch the app on your chosen platform:
+
+    ```dotnetcli
+    dotnet build -t:Run -f net6.0-android
+    dotnet build -t:Run -f net6.0-ios
+    dotnet build -t:Run -f net6.0-maccatalyst
+    ```
+
+    > [!NOTE]
+    > These commands will launch the app on the default platform device, if one can be found. On Android, it's recommended to start an emulator before building and launching your app.
+
+### iOS simulator selection
+
+It's possible to specify which simulator is launched and used for net6.0-ios by specifying the `_DeviceName` MSBuild property:
+
+```dotnetcli
+dotnet build -t:Run -f net6.0-ios -p:_DeviceName=:v2:udid=<UDID>
+```
+
+You can retrieve a list of possible unique device id (UDID) values by executing the `simctl list` command:
+
+```console
+/Applications/Xcode.app/Contents/Developer/usr/bin/simctl list
+```
+
+> [!NOTE]
+> The default iOS simulator will be launched if you don't specify a UDID.
+
+::: zone-end

--- a/docs/get-started/first-app.md
+++ b/docs/get-started/first-app.md
@@ -22,7 +22,7 @@ In this tutorial, you'll learn how to create and run your first .NET Multi-platf
 
 ## Get started with Visual Studio 2019
 
-In this tutorial, you'll learn how to create your first .NET MAUI app in Visual Studio 2019, and run it on an Android emulator:
+In this tutorial, you'll create your first .NET MAUI app in Visual Studio 2019, and run it on an Android emulator:
 
 1. Launch Visual Studio 2019 build 16.11 (Preview 2 or greater), and in the start window click **Create a new project** to create a new project:
 
@@ -69,7 +69,7 @@ If, while connecting Visual Studio to your Mac through Xamarin Mac Agent (XMA), 
 
 ## Get started with .NET command-line interface
 
-In this tutorial, you'll learn how to create and run your first .NET MAUI app using the .NET command-line interface (CLI):
+In this tutorial, you'll create and run your first .NET MAUI app using the .NET command-line interface (CLI):
 
 1. In the .NET CLI, create a new .NET MAUI app:
 

--- a/docs/get-started/first-app.md
+++ b/docs/get-started/first-app.md
@@ -50,7 +50,7 @@ In this tutorial, you'll create your first .NET MAUI app in Visual Studio 2019, 
 
     [![App running in the Android emulator](first-app-images/running-app.png)](first-app-images/running-app-large.png#lightbox)
 
-### Build and debug iOS apps
+## Build and debug iOS apps
 
 To build and debug .NET 6 iOS apps from Visual Studio 2019 you must manually install the .NET 6 SDK and iOS workloads on both Windows and macOS (your Mac build host).
 
@@ -101,7 +101,7 @@ In this tutorial, you'll create and run your first .NET MAUI app using the .NET 
     > [!NOTE]
     > These commands will launch the app on the default platform device, if one can be found. On Android, it's recommended to start an emulator before building and launching your app.
 
-### iOS simulator selection
+## iOS simulator selection
 
 It's possible to specify which simulator is launched and used for net6.0-ios by specifying the `_DeviceName` MSBuild property:
 

--- a/docs/get-started/first-app.md
+++ b/docs/get-started/first-app.md
@@ -65,7 +65,7 @@ If, while connecting Visual Studio to your Mac through Xamarin Mac Agent (XMA), 
 ## Prerequisites
 
 - An environment that has been configured for .NET MAUI development, using the maui-check tool. For more information, see [Install .NET 6 Preview 5](installation.md#install-net-6-preview-5).
-- Simulators and emulators for your chosen platforms.
+- A configured simulator or emulator for your chosen platform. For more information about creating an Android emulator, see [Android emulator setup](/xamarin/android/get-started/installation/android-emulator/).
 
 ## Get started with .NET command-line interface
 
@@ -115,7 +115,6 @@ You can retrieve a list of possible unique device id (UDID) values by executing 
 /Applications/Xcode.app/Contents/Developer/usr/bin/simctl list
 ```
 
-> [!NOTE]
-> The default iOS simulator will be launched if you don't specify a UDID.
+The default iOS simulator will be launched if you don't specify a UDID.
 
 ::: zone-end

--- a/docs/get-started/first-app.md
+++ b/docs/get-started/first-app.md
@@ -1,7 +1,7 @@
 ---
 title: "Build your first .NET MAUI app in Visual Studio"
 description: "How to create and run your first .NET MAUI app."
-zone_pivot_groups: platform
+zone_pivot_groups: preview-platforms
 ms.date: 06/17/2021
 ---
 

--- a/docs/get-started/first-app.md
+++ b/docs/get-started/first-app.md
@@ -101,7 +101,7 @@ In this tutorial, you'll create and run your first .NET MAUI app using the .NET 
     > [!NOTE]
     > These commands will launch the app on the default platform device, if one can be found. On Android, it's recommended to start an emulator before building and launching your app.
 
-## iOS simulator selection
+## Select an iOS simulator
 
 It's possible to specify which simulator is launched and used for net6.0-ios by specifying the `_DeviceName` MSBuild property:
 

--- a/docs/get-started/first-app.md
+++ b/docs/get-started/first-app.md
@@ -2,7 +2,7 @@
 title: "Build your first .NET MAUI app in Visual Studio"
 description: "How to create and run your first .NET MAUI app."
 zone_pivot_groups: preview-platforms
-ms.date: 06/17/2021
+ms.date: 06/18/2021
 ---
 
 # Build your first .NET MAUI app

--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -1,7 +1,7 @@
 ---
 title: ".NET MAUI installation"
 description: "Installation instructions for .NET MAUI."
-ms.date: 06/17/2021
+ms.date: 06/18/2021
 ---
 
 # .NET MAUI installation

--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -9,7 +9,9 @@ ms.date: 06/17/2021
 > [!IMPORTANT]
 > These requirements will change as new preview releases of Visual Studio and .NET MAUI are released.
 
-To create .NET Multi-platform App UI (MAUI) apps, you currently require .NET 6 Preview 5 with .NET MAUI and the platform SDKs for Android, iOS, macOS, tvOS, and Mac Catalyst. You also need [Visual Studio 16.11 Preview 2](https://visualstudio.microsoft.com/vs/preview/) with the following workloads installed:
+To create .NET Multi-platform App UI (MAUI) apps, you currently require .NET 6 Preview 5 with .NET MAUI and the platform SDKs for Android, iOS, macOS, tvOS, and Mac Catalyst.
+
+To create .NET MAUI apps in Visual Studio, you'll also need [Visual Studio 16.11 Preview 2](https://visualstudio.microsoft.com/vs/preview/) with the following workloads installed:
 
 - Mobile development with .NET
 - Universal Windows Platform development
@@ -135,52 +137,3 @@ exists.
 
 - Congratulations, everything looks great!
 ```
-
-## Build and launch apps
-
-For instructions on how to create and build your first .NET MAUI app, see [Build your first .NET MAUI app](first-app.md).
-
-Once a .NET MAUI app has been created, it can optionally be built using .NET CLI. The following .NET CLI commands show how to build and launch a .NET MAUI app on three different platforms:
-
-```dotnetcli
-dotnet build -t:Run -f net6.0-android
-dotnet build -t:Run -f net6.0-ios -p:_DeviceName=:v2:udid=<UDID>
-dotnet build -t:Run -f net6.0-maccatalyst
-```
-
-### iOS simulator selection
-
-It's possible to specify which simulator is launched and used for net6.0-ios by specifying the `_DeviceName` MSBuild property:
-
-```dotnetcli
-dotnet build -t:Run -f net6.0-ios -p:_DeviceName=:v2:udid=<UDID>
-```
-
-You can retrieve a list of possible unique device id (UDID) values by executing the `simctl list` command:
-
-```console
-/Applications/Xcode.app/Contents/Developer/usr/bin/simctl list
-```
-
-> [!NOTE]
-> The default iOS simulator will be launched if you don't specify a UDID.
-
-## IDE support
-
-Currently, you should use the latest preview version of Visual Studio 2019 16.11 on Windows (with the Mobile development with .NET and Universal Windows Platform development workloads installed).
-
-Visual Studio for Mac support will arrive in a future release.
-
-### iOS from Visual Studio
-
-To build and debug .NET 6 iOS apps from Visual Studio 2019 you must manually install the .NET 6 SDK and iOS workloads on both Windows and macOS (your Mac build host).
-
-If, while connecting Visual Studio to your Mac through Xamarin Mac Agent (XMA), you are prompted to install a different version of the SDK, you can ignore the prompt since it refers to a legacy version of XMA.
-
-> [!NOTE]
-> Visual Studio 2019 can only currently deploy .NET MAUI iOS apps to the iOS simulator, and not to physical devices.
-
-## Known issues
-
-- There are no project property pages available for iOS and Android.
-- Editors, such as the manifest editor and entitlements editor, will fail to open. As a workaround, files can be edited in the XML editor.

--- a/docs/get-started/migrate.md
+++ b/docs/get-started/migrate.md
@@ -48,7 +48,6 @@ This example ports the [Button Demos](/samples/xamarin/xamarin-forms-samples/use
     | `using Xamarin.Forms` | `using Microsoft.Maui` **AND** `using Microsoft.Maui.Controls` |
     | `using Xamarin.Forms.Xaml` | `using Microsoft.Maui.Controls.Xaml` |
 
-1. In the **Startup** class, disable the compatibility renderers by passing `false` to the `UseFormsCompatibility` method. This ensures that you'll be using the .NET MAUI `Button`, rather than the Xamarin.Forms `Button`.
 1. Run the app on your chosen platform:
 
     ```dotnetcli

--- a/docs/zone-pivot-groups.yml
+++ b/docs/zone-pivot-groups.yml
@@ -1,0 +1,10 @@
+### YamlMime:ZonePivotGroups
+groups:
+- id: platform
+  title: Platform
+  prompt: Choose your development environment
+  pivots:
+    - id: windows
+      title: Visual Studio 2019
+    - id: dotnet-cli
+      title: .NET CLI

--- a/docs/zone-pivot-groups.yml
+++ b/docs/zone-pivot-groups.yml
@@ -1,6 +1,6 @@
 ### YamlMime:ZonePivotGroups
 groups:
-- id: platform
+- id: preview-platforms
   title: Platform
   prompt: Choose your development environment
   pivots:


### PR DESCRIPTION
Fixes #32 
Fixes #29 

Also removes any references to `UseFormsCompatibility`, which has been removed in P5.