### PR TITLE
Fix errors caught by linter

### DIFF
--- a/ThirdPartyNotices.md
+++ b/ThirdPartyNotices.md
@@ -1,4 +1,5 @@
 ## Legal Notices
+
 Microsoft and any contributors grant you a license to the Microsoft documentation and other content
 in this repository under the [Creative Commons Attribution 4.0 International Public License](https://creativecommons.org/licenses/by/4.0/legalcode),
 see the [LICENSE](LICENSE) file, and grant you a license to any code in the repository under the [MIT License](https://opensource.org/licenses/MIT), see the
@@ -7,9 +8,9 @@ see the [LICENSE](LICENSE) file, and grant you a license to any code in the repo
 Microsoft, Windows, Microsoft Azure and/or other Microsoft products and services referenced in the documentation
 may be either trademarks or registered trademarks of Microsoft in the United States and/or other countries.
 The licenses for this project do not grant you rights to use any Microsoft names, logos, or trademarks.
-Microsoft's general trademark guidelines can be found at http://go.microsoft.com/fwlink/?LinkID=254653.
+Microsoft's general trademark guidelines can be found at <http://go.microsoft.com/fwlink/?LinkID=254653>.
 
-Privacy information can be found at https://privacy.microsoft.com/en-us/
+Privacy information can be found at <https://privacy.microsoft.com/>
 
 Microsoft and any contributors reserve all others rights, whether under their respective copyrights, patents,
 or trademarks, whether by implication, estoppel or otherwise.

--- a/docs/user-interface/handlers/customize.md
+++ b/docs/user-interface/handlers/customize.md
@@ -94,28 +94,28 @@ using Microsoft.Maui.Graphics;
 
 namespace MauiApp1
 {
-  	public partial class App : Application
-  	{
-  		public App()
-  		{
-          InitializeComponent();
+    public partial class App : Application
+    {
+        public App()
+        {
+            InitializeComponent();
 
-          Microsoft.Maui.Handlers.EntryHandler.EntryMapper[nameof(IView.Background)] = (handler, view) =>
-          {
-              if (view is MyEntry)
-              {
+            Microsoft.Maui.Handlers.EntryHandler.EntryMapper[nameof(IView.Background)] = (handler, view) =>
+            {
+                if (view is MyEntry)
+                {
 #if __ANDROID__
-                  handler.NativeView.SetBackgroundColor(Colors.Red.ToNative());
+                    handler.NativeView.SetBackgroundColor(Colors.Red.ToNative());
 #elif __IOS__
                   handler.NativeView.BackgroundColor = Colors.Red.ToNative();
                   handler.NativeView.BorderStyle = UIKit.UITextBorderStyle.Line;
 #elif WINDOWS
                   handler.NativeView.Background = Colors.Red.ToNative();
 #endif
-              }
-          };
-  		}
-  	}
+                }
+            };
+        }
+    }
 }
 ```
 


### PR DESCRIPTION
**docs/user-interface/handlers/customize.md**
- Multiple hard tabs. Fixed and reformatted code

**./ThirdPartyNotices.md**
- No blank line at the end of article
- Bare URLs converted to `< >` syntax
- Removed en-us from URL
- Added blank line around header

@davidbritch 