### PR TITLE
Fix minor word transposition

### DIFF
--- a/docs/includes/preview-note.md
+++ b/docs/includes/preview-note.md
@@ -1,2 +1,2 @@
 > [!IMPORTANT]
-> The documentation for .NET Multi-app Platform UI (.NET MAUI) is under construction.
+> The documentation for .NET Multi-platform App UI (.NET MAUI) is under construction.


### PR DESCRIPTION
The expansion of "MAUI" was incorrect in the "under construction" warning.