### PR TITLE
Add info about Windows version

### DIFF
--- a/docs/supported-platforms.md
+++ b/docs/supported-platforms.md
@@ -10,8 +10,8 @@ ms.date: 06/07/2021
 
 - Android 5.0 (API 21) or higher.
 - iOS 10 or higher.
-- macOS 10.13 or higher (using Mac Catalyst).
-- Windows desktop and the Universal Windows Platform (UWP), using Windows UI Library (WinUI) 3.
+- macOS 10.13 or higher, using Mac Catalyst.
+- Windows 11 and Windows 10 version 1809 or higher, using [Windows UI Library (WinUI) 3](/windows/apps/winui/winui3/).
 
 [!INCLUDE [docs under construction](~/includes/preview-note.md)]
 


### PR DESCRIPTION
- Removed the UWP info as I don't think it applies. WinUI 3 is standalone.
- Added Win 11 and 10 versions according to the WinUI 3 information.

Fixes #394 