### PR TITLE
Update app-lifecycle.md

### DIFF
--- a/docs/fundamentals/app-lifecycle.md
+++ b/docs/fundamentals/app-lifecycle.md
@@ -48,7 +48,7 @@ In addition to these events, the `Window` class also has the following overridab
 
 - `OnCreated`, which is invoked when the `Created` event is raised.
 - `OnActivated`, which is invoked when the `Activated` event is raised.
-- `OnDeactivated`, which is invoked when the `OnDeactivated` event is raised.
+- `OnDeactivated`, which is invoked when the `Deactivated` event is raised.
 - `OnStopped`, which is invoked when the `Stopped` event is raised.
 - `OnResumed`, which is invoked when the `Resumed` event is raised.
 - `OnDestroying`, which is invoked when the `Destroying` event is raised.


### PR DESCRIPTION
There was a mistake in the overridable methods for the line that reads `OnDeactivated`, which is invoked when the `OnDeactivated` event is raised. I believe that the event referred to should be the 'Deactivated' event as indicated earlier on in the article.