### PR TITLE
Windows Publishing Updates

### DIFF
--- a/docs/windows/deployment/overview.md
+++ b/docs/windows/deployment/overview.md
@@ -112,17 +112,15 @@ The `<GenerateAppxPackageOnBuild>` set to `true` packages the app and signs it w
 To publish your app, open the **Developer Command Prompt for VS 2022 Preview** terminal and navigate to the project's folder. Run `dotnet` in publish mode:  
 
 ```console
-dotnet publish /p:TargetFramework=net6.0-windows10.0.19041.0 /p:configuration=release
+dotnet publish -f net6.0-windows10.0.19041.0 -c Release
 ```
 
 The following table defines the parameters used by the previous command:
 
-| Parameter                  | Value                                                                               |
-|----------------------------|-------------------------------------------------------------------------------------|
-| `/restore`                 | Restores any dependencies referenced by the project.                                |
-| `/t:Publish`               | Runs the publish command.                                                           |
-| `/p:TargetFramework`       | The target framework, which is a Windows TFM, such as `net6.0-windows10.0.19041.0`. Make sure this value is the exact same between what is in your cspoj file (in the `<TargetFrameworks>` node) and this command-line argument. |
-| `/p:configuration=Release` | Sets the build configuration, which is `Release`.                                   |
+| Parameter                    | Value                                                                               |
+|------------------------------|-------------------------------------------------------------------------------------|
+| `-f net6.0-windows{version}` | The target framework, which is a Windows TFM, such as `net6.0-windows10.0.19041.0`. Make sure this value is the exact same between what is in your cspoj file (in the `<TargetFrameworks>` node) and this command-line argument.           |
+| `-c Release`                 | Sets the build configuration, which is `Release`.                                   |
 
 Publishing builds and packages the app, copying the signed package to the _bin\\Release\\net6.0-windows10.0.19041.0\\win10-x64\\AppPackages\\\<appname>\\_ folder. Where \<appname> is a folder named after both your project and version. In this folder there's an _msix_ file, that's the app package.
 

--- a/docs/windows/deployment/overview.md
+++ b/docs/windows/deployment/overview.md
@@ -72,7 +72,7 @@ For more information, see [Create a certificate for package signing](/windows/ms
 <!--
 ### Optionally export a PFX file
 
-You can use the thumbprint of the certificate to sign your package later, or you export the certificate to a Personal Information Exchange (PFX) file. The PFX file is secured with a password and can be referenced by your project. To export the certificate as a PFX file, do the following:
+You can use the thumbprint of the certificate to sign your package later, or you export the certificate to a Personal Information Exchange (PFX) file. The PFX file is secured with a password and can be referenced by your project. If you want to do signing from an automated build pipeline, you will need to have this file. To export the certificate as a PFX file, do the following:
 
 01. In the same PowerShell terminal session in the [Create a signing certificate](#create-a-signing-certificate) section, create a security password and assign it to the `$password` variable:
 
@@ -99,6 +99,7 @@ Add the following `<PropertyGroup>` node to your project file. This property gro
 <PropertyGroup Condition="$(TargetFramework.Contains('-windows')) and '$(Configuration)' == 'Release'">
     <GenerateAppxPackageOnBuild>true</GenerateAppxPackageOnBuild>
     <AppxPackageSigningEnabled>true</AppxPackageSigningEnabled>
+    <PackageCertificateKeyFile>myCert.pfx</PackageCertificateKeyFile> <!-- Optional if you want to use the exported PFX file -->
     <PackageCertificateThumbprint>A10612AF095FD8F8255F4C6691D88F79EF2B135E</PackageCertificateThumbprint>
 </PropertyGroup>
 ```
@@ -112,13 +113,17 @@ The `<GenerateAppxPackageOnBuild>` set to `true` packages the app and signs it w
 To publish your app, open the **Developer Command Prompt for VS 2022 Preview** terminal and navigate to the project's folder. Run `dotnet` in publish mode:  
 
 ```console
-dotnet publish -f net6.0-windows10.0.19041.0 -c Release
+dotnet publish MyMauiApp.csproj -f net6.0-windows10.0.19041.0 -c Release
 ```
+
+> [!NOTE]
+> When running the `dotnet publish` command without specifying the `.csproj` file, it will start publishing the solution (the `.sln` file) which is unsupported.
 
 The following table defines the parameters used by the previous command:
 
 | Parameter                    | Value                                                                               |
 |------------------------------|-------------------------------------------------------------------------------------|
+| `MyMauiApp.csproj`           | Path to the project file of your .NET MAUI app                                      |
 | `-f net6.0-windows{version}` | The target framework, which is a Windows TFM, such as `net6.0-windows10.0.19041.0`. Make sure this value is the exact same between what is in your cspoj file (in the `<TargetFrameworks>` node) and this command-line argument.           |
 | `-c Release`                 | Sets the build configuration, which is `Release`.                                   |
 

--- a/docs/windows/deployment/overview.md
+++ b/docs/windows/deployment/overview.md
@@ -124,7 +124,7 @@ The following table defines the parameters used by the previous command:
 | Parameter                    | Value                                                                               |
 |------------------------------|-------------------------------------------------------------------------------------|
 | `MyMauiApp.csproj`           | Path to the project file of your .NET MAUI app                                      |
-| `-f net6.0-windows{version}` | The target framework, which is a Windows TFM, such as `net6.0-windows10.0.19041.0`. Make sure this value is the exact same between what is in your cspoj file (in the `<TargetFrameworks>` node) and this command-line argument.           |
+| `-f net6.0-windows{version}` | The target framework, which is a Windows TFM, such as `net6.0-windows10.0.19041.0`. Ensure that this value is identical to the value in the `<TargetFrameworks>` node in your .csproj.           |
 | `-c Release`                 | Sets the build configuration, which is `Release`.                                   |
 
 Publishing builds and packages the app, copying the signed package to the _bin\\Release\\net6.0-windows10.0.19041.0\\win10-x64\\AppPackages\\\<appname>\\_ folder. Where \<appname> is a folder named after both your project and version. In this folder there's an _msix_ file, that's the app package.

--- a/docs/windows/deployment/overview.md
+++ b/docs/windows/deployment/overview.md
@@ -112,19 +112,19 @@ The `<GenerateAppxPackageOnBuild>` set to `true` packages the app and signs it w
 To publish your app, open the **Developer Command Prompt for VS 2022 Preview** terminal and navigate to the project's folder. Run `dotnet` in publish mode:  
 
 ```console
-dotnet publish /p:TargetFramework=net6.0-windows10.0.19041 /p:configuration=release
+dotnet publish /p:TargetFramework=net6.0-windows10.0.19041.0 /p:configuration=release
 ```
 
 The following table defines the parameters used by the previous command:
 
-| Parameter                  | Value                                                                             |
-|----------------------------|-----------------------------------------------------------------------------------|
-| `/restore`                 | Restores any dependencies referenced by the project.                              |
-| `/t:Publish`               | Runs the publish command.                                                         |
-| `/p:TargetFramework`       | The target framework, which is a Windows TFM, such as `net6.0-windows10.0.19041`. |
-| `/p:configuration=Release` | Sets the build configuration, which is `Release`.                                 |
+| Parameter                  | Value                                                                               |
+|----------------------------|-------------------------------------------------------------------------------------|
+| `/restore`                 | Restores any dependencies referenced by the project.                                |
+| `/t:Publish`               | Runs the publish command.                                                           |
+| `/p:TargetFramework`       | The target framework, which is a Windows TFM, such as `net6.0-windows10.0.19041.0`. Make sure this value is the exact same between what is in your cspoj file (in the `<TargetFrameworks>` node) and this command-line argument. |
+| `/p:configuration=Release` | Sets the build configuration, which is `Release`.                                   |
 
-Publishing builds and packages the app, copying the signed package to the _bin\\Release\\net6.0-windows10.0.19041\\win10-x64\\AppPackages\\\<appname>\\_ folder. Where \<appname> is a folder named after both your project and version. In this folder there's an _msix_ file, that's the app package.
+Publishing builds and packages the app, copying the signed package to the _bin\\Release\\net6.0-windows10.0.19041.0\\win10-x64\\AppPackages\\\<appname>\\_ folder. Where \<appname> is a folder named after both your project and version. In this folder there's an _msix_ file, that's the app package.
 
 ## Installing the app
 

--- a/docs/windows/deployment/overview.md
+++ b/docs/windows/deployment/overview.md
@@ -109,12 +109,10 @@ The `<GenerateAppxPackageOnBuild>` set to `true` packages the app and signs it w
 
 ## Publish
 
-At this time, publishing is only supported through `msbuild`, not `dotnet`.
-
-To publish your app, open the **Developer Command Prompt for VS 2022 Preview** terminal and navigate to the project's folder. Run `msbuild` in publish mode:  
+To publish your app, open the **Developer Command Prompt for VS 2022 Preview** terminal and navigate to the project's folder. Run `dotnet` in publish mode:  
 
 ```console
-msbuild /restore /t:Publish /p:TargetFramework=net6.0-windows10.0.19041 /p:configuration=release
+dotnet publish /p:TargetFramework=net6.0-windows10.0.19041 /p:configuration=release
 ```
 
 The following table defines the parameters used by the previous command:
@@ -173,18 +171,6 @@ The following list describes the current limitations with publishing and packagi
 
 01. The published app doesn't work if you try to run it directly with the executable file out of the publish folder.
 01. The way to run the app is to first install it through the packaged _MSIX_ file.
-
-## .NET MAUI Blazor app considerations
-
-Currently, .NET MAUI Blazor apps won't run when deployed to another computer. There's one more config section to add to your project to make the published app work on other computers:
-
-```xml
-<Target Name="_RemoveStaticWebAssetsDevelopmentManifest" BeforeTargets="GetCopyToOutputDirectoryItems">
-    <ItemGroup>
-        <ContentWithTargetPath Remove="$(StaticWebAssetDevelopmentManifestPath)" />
-    </ItemGroup>
-</Target>
-```
 
 ## See also
 


### PR DESCRIPTION
* Publishing now works with `dotnet publish`
  * Added a note about the TFMs that need to match up and edited the Windows TFMs to reflect the current templates
  * Added a note about `dotnet publish` that one should reference the `csproj`
* The workaround for Blazor apps is no longer needed

Fixes #509 