### PR TITLE
Add note about XAML namespaces to flyout article

### DIFF
--- a/docs/fundamentals/shell/flyout.md
+++ b/docs/fundamentals/shell/flyout.md
@@ -505,6 +505,9 @@ The `FlyoutFooter` type is shown in the following example:
 </ContentView>
 ```
 
+> [!IMPORTANT]
+> The previous XAML example defined a new XAML namespace named `sys`: `xmlns:sys="clr-namespace:System;assembly=netstandard"`. This XAML namespace maps `sys` to the .NET `System` namespace. The mapping allows you to use the .NET types defined in that namespace, such as `DateTime`, in the XAML. For more information, see [XAML Namespaces](../../xaml/namespaces.md).
+
 This results in the following flyout footer:
 
 :::image type="content" source="media/flyout/flyout-footer.png" alt-text="Screenshot of the flyout footer.":::

--- a/docs/fundamentals/shell/flyout.md
+++ b/docs/fundamentals/shell/flyout.md
@@ -506,7 +506,7 @@ The `FlyoutFooter` type is shown in the following example:
 ```
 
 > [!IMPORTANT]
-> The previous XAML example defined a new XAML namespace named `sys`: `xmlns:sys="clr-namespace:System;assembly=netstandard"`. This XAML namespace maps `sys` to the .NET `System` namespace. The mapping allows you to use the .NET types defined in that namespace, such as `DateTime`, in the XAML. For more information, see [XAML Namespaces](../../xaml/namespaces.md).
+> The previous XAML example defined a new XAML namespace named `sys`: `xmlns:sys="clr-namespace:System;assembly=netstandard"`. This XAML namespace maps `sys` to the .NET `System` namespace. The mapping allows you to use the .NET types defined in that namespace, such as `DateTime`, in the XAML. For more information, see [XAML Namespaces](../../xaml/namespaces/index.md).
 
 This results in the following flyout footer:
 


### PR DESCRIPTION
Added a note about XAML namespaces. Without it, someone may just copy the label code directly and then not understand why it isn't compiling.

Fixes #566