### PR TITLE
Publish multiple projects in a solution

### DIFF
--- a/docs/android/deployment/overview.md
+++ b/docs/android/deployment/overview.md
@@ -113,7 +113,7 @@ If either of those conditions fail, the settings aren't processed. More importan
 
 At this time, publishing is only supported through the .NET command line interface.
 
-To publish your app, open a terminal and navigate to the project's folder. Run the `dotnet publish` command, providing the following parameters:
+To publish your app, open a terminal and navigate to the folder for your .NET MAUI app project. Run the `dotnet publish` command, providing the following parameters:
 
 | Parameter                    | Value                                                                                                                                     |
 |------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
@@ -122,6 +122,9 @@ To publish your app, open a terminal and navigate to the project's folder. Run t
 | `/p:AndroidSigningKeyPass`   | This is the value used for the `<AndroidSigningKeyPass>` project setting, the password you provided when you created the keystore file.   |
 | `/p:AndroidSigningStorePass` | This is the value used for the `<AndroidSigningStorePass>` project setting, the password you provided when you created the keystore file. |
 
+> [!WARNING]
+> Attempting to publish a .NET MAUI solution will result in the `dotnet publish` command attempting to publish each project in the solution individually, which cam cause issues when you've added other project types to your solution. Therefore, the `dotnet publish` command should be scoped to your .NET MAUI app project.
+
 For example:
 
 ```console
@@ -129,6 +132,8 @@ dotnet publish -f:net6.0-android -c:Release /p:AndroidSigningKeyPass=mypassword 
 ```
 
 Publishing builds the app, and then copies the _aab_ and _apk_ files to the _bin\\Release\\net6.0-android\\publish_ folder. There are two _aab_ files, one unsigned and another signed. The signed variant has **-signed** in the file name.
+
+For more information about the `dotnet publish` command, see [dotnet publish](/dotnet/core/tools/dotnet-publish).
 
 To learn how to upload a signed Android App Bundle to the Google Play Store, see [Upload your app to the Play Console](https://developer.android.com/studio/publish/upload-bundle).
 

--- a/docs/android/deployment/overview.md
+++ b/docs/android/deployment/overview.md
@@ -123,7 +123,7 @@ To publish your app, open a terminal and navigate to the folder for your .NET MA
 | `/p:AndroidSigningStorePass` | This is the value used for the `<AndroidSigningStorePass>` project setting, the password you provided when you created the keystore file. |
 
 > [!WARNING]
-> Attempting to publish a .NET MAUI solution will result in the `dotnet publish` command attempting to publish each project in the solution individually, which cam cause issues when you've added other project types to your solution. Therefore, the `dotnet publish` command should be scoped to your .NET MAUI app project.
+> Attempting to publish a .NET MAUI solution will result in the `dotnet publish` command attempting to publish each project in the solution individually, which can cause issues when you've added other project types to your solution. Therefore, the `dotnet publish` command should be scoped to your .NET MAUI app project.
 
 For example:
 

--- a/docs/ios/deployment/overview.md
+++ b/docs/ios/deployment/overview.md
@@ -156,6 +156,7 @@ To publish your app, open a terminal and navigate to the project's folder. Run t
 
 | Parameter                    | Value                                                                                           |
 |------------------------------|-------------------------------------------------------------------------------------------------|
+| `YourProject.csproj`         | The `csproj` file of your .NET MAUI app project                                                 |
 | `-f` or `--framework`        | The target framework, which is `net6.0-ios`.                                                    |
 | `-c` or `--configuration`    | The build configuration, which is `Release`.                                                    |
 
@@ -180,11 +181,14 @@ In addition, the following common parameters can be specified on the command lin
 For example, use the following command to create an *.ipa*:
 
 ```console
-dotnet publish -f:net6.0-ios -c:Release /p:ServerAddress={macOS build host IP address} /p:ServerUser={macOS username} /p:ServerPassword={macOS password} /p:TcpPort=58181 /p:ArchiveOnBuild=true /p:_DotNetRootRemoteDirectory=/Users/{macOS username}/Library/Caches/Xamarin/XMA/SDKs/dotnet/
+dotnet publish YourProject.csproj -f:net6.0-ios -c:Release /p:ServerAddress={macOS build host IP address} /p:ServerUser={macOS username} /p:ServerPassword={macOS password} /p:TcpPort=58181 /p:ArchiveOnBuild=true /p:_DotNetRootRemoteDirectory=/Users/{macOS username}/Library/Caches/Xamarin/XMA/SDKs/dotnet/
 ```
 
 > [!NOTE]
 > If the `ServerPassword` parameter is omitted from a command line build invocation, Pair to Mac attempts to log in to the Mac build host using the saved SSH keys.
+
+> [!NOTE]
+> When running the `dotnet publish` command without specifying the `.csproj` file, it will try and publish all projects separately which will cause issues when you've added other project types to your solution. To prevent issues, always specify the `csproj` file of your .NET MAUI app project as a parameter. 
 
 Publishing builds the app, and then copies the *.ipa* to the *bin\\Release\\net6.0-ios\\ios-arm64\\publish* folder. During the publishing process it maybe necessary to allow `codesign` to run on your paired Mac:
 

--- a/docs/ios/deployment/overview.md
+++ b/docs/ios/deployment/overview.md
@@ -160,7 +160,7 @@ To publish your app, open a terminal and navigate to the folder for your .NET MA
 | `-c` or `--configuration`    | The build configuration, which is `Release`.                                                    |
 
 > [!WARNING]
-> Attempting to publish a .NET MAUI solution will result in the `dotnet publish` command attempting to publish each project in the solution individually, which cam cause issues when you've added other project types to your solution. Therefore, the `dotnet publish` command should be scoped to your .NET MAUI app project.
+> Attempting to publish a .NET MAUI solution will result in the `dotnet publish` command attempting to publish each project in the solution individually, which can cause issues when you've added other project types to your solution. Therefore, the `dotnet publish` command should be scoped to your .NET MAUI app project.
 
 In addition, the following common parameters can be specified on the command line if they aren't provided in a `<PropertyGroup>` in your project file:
 

--- a/docs/ios/deployment/overview.md
+++ b/docs/ios/deployment/overview.md
@@ -188,7 +188,7 @@ dotnet publish YourProject.csproj -f:net6.0-ios -c:Release /p:ServerAddress={mac
 > If the `ServerPassword` parameter is omitted from a command line build invocation, Pair to Mac attempts to log in to the Mac build host using the saved SSH keys.
 
 > [!NOTE]
-> When running the `dotnet publish` command without specifying the `.csproj` file, it will try and publish all projects separately which will cause issues when you've added other project types to your solution. To prevent issues, always specify the `csproj` file of your .NET MAUI app project as a parameter. 
+> When running the `dotnet publish` command without specifying the `.csproj` file, it will try and publish all projects separately which will cause issues when you've added other project types to your solution. To prevent issues, always specify the `csproj` file of your .NET MAUI app project as a parameter.
 
 Publishing builds the app, and then copies the *.ipa* to the *bin\\Release\\net6.0-ios\\ios-arm64\\publish* folder. During the publishing process it maybe necessary to allow `codesign` to run on your paired Mac:
 

--- a/docs/ios/deployment/overview.md
+++ b/docs/ios/deployment/overview.md
@@ -1,7 +1,7 @@
 ---
 title: "Publish a .NET MAUI app for iOS"
 description: "Learn how to package and publish a iOS .NET MAUI app."
-ms.date: 05/09/2022
+ms.date: 06/13/2022
 ---
 
 # Publish a .NET MAUI app for iOS
@@ -152,13 +152,15 @@ Building native iOS apps using .NET MAUI requires access to Apple's build tools,
 
 At this time, publishing is only supported through the .NET command line interface.
 
-To publish your app, open a terminal and navigate to the project's folder. Run the `dotnet publish` command, providing the following parameters:
+To publish your app, open a terminal and navigate to the folder for your .NET MAUI app project. Run the `dotnet publish` command, providing the following parameters:
 
 | Parameter                    | Value                                                                                           |
 |------------------------------|-------------------------------------------------------------------------------------------------|
-| `YourProject.csproj`         | The `csproj` file of your .NET MAUI app project                                                 |
 | `-f` or `--framework`        | The target framework, which is `net6.0-ios`.                                                    |
 | `-c` or `--configuration`    | The build configuration, which is `Release`.                                                    |
+
+> [!WARNING]
+> Attempting to publish a .NET MAUI solution will result in the `dotnet publish` command attempting to publish each project in the solution individually, which cam cause issues when you've added other project types to your solution. Therefore, the `dotnet publish` command should be scoped to your .NET MAUI app project.
 
 In addition, the following common parameters can be specified on the command line if they aren't provided in a `<PropertyGroup>` in your project file:
 
@@ -181,20 +183,19 @@ In addition, the following common parameters can be specified on the command lin
 For example, use the following command to create an *.ipa*:
 
 ```console
-dotnet publish YourProject.csproj -f:net6.0-ios -c:Release /p:ServerAddress={macOS build host IP address} /p:ServerUser={macOS username} /p:ServerPassword={macOS password} /p:TcpPort=58181 /p:ArchiveOnBuild=true /p:_DotNetRootRemoteDirectory=/Users/{macOS username}/Library/Caches/Xamarin/XMA/SDKs/dotnet/
+dotnet publish -f:net6.0-ios -c:Release /p:ServerAddress={macOS build host IP address} /p:ServerUser={macOS username} /p:ServerPassword={macOS password} /p:TcpPort=58181 /p:ArchiveOnBuild=true /p:_DotNetRootRemoteDirectory=/Users/{macOS username}/Library/Caches/Xamarin/XMA/SDKs/dotnet/
 ```
 
 > [!NOTE]
 > If the `ServerPassword` parameter is omitted from a command line build invocation, Pair to Mac attempts to log in to the Mac build host using the saved SSH keys.
-
-> [!NOTE]
-> When running the `dotnet publish` command without specifying the `.csproj` file, it will try and publish all projects separately which will cause issues when you've added other project types to your solution. To prevent issues, always specify the `csproj` file of your .NET MAUI app project as a parameter.
 
 Publishing builds the app, and then copies the *.ipa* to the *bin\\Release\\net6.0-ios\\ios-arm64\\publish* folder. During the publishing process it maybe necessary to allow `codesign` to run on your paired Mac:
 
 :::image type="content" source="media/overview/codesign.png" alt-text="Allow codesign to sign your app on your paired Mac.":::
 
 The *.ipa* file can then be uploaded to the App Store using App Store Connect. To learn how to use App Store Connect, see [App Store Connect workflow](https://help.apple.com/app-store-connect/#/dev300c2c5bf).
+
+For more information about the `dotnet publish` command, see [dotnet publish](/dotnet/core/tools/dotnet-publish).
 
 ## See also
 

--- a/docs/macos/deployment/overview.md
+++ b/docs/macos/deployment/overview.md
@@ -32,7 +32,7 @@ To publish your app, open a terminal and navigate to the folder for your .NET MA
 | `/p:CreatePackage`           | An optional parameter that controls whether to create an .app or a .pkg. Use `true` for a .pkg. |
 
 > [!WARNING]
-> Attempting to publish a .NET MAUI solution will result in the `dotnet publish` command attempting to publish each project in the solution individually, which cam cause issues when you've added other project types to your solution. Therefore, the `dotnet publish` command should be scoped to your .NET MAUI app project.
+> Attempting to publish a .NET MAUI solution will result in the `dotnet publish` command attempting to publish each project in the solution individually, which can cause issues when you've added other project types to your solution. Therefore, the `dotnet publish` command should be scoped to your .NET MAUI app project.
 
 For example, use the following command to create an *.app*:
 

--- a/docs/macos/deployment/overview.md
+++ b/docs/macos/deployment/overview.md
@@ -21,7 +21,7 @@ When distributing your .NET Multi-platform App UI (.NET MAUI) app for macOS, you
 
 At this time, publishing is only supported through the .NET command line interface.
 
-To publish your app, open a terminal and navigate to the project's folder. Run the `dotnet build` command, providing the following parameters:
+To publish your app, open a terminal and navigate to the folder for your .NET MAUI app project. Run the `dotnet build` command, providing the following parameters:
 
 <!-- dotnet publish doesn't work at the time of writing -->
 
@@ -30,6 +30,9 @@ To publish your app, open a terminal and navigate to the project's folder. Run t
 | `-f` or `--framework`        | The target framework, which is `net6.0-maccatalyst`.                                            |
 | `-c` or `--configuration`    | The build configuration, which is `Release`.                                                    |
 | `/p:CreatePackage`           | An optional parameter that controls whether to create an .app or a .pkg. Use `true` for a .pkg. |
+
+> [!WARNING]
+> Attempting to publish a .NET MAUI solution will result in the `dotnet publish` command attempting to publish each project in the solution individually, which cam cause issues when you've added other project types to your solution. Therefore, the `dotnet publish` command should be scoped to your .NET MAUI app project.
 
 For example, use the following command to create an *.app*:
 
@@ -44,6 +47,8 @@ dotnet build -f:net6.0-maccatalyst -c:Release /p:CreatePackage=true
 ```
 
 Publishing builds the app, and then copies the *.app* or *.pkg* to the *bin/Release/net6.0-maccatalyst/maccatalyst-x64* folder.
+
+For more information about the `dotnet publish` command, see [dotnet publish](/dotnet/core/tools/dotnet-publish).
 
 ## Run the unsigned app
 

--- a/docs/windows/deployment/overview.md
+++ b/docs/windows/deployment/overview.md
@@ -115,7 +115,7 @@ To publish your app, open the **Developer Command Prompt for VS 2022 Preview** t
 | `-c Release`                 | Sets the build configuration, which is `Release`.                                   |
 
 > [!WARNING]
-> Attempting to publish a .NET MAUI solution will result in the `dotnet publish` command attempting to publish each project in the solution individually, which cam cause issues when you've added other project types to your solution. Therefore, the `dotnet publish` command should be scoped to your .NET MAUI app project.
+> Attempting to publish a .NET MAUI solution will result in the `dotnet publish` command attempting to publish each project in the solution individually, which can cause issues when you've added other project types to your solution. Therefore, the `dotnet publish` command should be scoped to your .NET MAUI app project.
 
 For example:
 

--- a/docs/windows/deployment/overview.md
+++ b/docs/windows/deployment/overview.md
@@ -107,23 +107,25 @@ Setting the `<GenerateAppxPackageOnBuild>` property to `true` packages the app a
 
 ## Publish
 
-To publish your app, open the **Developer Command Prompt for VS 2022 Preview** terminal and navigate to the project's folder. Run `dotnet` in publish mode:  
-
-```console
-dotnet publish -f net6.0-windows10.0.19041.0 -c Release
-```
-
-> [!NOTE]
-> When running the `dotnet publish` command without specifying the `.csproj` file, it will start publishing the solution (the `.sln` file) which is unsupported.
-
-The following table defines the parameters used by the previous command:
+To publish your app, open the **Developer Command Prompt for VS 2022 Preview** terminal and navigate to the folder for your .NET MAUI app project. Run the `dotnet publish` command, providing the following parameters:
 
 | Parameter                    | Value                                                                               |
 |------------------------------|-------------------------------------------------------------------------------------|
 | `-f net6.0-windows{version}` | The target framework, which is a Windows TFM, such as `net6.0-windows10.0.19041.0`. Ensure that this value is identical to the value in the `<TargetFrameworks>` node in your .csproj.           |
 | `-c Release`                 | Sets the build configuration, which is `Release`.                                   |
 
+> [!WARNING]
+> Attempting to publish a .NET MAUI solution will result in the `dotnet publish` command attempting to publish each project in the solution individually, which cam cause issues when you've added other project types to your solution. Therefore, the `dotnet publish` command should be scoped to your .NET MAUI app project.
+
+For example:
+
+```console
+dotnet publish -f net6.0-windows10.0.19041.0 -c Release
+```
+
 Publishing builds and packages the app, copying the signed package to the _bin\\Release\\net6.0-windows10.0.19041.0\\win10-x64\\AppPackages\\\<appname>\\_ folder. Where \<appname> is a folder named after both your project and version. In this folder there's an _msix_ file, that's the app package.
+
+For more information about the `dotnet publish` command, see [dotnet publish](/dotnet/core/tools/dotnet-publish).
 
 ## Installing the app
 


### PR DESCRIPTION
We're getting questions/issues about publishing iOS projects when there are multiple projects in a solution. Just running `dotnet publish` will try to publish each project separately which won't work. Adding some more clarity to the docs.

Fixes #543