### PR TITLE
Add no response github action

### DIFF
--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -1,0 +1,23 @@
+name: No Response
+
+# Both `issue_comment` and `scheduled` event types are required for this Action
+# to work properly.
+on:
+  issue_comment:
+    types: [created]
+  schedule:
+    # Schedule every day at 00:05
+    - cron: '5 0 * * *'
+
+jobs:
+  noResponse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: lee-dohm/no-response@9bb0a4b5e6a45046f00353d5de7d90fb8bd773bb
+        with:
+          token: ${{ github.token }}
+          responseRequiredLabel: needs-more-info
+          daysUntilClose: 14
+          closeComment: >
+            This issue has been automatically closed due to no response from the original author.
+            Please feel free to reopen it if you have more information that can help us investigate the issue further.


### PR DESCRIPTION
This mirrors what is in the docs repo.

The "needs-more-info" label will be a flag to auto close an issue that is inactive for 14 days. If someone comments on the issue, the label is removed and action abandons monitoring it.

@davidbritch 