### PR TITLE
Clarify reading bundled file is read-only; Add example

### DIFF
--- a/docs/platform-integration/snippets/shared_1/MainPage.xaml
+++ b/docs/platform-integration/snippets/shared_1/MainPage.xaml
@@ -14,6 +14,7 @@
             <Button Text="Communications" Clicked="Comms_Clicked" />
             <Button Text="SymaticReader" Clicked="Reader_Clicked" />
             <Button Text="Media" Clicked="Media_Clicked" />
+            <Button Text="Storage" Clicked="Storage_Clicked" />
 
         </VerticalStackLayout>
     </ScrollView>

--- a/docs/platform-integration/snippets/shared_1/MainPage.xaml.cs
+++ b/docs/platform-integration/snippets/shared_1/MainPage.xaml.cs
@@ -53,5 +53,10 @@ public partial class MainPage : ContentPage
     {
         Navigation.PushAsync(new MediaPage());
     }
+
+    private void Storage_Clicked(object sender, EventArgs e)
+    {
+        Navigation.PushAsync(new StoragePage());
+    }
 }
 

--- a/docs/platform-integration/snippets/shared_1/PlatformIntegration.csproj.user
+++ b/docs/platform-integration/snippets/shared_1/PlatformIntegration.csproj.user
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <ActiveDebugFramework>net6.0-windows10.0.19041.0</ActiveDebugFramework>
+    <ActiveDebugFramework>net6.0-android</ActiveDebugFramework>
     <IsFirstTimeProjectOpen>False</IsFirstTimeProjectOpen>
-    <ActiveDebugProfile>Windows Machine</ActiveDebugProfile>
+    <ActiveDebugProfile>Pixel 3a - API 30 (Android 11.0 - API 30)</ActiveDebugProfile>
     <SelectedDevice>pixel_3a_-_api_30</SelectedDevice>
     <SelectedPlatformGroup>Emulator</SelectedPlatformGroup>
     <DefaultDevice>pixel_3a_-_api_30</DefaultDevice>

--- a/docs/platform-integration/snippets/shared_1/Storage.cs
+++ b/docs/platform-integration/snippets/shared_1/Storage.cs
@@ -1,3 +1,5 @@
+using System.Security.AccessControl;
+
 namespace PlatformIntegration;
 
 public class StoragePage : ContentPage
@@ -17,7 +19,18 @@ public class StoragePage : ContentPage
 
         Content = new VerticalStackLayout
         {
+            new Button { Text = "ToUpperFile",
+                Command = new Command(ToUpperFile) },
         };
+    }
+
+    async void ToUpperFile(object param1)
+    {
+        await ConvertFileToUpperCase("AboutAssets.txt", "NewAssets.txt");
+
+        string targetFile = System.IO.Path.Combine(FileSystem.Current.AppDataDirectory, "NewAssets.txt");
+
+        ((VerticalStackLayout)Content).Children.Add(new Label() { Text = System.IO.File.ReadAllText(targetFile) });
     }
 
     //<file_pick>
@@ -87,6 +100,28 @@ public class StoragePage : ContentPage
         return await reader.ReadToEndAsync();
     }
     //</filesys_readtxtfile>
+
+    //<filesys_toupper>
+    public async Task ConvertFileToUpperCase(string sourceFile, string targetFileName)
+    {
+        // Read the source file
+        using Stream fileStream = await FileSystem.Current.OpenAppPackageFileAsync(sourceFile);
+        using StreamReader reader = new StreamReader(fileStream);
+
+        string content = await reader.ReadToEndAsync();
+
+        // Transform file content to upper case text
+        content = content.ToUpperInvariant();
+
+        // Write the file content to the app data directory
+        string targetFile = System.IO.Path.Combine(FileSystem.Current.AppDataDirectory, targetFileName);
+
+        using FileStream outputStream = System.IO.File.OpenWrite(targetFile);
+        using StreamWriter streamWriter = new StreamWriter(outputStream);
+
+        await streamWriter.WriteAsync(content);
+    }
+    //</filesys_toupper>
 
     public void PreferencesSet()
     {

--- a/docs/platform-integration/storage/file-system-helpers.md
+++ b/docs/platform-integration/storage/file-system-helpers.md
@@ -33,6 +33,12 @@ To open a file that is bundled into the app package, use the `OpenAppPackageFile
 
 :::code language="csharp" source="../snippets/shared_1/Storage.cs" id="filesys_readtxtfile":::
 
+### Writing from a bundled file to the app data folder
+
+You can't modify an app's bundled file. But you can read it first, then write it back to the [cache directory](#cache-directory) or [app data directory](#app-data-directory). The following example uses `OpenAppPackageFileAsync` to read a bundled file, alters it, and then writes it to the app data folder:
+
+:::code language="csharp" source="../snippets/shared_1/Storage.cs" id="filesys_toupper":::
+
 ## Platform differences
 
 This section describes the platform-specific differences with the file system helpers.

--- a/docs/platform-integration/storage/file-system-helpers.md
+++ b/docs/platform-integration/storage/file-system-helpers.md
@@ -1,7 +1,7 @@
 ---
 title: "File system helpers"
 description: "Learn how to use the .NET MAUI FileSystem class in the Microsoft.Maui.Storage namespace. This class contains helper methods that access the application's cache and data directories, and helps open files in the app package."
-ms.date: 05/23/2022
+ms.date: 07/14/2022
 no-loc: ["Microsoft.Maui", "Microsoft.Maui.Storage", "FileSystem"]
 ---
 
@@ -29,7 +29,7 @@ To get the app's top-level directory for any files that aren't user data files. 
 
 ## Bundled files
 
-To open a file that is bundled into the app package, use the `OpenAppPackageFileAsync` method and pass the file name. This method returns an <xref:System.IO.Stream> representing the file contents. The following example demonstrates using a method to read the text contents of a file:
+To open a file that is bundled into the app package, use the `OpenAppPackageFileAsync` method and pass the file name. This method returns a read-only <xref:System.IO.Stream> representing the file contents. The following example demonstrates using a method to read the text contents of a file:
 
 :::code language="csharp" source="../snippets/shared_1/Storage.cs" id="filesys_readtxtfile":::
 
@@ -47,7 +47,7 @@ Returns the [CacheDir](https://developer.android.com/reference/android/content/C
 Returns the [FilesDir](https://developer.android.com/reference/android/content/Context.html#getFilesDir) of the current context, which are backed up using [Auto Backup](https://developer.android.com/guide/topics/data/autobackup.html) starting on API 23 and above.
 
 - `FileSystem.OpenAppPackageFileAsync`\
-Files that were added to the project with the **Build Action** of **MauiAsset** can be opened with this method. .NET MAUI projects will process any file in the _Platform\Resources\Raw_ folder as a **MauiAsset**.
+Files that were added to the project with the **Build Action** of **MauiAsset** can be opened with this method. .NET MAUI projects will process any file in the _Resources\Raw_ folder as a **MauiAsset**.
 
 # [iOS\macOS](#tab/ios)
 
@@ -61,7 +61,7 @@ Returns the [Library](https://developer.apple.com/library/content/documentation/
   > In the iOS Simulator, the Application ID (which is part of the directory name) changes on every build so you have to retrieve the correct ID each time you build your application for the Simulator.
 
 - `FileSystem.OpenAppPackageFileAsync`\
-Files that were added to the project with the **Build Action** of **MauiAsset** can be opened with this method. .NET MAUI projects will process any file in the _Platform\Resources\Raw_ folder as a **MauiAsset**.
+Files that were added to the project with the **Build Action** of **MauiAsset** can be opened with this method. .NET MAUI projects will process any file in the _Resources\Raw_ folder as a **MauiAsset**.
 
 # [Windows](#tab/windows)
 
@@ -72,7 +72,7 @@ Returns the `LocalCacheFolder` directory. <!-- (/uwp/api/windows.storage.applica
 Returns the `LocalFolder` directory that is backed up to the cloud. <!-- (/uwp/api/windows.storage.applicationdata.localfolder#Windows_Storage_ApplicationData_LocalFolder) -->
 
 - `FileSystem.OpenAppPackageFileAsync`\
-Files that were added to the project with the **Build Action** of **MauiAsset** can be opened with this method. .NET MAUI projects will process any file in the _Platform\Resources\Raw_ folder as a **MauiAsset**.
+Files that were added to the project with the **Build Action** of **MauiAsset** can be opened with this method. .NET MAUI projects will process any file in the _Resources\Raw_ folder as a **MauiAsset**.
 
 -----
 <!-- markdownlint-enable MD025 -->


### PR DESCRIPTION
- Clarify that the bundled file stream is read-only.
- Add example of writing bundled file to app data folder.

Fixes #700