### PR TITLE
Fix IOS preprocessor to make code work

### DIFF
--- a/docs/user-interface/handlers/customize.md
+++ b/docs/user-interface/handlers/customize.md
@@ -62,7 +62,7 @@ public partial class CustomizeEntryPage : ContentPage
         {
 #if ANDROID
             handler.PlatformView.SetBackgroundColor(Colors.Transparent.ToPlatform());
-#elif iOS
+#elif IOS
             handler.PlatformView.BorderStyle = UIKit.UITextBorderStyle.None;
 #elif WINDOWS
             handler.PlatformView.FontWeight = Microsoft.UI.Text.FontWeights.Thin;


### PR DESCRIPTION
On the .NET MAUI repo we got an [issue](https://github.com/dotnet/maui/issues/8755) stating that the code on this Docs page wasn't working. Seems that the preprocessor statement for iOS was capitalized wrong, fixing that with this PR!
