### PR TITLE
Add a note for the Platforms folder

### DIFF
--- a/docs/platform-integration/configure-multi-targeting.md
+++ b/docs/platform-integration/configure-multi-targeting.md
@@ -73,6 +73,9 @@ This XML configures the build system to remove platform-based folder patterns un
 - Don't compile C# code that's located in the _iOS_ folder, or sub-folder of the _iOS_ folder, if you aren't building for iOS or MacCatalyst.
 - Don't compile C# code that's located in the _Windows_ folder, or sub-folder of the _Windows_ folder, if you aren't building for Windows.
 
+> [!NOTE]
+> The _Platforms_ folder gets a special handling so that files in _Platforms/iOS_ are **only** used on iOS even if you configured here that all files within any _iOS_ folder are also used for Mac Catalyst. If you want files to be used on iOS **and** Mac Catalyst, then don't place them within _Platforms_.
+
 > [!IMPORTANT]
 > Folder-based multi-targeting can be combined with filename-based multi-targeting. For more information, see [Combine filename and folder multi-targeting](#combine-filename-and-folder-multi-targeting).
 
@@ -108,3 +111,6 @@ This XML configures the build system to remove platform-based filename and folde
 - Don't compile C# code whose filename ends with _.Android.cs_, or that's located in the _Android_ folder or sub-folder of the _Android_ folder, if you aren't building for Android.
 - Don't compile C# code whose filename ends with _.iOS.cs_, or that's located in the _iOS_ folder or sub-folder of the _iOS_ folder, if you aren't building for iOS or MacCatalyst.
 - Don't compile C# code whose filename ends with _.Windows.cs_, or that's located in the _Windows_ folder or sub-folder of the _Windows_ folder, if you aren't building for Windows.
+
+> [!NOTE]
+> The _Platforms_ folder gets a special handling so that files in _Platforms/iOS_ are **only** used on iOS even if you configured here that all files within any _iOS_ folder are also used for Mac Catalyst. If you want files to be used on iOS **and** Mac Catalyst, then don't place them within _Platforms_.


### PR DESCRIPTION
The files for the .csproj did not work within the Platforms folder. I lost a few weeks sulking over that and trying to find a workaround. Hopefully with that note others will place their files somewhere else from the start.

Preview does not work for the [!NOTE]. I want it to look as the [!IMPORTANT]. I just copied that and the preview for [!IMPORTANT] also doesn't work, so I guess we're good.