### PR TITLE
Update horizontalstacklayout.md

### DIFF
--- a/docs/user-interface/layouts/horizontalstacklayout.md
+++ b/docs/user-interface/layouts/horizontalstacklayout.md
@@ -153,7 +153,7 @@ The following XAML shows an example of nesting `VerticalStackLayout` objects in 
 </ContentPage>
 ```
 
-In this example, the parent `HorizontalStackLayout` contains two nested `HorizontalStackLayout` objects:
+In this example, the parent `HorizontalStackLayout` contains two nested `VerticalStackLayout` objects:
 
 :::image type="content" source="media/horizontalstacklayout/nested.png" alt-text="HorizontalStackLayout displaying two nested HorizontalStackLayout objects screenshot.":::
 


### PR DESCRIPTION
Corrected sentence: "In this example, the parent HorizontalStackLayout contains two nested VerticalStackLayout objects" from "In this example, the parent HorizontalStackLayout contains two nested VerticalStackLayout objects" at end of article.