### PR TITLE
Typo fix - update to FlexLayout article

### DIFF
--- a/docs/user-interface/layouts/flexlayout.md
+++ b/docs/user-interface/layouts/flexlayout.md
@@ -222,7 +222,6 @@ A `FlexLayout` can substitute for a `StackLayout`:
     </FlexLayout>
 </ContentPage>
 ```
-
 In this example, the `Direction` property is set to `Column`, which causes the children of the `FlexLayout` to be arranged in a single column. The `AlignItems` property is set to `Center`, which causes each child to be horizontally centered. The `JustifyContent` property is set to `SpaceEvenly` which allocates all leftover vertical space equally between all the children, above the first child and below the last child:
 
 :::image type="content" source="media/flexlayout/stack.png" alt-text="Vertically oriented .NET MAUI FlexLayout.":::
@@ -250,7 +249,7 @@ A `FlexLayout` can wrap its children to additional rows or columns:
 </ContentPage>
 ```
 
-In this example, the `Direction` property of the `FlexLayout` is not set, so it has the default setting of `Row`, meaning that the children are arranged in rows and the main axis is horizontal. The `Wrap` property is set to to `Wrap`, which causes children to wrap to the next row if there are too many children to fit on a row. The `JustifyContent` property is set to `SpaceAround` which allocates all leftover space on the main axis so that each child is surrounded by the same amount of space:
+In this example, the `Direction` property of the `FlexLayout` is not set, so it has the default setting of `Row`, meaning that the children are arranged in rows and the main axis is horizontal. The `Wrap` property is set to `Wrap`, which causes children to wrap to the next row if there are too many children to fit on a row. The `JustifyContent` property is set to `SpaceAround` which allocates all leftover space on the main axis so that each child is surrounded by the same amount of space:
 
 :::image type="content" source="media/flexlayout/wrap.png" alt-text="Horizontally wrapping .NET MAUI FlexLayout.":::
 

--- a/docs/user-interface/layouts/flexlayout.md
+++ b/docs/user-interface/layouts/flexlayout.md
@@ -222,6 +222,7 @@ A `FlexLayout` can substitute for a `StackLayout`:
     </FlexLayout>
 </ContentPage>
 ```
+
 In this example, the `Direction` property is set to `Column`, which causes the children of the `FlexLayout` to be arranged in a single column. The `AlignItems` property is set to `Center`, which causes each child to be horizontally centered. The `JustifyContent` property is set to `SpaceEvenly` which allocates all leftover vertical space equally between all the children, above the first child and below the last child:
 
 :::image type="content" source="media/flexlayout/stack.png" alt-text="Vertically oriented .NET MAUI FlexLayout.":::


### PR DESCRIPTION
Correct (`Wrap` property is set to to `Wrap`) to (Wrap` property is set to `Wrap`).