### PR TITLE
Change tip for XAML compilation from assemblyinfo to mauiprogram

### DIFF
--- a/docs/xaml/xamlc.md
+++ b/docs/xaml/xamlc.md
@@ -25,7 +25,7 @@ XAML compilation can be enabled by passing `XamlCompilationOptions.Compile` to t
 In this example, XAML compilation is enabled for all of the XAML contained within the assembly, with XAML errors being reported at compile-time rather than runtime.
 
 > [!TIP]
-> While the `XamlCompilationAttribute` can be placed anywhere, a good place to put it is in **AssemblyInfo.cs**.
+> While the `XamlCompilationAttribute` can be placed anywhere, a good place to put it is in **MauiProgram.cs**.
 
 XAML compilation can also be enabled at the type level:
 


### PR DESCRIPTION
AssemblyInfo.cs doesn't exist as an editable file anymore, at least by default since it's auto generated. I changed it to suggest MauiProgram.cs instead.