### PR TITLE
Standardize essentials examples and how the interface/class is introduced

### DIFF
--- a/docs/platform-integration/appmodel/app-actions.md
+++ b/docs/platform-integration/appmodel/app-actions.md
@@ -1,7 +1,7 @@
 ---
 title: "App actions (shortcuts)"
 description: "Describes the IAppActions interface in the Microsoft.Maui.ApplicationModel namespace, which lets you create and respond to app shortcuts from the app icon."
-ms.date: 05/23/2022
+ms.date: 09/02/2022
 no-loc: ["Microsoft.Maui", "Microsoft.Maui.ApplicationModel", "AppDelegate.cs", "AppActions", "Platforms/Android/MainActivity.cs", "Platforms/iOS/AppDelegate.cs", "Platforms/Windows/App.xaml.cs", "Id", "Title", "Subtitle", "Icon"]
 ---
 
@@ -9,7 +9,7 @@ no-loc: ["Microsoft.Maui", "Microsoft.Maui.ApplicationModel", "AppDelegate.cs", 
 
 This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `IAppActions` interface, which lets you create and respond to app shortcuts. App shortcuts are helpful to users because they allow you, as the app developer, to present them with extra ways of starting your app. For example, if you were developing an email and calendar app, you could present two different app actions, one to open the app directly to the current day of the calendar, and another to open to the email inbox folder.
 
-The `IAppActions` interface is exposed through the `AppActions.Current` property, and is available in the `Microsoft.Maui.ApplicationModel` namespace.
+The default implementation of the `IAppActions` interface is available through the `AppActions.Current` property. Both the `IAppActions` interface and `AppActions` class are contained in the `Microsoft.Maui.ApplicationModel` namespace.
 
 ## Get started
 

--- a/docs/platform-integration/appmodel/app-information.md
+++ b/docs/platform-integration/appmodel/app-information.md
@@ -1,15 +1,15 @@
 ---
 title: "App Information"
 description: "Describes the IAppInfo interface in the Microsoft.Maui.ApplicationModel namespace, which provides information about your application. For example, it exposes the app name and version."
-ms.date: 05/23/2022
+ms.date: 09/02/2022
 no-loc: ["Microsoft.Maui", "Microsoft.Maui.ApplicationModel"]
 ---
 
 # App information
 
-This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `IAppInfo` interface, which provides information about your application. The `IAppInfo` interface is exposed through the `AppInfo.Current` property.
+This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `IAppInfo` interface, which provides information about your application.
 
-The `AppInfo` and `IAppInfo` types are available in the `Microsoft.Maui.ApplicationModel` namespace.
+The default implementation of the `IAppInfo` interface is available through the `AppInfo.Current` property. Both the `IAppInfo` interface and `AppInfo` class are contained in the `Microsoft.Maui.ApplicationModel` namespace.
 
 ## Read the app information
 

--- a/docs/platform-integration/appmodel/launcher.md
+++ b/docs/platform-integration/appmodel/launcher.md
@@ -1,13 +1,15 @@
 ---
 title: "Launcher"
 description: "Learn how to use the .NET MAUI ILauncher interface in the Microsoft.Maui.ApplicationModel namespace, which can open another application by URI."
-ms.date: 05/23/2022
+ms.date: 09/02/2022
 no-loc: ["Microsoft.Maui", "Microsoft.Maui.ApplicationModel"]
 ---
 
 # Launcher
 
-This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `ILauncher` interface. This interface enables an application to open a URI by the system. This is often used when deep linking into another application's custom URI schemes. The `ILauncher` interface is exposed through the `Launcher.Default` property.
+This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `ILauncher` interface. This interface enables an application to open a URI by the system. This is often used when deep linking into another application's custom URI schemes.
+
+The default implementation of the `ILauncher` interface is available through the `Launcher.Default` property. Both the `ILauncher` interface and `Launcher` class are contained in the `Microsoft.Maui.ApplicationModel` namespace.
 
 > [!IMPORTANT]
 > To open the browser to a website, use the [Browser](open-browser.md) API instead.

--- a/docs/platform-integration/appmodel/maps.md
+++ b/docs/platform-integration/appmodel/maps.md
@@ -1,15 +1,15 @@
 ---
 title: "Map"
-description: "Learn how to use the .NET MAUI Map class in the Microsoft.Maui.ApplicationModel namespace. This class enables an application to open the installed map application to a specific location or place mark."
-ms.date: 05/23/2022
+description: "Learn how to use the .NET MAUI IMap interface in the Microsoft.Maui.ApplicationModel namespace. This interface enables an application to open the installed map application to a specific location or place mark."
+ms.date: 09/02/2022
 no-loc: ["Microsoft.Maui", "Microsoft.Maui.ApplicationModel"]
 ---
 
 # Map
 
-This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `IMap` interface. This interface enables an application to open the installed map application to a specific location or place mark. A default implementation of the `IMap` interface is exposed through the `Map.Default` property.
+This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `IMap` interface. This interface enables an application to open the installed map application to a specific location or place mark.
 
-The `IMap` and `Map` types are available in the `Microsoft.Maui.ApplicationModel` namespace.
+The default implementation of the `IMap` interface is available through the `Map.Default` property. Both the `IMap` interface and `Map` class are contained in the `Microsoft.Maui.ApplicationModel` namespace.
 
 ## Get started
 

--- a/docs/platform-integration/appmodel/open-browser.md
+++ b/docs/platform-integration/appmodel/open-browser.md
@@ -1,13 +1,15 @@
 ---
 title: "Open the browser"
-description: "The Browser class in the Microsoft.Maui.ApplicationModel namespace enables an application to open a web link in the optimized system preferred browser or the external browser."
-ms.date: 05/23/2022
+description: "The IBrowser interface in the Microsoft.Maui.ApplicationModel namespace enables an application to open a web link in the optimized system preferred browser or the external browser."
+ms.date: 09/02/2022
 no-loc: ["Microsoft.Maui", "Microsoft.Maui.ApplicationModel"]
 ---
 
 # Browser
 
-This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `IBrowser` interface. This interface enables an application to open a web link in the system-preferred browser or the external browser. A default implementation of the `IBrowser` interface is exposed through the `Browser.Default` property.
+This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `IBrowser` interface. This interface enables an application to open a web link in the system-preferred browser or the external browser.
+
+The default implementation of the `IBrowser` interface is available through the `Browser.Default` property. Both the `IBrowser` interface and `Browser` class are contained in the `Microsoft.Maui.ApplicationModel` namespace.
 
 ## Get started
 

--- a/docs/platform-integration/appmodel/version-tracking.md
+++ b/docs/platform-integration/appmodel/version-tracking.md
@@ -1,15 +1,15 @@
 ---
 title: "Version tracking"
-description: "Learn how to use the .NET MAUI VersionTracking class, which lets you check the applications version and build numbers along with seeing additional information."
-ms.date: 05/23/2022
+description: "Learn how to use the .NET MAUI IVersionTracking interface, which lets you check the applications version and build numbers along with seeing additional information."
+ms.date: 09/02/2022
 no-loc: ["Microsoft.Maui", "Microsoft.Maui.ApplicationModel"]
 ---
 
 # Version tracking
 
-This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `IVersionTracking` interface. This interface lets you check the applications version and build numbers along with seeing additional information such as if it's the first time the application launched. The `IVersionTracking` interface is exposed through the `VersionTracking.Default` property.
+This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `IVersionTracking` interface. This interface lets you check the applications version and build numbers along with seeing additional information such as if it's the first time the application launched.
 
-The `VersionTracking` and `IVersionTracking` types are available in the `Microsoft.Maui.ApplicationModel` namespace.
+The default implementation of the `IVersionTracking` interface is available through the `VersionTracking.Default` property. Both the `IVersionTracking` interface and `VersionTracking` class are contained in the `Microsoft.Maui.ApplicationModel` namespace.
 
 ## Get started
 

--- a/docs/platform-integration/communication/authentication.md
+++ b/docs/platform-integration/communication/authentication.md
@@ -1,15 +1,15 @@
 ---
 title: "Web Authenticator"
-description: "Learn how to use the .NET MAUI WebAuthenticator class, which lets you start browser-based authentication flows, which listen for a callback to the app."
-ms.date: 05/23/2022
+description: "Learn how to use the .NET MAUI IWebAuthenticator interface, which lets you start browser-based authentication flows, which listen for a callback to the app."
+ms.date: 09/02/2022
 no-loc: ["Microsoft.Maui", "Microsoft.Maui.Authentication"]
 ---
 
 # Web authenticator
 
-This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) the `IWebAuthenticator` interface. This interface lets you start browser-based authentication flows, which listen for a callback to a specific URL registered to the app. The `IWebAuthenticator` interface is exposed through the `WebAuthenticator.Default` property.
+This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) the `IWebAuthenticator` interface. This interface lets you start browser-based authentication flows, which listen for a callback to a specific URL registered to the app.
 
-The `WebAuthenticator` and `IWebAuthenticator` types are available in the `Microsoft.Maui.Authentication` namespace.
+The default implementation of the `IWebAuthenticator` interface is available through the `WebAuthenticator.Default` property. Both the `IWebAuthenticator` interface and `WebAuthenticator` class are contained in the `Microsoft.Maui.Authentication` namespace.
 
 ## Overview
 

--- a/docs/platform-integration/communication/contacts.md
+++ b/docs/platform-integration/communication/contacts.md
@@ -1,16 +1,15 @@
 ---
 title: "Contacts"
-description: "Learn how to use the .NET MAUI Contacts class in the Microsoft.Maui.ApplicationModel.Communication namespace, which lets a pick a contact and retrieve information about it."
-ms.date: 05/25/2022
+description: "Learn how to use the .NET MAUI Contacts interface in the Microsoft.Maui.ApplicationModel.Communication namespace, which lets a pick a contact and retrieve information about it."
+ms.date: 09/02/2022
 no-loc: ["Microsoft.Maui", "Microsoft.Maui.ApplicationModel.Communication"]
 ---
 
 # Contacts
 
 This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `IContacts` interface to select a contact and read information about it.
-The `IContacts` interface is exposed through the `Contacts.Default` property.
 
-The `Contacts` and `IContacts` types are available in the `Microsoft.Maui.ApplicationModel.Communication` namespace.
+The default implementation of the `IContacts` interface is available through the `Contacts.Default` property. Both the `IContacts` interface and `Contacts` class are contained in the `Microsoft.Maui.ApplicationModel.Communication` namespace.
 
 > [!IMPORTANT]
 > Because of a namespace conflict, the `Contacts` type must be fully qualified when targeting iOS or macOS: `Microsoft.Maui.ApplicationModel.Communication.Contacts`. New projects automatically target these platforms, along with Android and Windows.

--- a/docs/platform-integration/communication/email.md
+++ b/docs/platform-integration/communication/email.md
@@ -1,15 +1,15 @@
 ---
 title: "Email"
-description: "Learn how to use the .NET MAUI Email class in the Microsoft.Maui.ApplicationModel.Communication namespace to open the default email application. The subject, body, and recipients of an email can be set."
-ms.date: 05/23/2022
+description: "Learn how to use the .NET MAUI IEmail interface in the Microsoft.Maui.ApplicationModel.Communication namespace to open the default email application. The subject, body, and recipients of an email can be set."
+ms.date: 09/02/2022
 no-loc: ["Microsoft.Maui", "Microsoft.Maui.ApplicationModel.Communication"]
 ---
 
 # Email
 
-This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `IEmail` interface to open the default email app. When the email app is loaded, it can be set to create a new email with the specified recipients, subject, and body. The `IEmail` interface is exposed through the `Email.Default` property.
+This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `IEmail` interface to open the default email app. When the email app is loaded, it can be set to create a new email with the specified recipients, subject, and body.
 
-The `Email` and `IEmail` types are available in the `Microsoft.Maui.ApplicationModel.Communication` namespace.
+The default implementation of the `IEmail` interface is available through the `Email.Default` property. Both the `IEmail` interface and `Email` class are contained in the `Microsoft.Maui.ApplicationModel.Communication` namespace.
 
 ## Get started
 

--- a/docs/platform-integration/communication/networking.md
+++ b/docs/platform-integration/communication/networking.md
@@ -1,15 +1,15 @@
 ---
 title: "Connectivity"
-description: "Learn how to use the .NET MAUI Connectivity interface in the Microsoft.Maui.Networking namespace. With this interface, you can determine if you can communicate with the internet and which network devices are connected"
-ms.date: 05/23/2022
+description: "Learn how to use the .NET MAUI IConnectivity interface in the Microsoft.Maui.Networking namespace. With this interface, you can determine if you can communicate with the internet and which network devices are connected"
+ms.date: 09/02/2022
 no-loc: ["Microsoft.Maui", "Microsoft.Maui.Networking", "Connectivity"]
 ---
 
 # Connectivity
 
-This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `IConnectivity` interface to inspect the network accessibility of the device. The network connection may have access to the internet. Devices also contain different kinds of network connections, such as Bluetooth, cellular, or WiFi. The `IConnectivity` interface has an event to monitor changes in the devices connection state. The `IConnectivity` interface is exposed through the `Connectivity.Current` property.
+This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `IConnectivity` interface to inspect the network accessibility of the device. The network connection may have access to the internet. Devices also contain different kinds of network connections, such as Bluetooth, cellular, or WiFi. The `IConnectivity` interface has an event to monitor changes in the devices connection state.
 
-The `Connectivity` and `IConnectivity` types are available in the `Microsoft.Maui.Networking` namespace.
+The default implementation of the `IConnectivity` interface is available through the `Connectivity.Current` property. Both the `IConnectivity` interface and `Connectivity` class are contained in the `Microsoft.Maui.Networking` namespace.
 
 ## Get started
 

--- a/docs/platform-integration/communication/phone-dialer.md
+++ b/docs/platform-integration/communication/phone-dialer.md
@@ -1,15 +1,15 @@
 ---
 title: "Phone dialer"
-description: "Learn how to open the phone dialer to a specific number, in .NET MAUI. The PhoneDialer class in the Microsoft.Maui.ApplicationModel.Communication namespace is used to open the phone dialer."
-ms.date: 05/23/2022
+description: "Learn how to open the phone dialer to a specific number, in .NET MAUI. The IPhoneDialer interface in the Microsoft.Maui.ApplicationModel.Communication namespace is used to open the phone dialer."
+ms.date: 09/02/2022
 no-loc: ["Microsoft.Maui", "Microsoft.Maui.ApplicationModel.Communication"]
 ---
 
 # Phone dialer
 
-This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `IPhoneDialer` interface. This interface enables an application to open a phone number in the dialer. The `IPhoneDialer` interface is exposed through the `PhoneDialer.Default` property.
+This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `IPhoneDialer` interface. This interface enables an application to open a phone number in the dialer.
 
-The `PhoneDialer` and `IPhoneDialer` types are available in the `Microsoft.Maui.ApplicationModel.Communication` namespace.
+The default implementation of the `IPhoneDialer` interface is available through the `PhoneDialer.Default` property. Both the `IPhoneDialer` interface and `PhoneDialer` class are contained in the `Microsoft.Maui.ApplicationModel.Communication` namespace.
 
 ## Get started
 

--- a/docs/platform-integration/communication/sms.md
+++ b/docs/platform-integration/communication/sms.md
@@ -1,15 +1,15 @@
 ---
 title: "SMS"
-description: "Learn how to use the .NET MAUI Sms class in Microsoft.Maui.ApplicationModel.Communication to open the default SMS application. The text message can be preloaded with a message and recipient."
-ms.date: 05/23/2022
+description: "Learn how to use the .NET MAUI ISms interface in Microsoft.Maui.ApplicationModel.Communication to open the default SMS application. The text message can be preloaded with a message and recipient."
+ms.date: 09/02/2022
 no-loc: ["Microsoft.Maui", "Microsoft.Maui.ApplicationModel.Communication"]
 ---
 
 # SMS
 
-This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `ISms` interface to open the default SMS app and preload it with a message and recipient. The `ISms` interface is exposed through the `Sms.Default` property.
+This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `ISms` interface to open the default SMS app and preload it with a message and recipient.
 
-The `Sms` and `ISms` types are available in the `Microsoft.Maui.ApplicationModel.Communication` namespace.
+The default implementation of the `ISms` interface is available through the `Sms.Default` property. Both the `ISms` interface and `Sms` class are contained in the `Microsoft.Maui.ApplicationModel.Communication` namespace.
 
 ## Get started
 

--- a/docs/platform-integration/data/clipboard.md
+++ b/docs/platform-integration/data/clipboard.md
@@ -1,22 +1,22 @@
 ---
 title: "Clipboard"
-description: "Learn how to use the .NET MAUI Clipboard class in the Microsoft.Maui.ApplicationModel.DataTransfer namespace, which lets you copy and paste text to the system clipboard."
-ms.date: 05/23/2022
+description: "Learn how to use the .NET MAUI IClipboard interface in the Microsoft.Maui.ApplicationModel.DataTransfer namespace, which lets you copy and paste text to the system clipboard."
+ms.date: 09/02/2022
 no-loc: ["Microsoft.Maui", "Microsoft.Maui.ApplicationModel.DataTransfer"]
 ---
 
 # Clipboard
 
-This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `Clipboard` class. With this class, you can copy and paste text to and from the system clipboard.
+This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `IClipboard` interface. With this interface, you can copy and paste text to and from the system clipboard.
 
-The `Clipboard` class is available in the `Microsoft.Maui.ApplicationModel.DataTransfer` namespace.
+The default implementation of the `IClipboard` interface is available through the `Clipboard.Default` property. Both the `IClipboard` interface and `Clipboard` class are contained in the `Microsoft.Maui.ApplicationModel.DataTransfer` namespace.
 
 > [!TIP]
 > Access to the clipboard must be done on the main user interface thread. For more information on how to invoke methods on the main user interface thread, see [MainThread](../appmodel/main-thread.md).
 
 ## Using Clipboard
 
-The clipboard is accessed through default implementation of the `IClipboard` interface, available from the `Microsoft.Maui.ApplicationModel.DataTransfer.Clipboard.Default` property. Access to the clipboard is limited to string data. You can check if the clipboard contains data, set or clear the data, and read the data. The `ClipboardContentChanged` event is raised whenever the clipboard data changes.
+ Access to the clipboard is limited to string data. You can check if the clipboard contains data, set or clear the data, and read the data. The `ClipboardContentChanged` event is raised whenever the clipboard data changes.
 
 The following code example demonstrates using a button to set the clipboard data:
 

--- a/docs/platform-integration/data/share.md
+++ b/docs/platform-integration/data/share.md
@@ -1,15 +1,15 @@
 ---
 title: "Share"
-description: "Learn how to use the .NET MAUI Share class, which can share data, such as web links, to other applications on the device."
-ms.date: 05/23/2022
+description: "Learn how to use the .NET MAUI IShare interface, which can share data, such as web links, to other applications on the device."
+ms.date: 09/02/2022
 no-loc: ["Microsoft.Maui", "Microsoft.Maui.ApplicationModel.DataTransfer"]
 ---
 
 # Share
 
-This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `Share` class. This class provides an API to send data, such as text or web links, to the devices share function.
+This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `IShare` interface. This interface provides an API to send data, such as text or web links, to the devices share function.
 
-The `Share` class is available in the `Microsoft.Maui.ApplicationModel.DataTransfer` namespace.
+The default implementation of the `IShare` interface is available through the `Share.Default` property. Both the `IShare` interface and `Share` class are contained in the `Microsoft.Maui.ApplicationModel.DataTransfer` namespace.
 
 When a share request is made, the device displays a share window, prompting the user to choose an app to share with:
 

--- a/docs/platform-integration/device-media/picker.md
+++ b/docs/platform-integration/device-media/picker.md
@@ -1,15 +1,15 @@
 ---
 title: "Media picker"
-description: "Learn how to use the MediaPicker class in the Microsoft.Maui.Media namespace, to prompt the user to select or take a photo or video."
-ms.date: 05/23/2022
+description: "Learn how to use the IMediaPicker interface in the Microsoft.Maui.Media namespace, to prompt the user to select or take a photo or video."
+ms.date: 09/02/2022
 no-loc: ["Microsoft.Maui", "Microsoft.Maui.Media", "MediaPicker"]
 ---
 
 # Media picker
 
-This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `IMediaPicker` interface. This interface lets a user pick or take a photo or video on the device. The `IMediaPicker` interface is exposed through the `MediaPicker.Default` property.
+This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `IMediaPicker` interface. This interface lets a user pick or take a photo or video on the device.
 
-The `MediaPicker` and `IMediaPicker` types are available in the `Microsoft.Maui.Media` namespace.
+The default implementation of the `IMediaPicker` interface is available through the `MediaPicker.Default` property. Both the `IMediaPicker` interface and `MediaPicker` class are contained in the `Microsoft.Maui.Media` namespace.
 
 ## Get started
 

--- a/docs/platform-integration/device-media/screenshot.md
+++ b/docs/platform-integration/device-media/screenshot.md
@@ -1,15 +1,15 @@
 ---
 title: "Screenshot"
-description: "Learn how to use the Screenshot class in the Microsoft.Maui.Media namespace, to capture of the current displayed screen of the app."
-ms.date: 05/23/2022
+description: "Learn how to use the IScreenshot interface in the Microsoft.Maui.Media namespace, to capture of the current displayed screen of the app."
+ms.date: 09/02/2022
 no-loc: ["Microsoft.Maui", "Microsoft.Maui.Media", "ScreenShot"]
 ---
 
 # Screenshot
 
-This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `IScreenshot` interface. This interfaces lets you take a capture of the current displayed screen of the app. The `IScreenshot` interface is exposed through the `Screenshot.Default` property.
+This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `IScreenshot` interface. This interfaces lets you take a capture of the current displayed screen of the app.
 
-The `Screenshot` and `IScreenshot` types are available in the `Microsoft.Maui.Media` namespace.
+The default implementation of the `IScreenshot` interface is available through the `Screenshot.Default` property. Both the `IScreenshot` interface and `Screenshot` class are contained in the `Microsoft.Maui.Media` namespace.
 
 ## Capture a screenshot
 

--- a/docs/platform-integration/device-media/text-to-speech.md
+++ b/docs/platform-integration/device-media/text-to-speech.md
@@ -1,15 +1,15 @@
 ---
 title: "Text-to-Speech"
-description: "Learn how to use the .NET MAUI TextToSpeech class, which enables an application utilize the built in text-to-speech engines to speak back text from the device."
-ms.date: 05/23/2022
+description: "Learn how to use the .NET MAUI ITextToSpeech interface, which enables an application utilize the built in text-to-speech engines to speak back text from the device."
+ms.date: 09/02/2022
 no-loc: ["Microsoft.Maui", "Microsoft.Maui.Media", "TextToSpeech"]
 ---
 
 # Text-to-Speech
 
-This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `ITextToSpeech` interface. This interface enables an application to utilize the built-in text-to-speech engines to speak back text from the device. You can also use it to query for available languages. The `ITextToSpeech` interface is exposed through the `TextToSpeech.Default` property.
+This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `ITextToSpeech` interface. This interface enables an application to utilize the built-in text-to-speech engines to speak back text from the device. You can also use it to query for available languages.
 
-The `TextToSpeech` and `ITextToSpeech` types are available in the `Microsoft.Maui.Media` namespace.
+The default implementation of the `ITextToSpeech` interface is available through the `TextToSpeech.Default` property. Both the `ITextToSpeech` interface and `TextToSpeech` class are contained in the `Microsoft.Maui.Media` namespace.
 
 ## Using Text-to-Speech
 

--- a/docs/platform-integration/device/battery.md
+++ b/docs/platform-integration/device/battery.md
@@ -1,15 +1,15 @@
 ---
 title: "Battery"
-description: "Learn how to use the .NET MAUI Battery class in the Microsoft.Maui.Devices namespace. You can check the device's battery information and monitor for changes."
-ms.date: 05/23/2022
+description: "Learn how to use the .NET MAUI IBattery interface in the Microsoft.Maui.Devices namespace. You can check the device's battery information and monitor for changes."
+ms.date: 09/02/2022
 no-loc: ["Microsoft.Maui", "Microsoft.Maui.Devices"]
 ---
 
 # Battery
 
-This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `Battery` class to check the device's battery information and monitor for changes. This class also provides information about the device's energy-saver status, which indicates if the device is running in a low-power mode.
+This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `IBattery` interface to check the device's battery information and monitor for changes. This interface also provides information about the device's energy-saver status, which indicates if the device is running in a low-power mode.
 
-The `Battery` class is available in the `Microsoft.Maui.Devices` namespace.
+The default implementation of the `IBattery` interface is available through the `Battery.Default` property. Both the `IBattery` interface and `Battery` class are contained in the `Microsoft.Maui.Devices` namespace.
 
 ## Get started
 
@@ -59,7 +59,7 @@ No setup is required.
 
 ## Check the battery status
 
-The battery status can be checked by accessing the default implementation of the `IBattery` interface. This implementation is available from the `Microsoft.Maui.Devices.Battery.Default` property. The interface defines the `BatteryInfoChanged` event which is raised when the state of the battery changed. Outside of this event, you can still check the state of the battery at any time by using the various properties defined by the interface.
+The battery status can be checked by accessing the `Battery.Default` property, which is the default implementation of the `IBattery` interface. This interface defines various properties to provide information about the state of the battery. The `BatteryInfoChanged` event is also available, and is raised when the state of the battery changed.
 
 The following example demonstrates how to use the monitor the `BatteryInfoChanged` event and report the battery status two `Label` controls:
 
@@ -77,7 +77,7 @@ Devices that run on batteries can be put into a low-power energy-saver mode. Som
 The energy-saver status of the device can be read by accessing the `EnergySaverStatus` property, which is either `On`, `Off`, or `Unknown`. If the status is `On`, the application should avoid background processing or other activities that may consume a lot of power.
 
 The battery will raise the `EnergySaverStatusChanged` event when the battery enters or leaves energy-saver mode.
-You can also obtain the current energy-saver status of the device using the static `Battery.EnergySaverStatus` property:
+You can also obtain the current energy-saver status of the device using the `EnergySaverStatus` property:
 
 The following code example monitors the energy-saver status and sets a property accordingly.
 

--- a/docs/platform-integration/device/display.md
+++ b/docs/platform-integration/device/display.md
@@ -1,19 +1,17 @@
 ---
 title: "Device Display Information"
-description: "Learn how to use the .NET MAUI DeviceDisplay class in the Microsoft.Maui.Devices namespace, which provides screen metrics for the device on which the app is running."
-ms.date: 05/23/2022
+description: "Learn how to use the .NET MAUI IDeviceDisplay interface in the Microsoft.Maui.Devices namespace, which provides screen metrics for the device on which the app is running."
+ms.date: 09/02/2022
 no-loc: ["Microsoft.Maui", "Microsoft.Maui.Devices"]
 ---
 
 # Device display information
 
-This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `DeviceDisplay` class to read information about the device's screen metrics. This class can be used to request the screen stays awake while the app is running.
+This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `IDeviceDisplay` interface to read information about the device's screen metrics. This interface can be used to request the screen stays awake while the app is running.
 
-The `DeviceDisplay` class is available in the `Microsoft.Maui.Devices` namespace.
+The default implementation of the `IDeviceDisplay` interface is available through the `DeviceDisplay.Current` property. Both the `IDeviceDisplay` interface and `DeviceDisplay` class are contained in the `Microsoft.Maui.Devices` namespace.
 
 ## Main display info
-
-Information about your device's screen is accessed by the default implementation of the `IDeviceDisplay` interface, which is available by accessing the `Microsoft.Maui.Devices.DeviceDisplay.Current` property.
 
 The `IDeviceDisplay.MainDisplayInfo` property returns information about the screen and orientation. The following code example uses the `Loaded` event of a page to read information about the current screen:
 

--- a/docs/platform-integration/device/flashlight.md
+++ b/docs/platform-integration/device/flashlight.md
@@ -1,15 +1,17 @@
 ---
 title: "Flashlight"
-description: "Learn how to use the .NET MAUI Flashlight class in the Microsoft.Maui.Devices namespace. This class provides the ability to turn on or off the device's camera flash, to emulate a flashlight."
-ms.date: 05/23/2022
+description: "Learn how to use the .NET MAUI IFlashlight interface in the Microsoft.Maui.Devices namespace. This interface provides the ability to turn on or off the device's camera flash, to emulate a flashlight."
+ms.date: 09/02/2022
 no-loc: ["Microsoft.Maui", "Microsoft.Maui.Devices"]
 ---
 
 # Flashlight
 
-This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `Flashlight` class. With this class, you can toggle the device's camera flash on and off, to emulate a flashlight.
+This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `IFlashlight` interface. With this interface, you can toggle the device's camera flash on and off, to emulate a flashlight.
 
-The `Flashlight` class is available in the `Microsoft.Maui.Devices` namespace.
+The default implementation of the `IFlashlight` interface is available through the `Flashlight.Default` property. Both the `IFlashlight` interface and `Flashlight` class are contained in the `Microsoft.Maui.Devices` namespace.
+
+The `` class is available in the `Microsoft.Maui.Devices` namespace.
 
 ## Get started
 
@@ -70,7 +72,7 @@ No setup is required.
 
 ## Use Flashlight
 
-The flashlight is accessed through default implementation of the `IFlashlight` interface, available from the `Microsoft.Maui.Devices.Flashlight.Default` property. The flashlight can be turned on and off through the `TurnOnAsync` and `TurnOffAsync` methods. The following code example ties the flashlight's on or off state to a `Switch` control:
+The flashlight can be turned on and off through the `TurnOnAsync` and `TurnOffAsync` methods. The following code example ties the flashlight's on or off state to a `Switch` control:
 
 :::code language="csharp" source="../snippets/shared_1/DeviceDetailsPage.xaml.cs" id="flashlight":::
 

--- a/docs/platform-integration/device/geocoding.md
+++ b/docs/platform-integration/device/geocoding.md
@@ -1,7 +1,7 @@
 ---
 title: "Geocoding"
-description: "Learn how to use the .NET MAUI Geocoding class in the Microsoft.Maui.Devices.Sensors namespace. This class provides APIs to both geocode a placemark to a positional coordinate, and reverse geocode coordinates to a placemark."
-ms.date: 05/23/2022
+description: "Learn how to use the .NET MAUI IGeocoding interface in the Microsoft.Maui.Devices.Sensors namespace. This interface provides APIs to both geocode a placemark to a positional coordinate, and reverse geocode coordinates to a placemark."
+ms.date: 09/02/2022
 no-loc: ["Microsoft.Maui", "Microsoft.Maui.Devices", "Microsoft.Maui.Devices.Sensors"]
 ---
 
@@ -9,7 +9,7 @@ no-loc: ["Microsoft.Maui", "Microsoft.Maui.Devices", "Microsoft.Maui.Devices.Sen
 
 This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `IGeocoding` interface. This interfaces provides APIs to geocode a placemark to a positional coordinates and reverse geocode coordinates to a placemark. The `IGeocoding` interface is exposed through the `Geocoding.Default` property.
 
-The `Geocoding` and `IGeocoding` types are available in the `Microsoft.Maui.Devices.Sensors` namespace.
+The default implementation of the `IGeocoding` interface is available through the `Geocoding.Default` property. Both the `IGeocoding` interface and `Geocoding` class are contained in the `Microsoft.Maui.Devices.Sensors` namespace.
 
 ## Get started
 

--- a/docs/platform-integration/device/geolocation.md
+++ b/docs/platform-integration/device/geolocation.md
@@ -1,15 +1,15 @@
 ---
 title: "Geolocation"
-description: "Learn how to use the .NET MAUI Geolocation class in the Microsoft.Maui.Devices.Sensors namespace. This class provides API to retrieve the device's current geolocation coordinates."
-ms.date: 05/23/2022
+description: "Learn how to use the .NET MAUI IGeolocation interface in the Microsoft.Maui.Devices.Sensors namespace. This interface provides API to retrieve the device's current geolocation coordinates."
+ms.date: 09/02/2022
 no-loc: ["Microsoft.Maui", "Microsoft.Maui.Devices", "Microsoft.Maui.Devices.Sensors"]
 ---
 
 # Geolocation
 
-This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `IGeolocation` class. This class provides APIs to retrieve the device's current geolocation coordinates. The `IGeolocation` interface is exposed through the `Geolocation.Default` property.
+This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `IGeolocation` interface. This interface provides APIs to retrieve the device's current geolocation coordinates.
 
-The `Geolocation` and `IGeolocation` types are available in the `Microsoft.Maui.Devices.Sensors` namespace.
+The default implementation of the `IGeolocation` interface is available through the `Geolocation.Default` property. Both the `IGeolocation` interface and `Geolocation` class are contained in the `Microsoft.Maui.Devices.Sensors` namespace.
 
 ## Get started
 

--- a/docs/platform-integration/device/haptic-feedback.md
+++ b/docs/platform-integration/device/haptic-feedback.md
@@ -1,15 +1,15 @@
 ---
 title: "Haptic Feedback"
-description: "Learn how to use the .NET MAUI HapticFeedback class in the Microsoft.Maui.Devices namespace. This class lets you control haptic feedback on a device."
-ms.date: 05/23/2022
+description: "Learn how to use the .NET MAUI IHapticFeedback class in the Microsoft.Maui.Devices namespace. This interface lets you control haptic feedback on a device."
+ms.date: 09/02/2022
 no-loc: ["Microsoft.Maui", "Microsoft.Maui.Devices"]
 ---
 
 # Haptic feedback
 
-This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `HapticFeedback` class to control haptic feedback on a device. Haptic feedback is generally manifested by a gentle vibration sensation provided by the device to give a response to the user. Some examples of haptic feedback are when a user types on a virtual keyboard or when they play a game where the player's character has an encounter with an enemy character.
+This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `IHapticFeedback` interface to control haptic feedback on a device. Haptic feedback is generally manifested by a gentle vibration sensation provided by the device to give a response to the user. Some examples of haptic feedback are when a user types on a virtual keyboard or when they play a game where the player's character has an encounter with an enemy character.
 
-The `HapticFeedback` class is available in the `Microsoft.Maui.Devices` namespace.
+The default implementation of the `IHapticFeedback` interface is available through the `HapticFeedback.Default` property. Both the `IHapticFeedback` interface and `HapticFeedback` class are contained in the `Microsoft.Maui.Devices` namespace.
 
 ## Get started
 
@@ -61,6 +61,6 @@ No setup is required.
 
 ## Use haptic feedback
 
-Haptic feedback is accessed through default implementation of the `IHapticFeedback` interface, available from the `Microsoft.Maui.Devices.HapticFeedback.Default` property. The haptic feedback functionality is performed in two modes: a short `Click` or a `LongPress`. The following code example initiates a `Click` or `LongPress` haptic feedback response to the user based on which `Button` they click:
+The haptic feedback functionality is performed in two modes: a short `Click` or a `LongPress`. The following code example initiates a `Click` or `LongPress` haptic feedback response to the user based on which `Button` they click:
 
 :::code language="csharp" source="../snippets/shared_1/DeviceDetailsPage.xaml.cs" id="hapticfeedback":::

--- a/docs/platform-integration/device/information.md
+++ b/docs/platform-integration/device/information.md
@@ -1,19 +1,19 @@
 ---
 title: "Device information"
-description: "Learn how to use the .NET MAUI DeviceInfo class in the Microsoft.Maui.Devices namespace, which provides information about the device the app is running on."
-ms.date: 05/23/2022
+description: "Learn how to use the .NET MAUI IDeviceInfo interface in the Microsoft.Maui.Devices namespace, which provides information about the device the app is running on."
+ms.date: 09/02/2022
 no-loc: ["Microsoft.Maui", "Microsoft.Maui.Devices"]
 ---
 
 # Device information
 
-This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `DeviceInfo` class to read information about the device the app is running on.
+This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `IDeviceInfo` interface to read information about the device the app is running on.
 
-The `DeviceInfo` class is available in the `Microsoft.Maui.Devices` namespace.
+The default implementation of the `IDeviceInfo` interface is available through the `DeviceInfo.Current` property. Both the `IDeviceInfo` interface and `DeviceInfo` class are contained in the `Microsoft.Maui.Devices` namespace.
 
 ## Read device info
 
-Information about your device's is accessed by the default implementation of the `IDeviceInfo` interface, which is available by accessing the `Microsoft.Maui.Devices.DeviceInfo.Current` property. The `IDeviceInfo` interface provides many properties that describe the device, such as the manufacturer and idiom. The following example demonstrates reading the device info properties:
+The `IDeviceInfo` interface provides many properties that describe the device, such as the manufacturer and idiom. The following example demonstrates reading the device info properties:
 
 :::code language="csharp" source="../snippets/shared_1/DeviceDetailsPage.xaml.cs" id="read_info":::
 

--- a/docs/platform-integration/device/sensors.md
+++ b/docs/platform-integration/device/sensors.md
@@ -2,7 +2,7 @@
 title: Accessing device sensors overview
 description: "Learn how to use and monitor sensors provided by your device, with .NET MAUI. You can monitor the following sensors: accelerometer, barometer, compass, shake, gyroscope, magnetometer, orientation."
 ms.topic: overview
-ms.date: 05/23/2022
+ms.date: 09/02/2022
 ms.custom: template-overview
 show_latex: true
 no-loc: ["Microsoft.Maui", "Microsoft.Maui.Devices", "Microsoft.Maui.Devices.Sensors"]
@@ -41,9 +41,11 @@ Event handlers added to sensors with either the `Game` or `Fastest` speeds **are
 
 The accelerometer sensor measures the acceleration of the device along its three axes. The data reported by the sensor represents how the user is moving the device.
 
+The `IAccelerometer` interface provides access to the sensor, and is available through the `Accelerometer.Default` property. Both the `IAccelerometer` interface and `Accelerometer` class are contained in the `Microsoft.Maui.Devices.Sensors` namespace.
+
 To start monitoring the accelerometer sensor, call the `IAccelerometer.Start` method. .NET MAUI sends accelerometer data changes to your app by raising the `IAccelerometer.ReadingChanged` event. Use the `IAccelerometer.Stop` method to stop monitoring the sensor. You can detect the monitoring state of the accelerometer with the `IAccelerometer.IsMonitoring` property, which will be `true` if the accelerometer was started and is currently being monitored.
 
-The following code example demonstrates monitoring the accelerometer for changes. The `Accelerometer.Default` instance would be passed to the `ToggleAccelerometer` method:
+The following code example demonstrates monitoring the accelerometer for changes:
 
 :::code language="csharp" source="../snippets/shared_1/SensorsPage.xaml.cs" id="toggle_accelerometer":::
 
@@ -70,11 +72,13 @@ There is no platform-specific information related to the accelerometer sensor.
 
 The barometer sensor measures the ambient air pressure. The data reported by the sensor represents the current air pressure. This data is reported the first time you start monitoring the sensor and then each time the pressure changes.
 
+The `IBarometer` interface provides access to the sensor, and is available through the `Barometer.Default` property. Both the `IBarometer` interface and `Barometer` class are contained in the `Microsoft.Maui.Devices.Sensors` namespace.
+
 To start monitoring the barometer sensor, call the `IBarometer.Start` method. .NET MAUI sends air pressure readings to your app by raising the `IBarometer.ReadingChanged` event. Use the `IBarometer.Stop` method to stop monitoring the sensor. You can detect the monitoring state of the barometer with the `IBarometer.IsMonitoring` property, which will be `true` if the barometer is currently being monitored.
 
 The pressure reading is represented in hectopascals.
 
-The following code example demonstrates monitoring the barometer for changes. The `Barometer.Default` instance would be passed to the `ToggleBarometer` method:
+The following code example demonstrates monitoring the barometer for changes:
 
 :::code language="csharp" source="../snippets/shared_1/SensorsPage.xaml.cs" id="toggle_barometer":::
 
@@ -104,9 +108,11 @@ No platform-specific implementation details.
 
 The compass sensor monitors the device's magnetic north heading.
 
-To start monitoring the compass sensor, call the `Compass.Start` method. .NET MAUI raises the `Compass.ReadingChanged` event when the compass heading changes. Use the `Compass.Stop` method to stop monitoring the sensor. You can detect the monitoring state of the compass with the `Compass.IsMonitoring` property, which will be `true` if the compass is currently being monitored.
+The `ICompass` interface provides access to the sensor, and is available through the `Compass.Default` property. Both the `ICompass` interface and `Compass` class are contained in the `Microsoft.Maui.Devices.Sensors` namespace.
 
-The following code example demonstrates monitoring the compass for changes. The `Compass.Default` instance would be passed to the `ToggleCompass` method:
+To start monitoring the compass sensor, call the `ICompass.Start` method. .NET MAUI raises the `ICompass.ReadingChanged` event when the compass heading changes. Use the `ICompass.Stop` method to stop monitoring the sensor. You can detect the monitoring state of the compass with the `ICompass.IsMonitoring` property, which will be `true` if the compass is currently being monitored.
+
+The following code example demonstrates monitoring the compass for changes:
 
 :::code language="csharp" source="../snippets/shared_1/SensorsPage.xaml.cs" id="toggle_compass":::
 
@@ -151,13 +157,15 @@ No platform-specific implementation details.
 
 Even though this article is listing **shake** as a sensor, it isn't. The [accelerometer](#accelerometer) is used to detect when the device is shaken.
 
+The `IAccelerometer` interface provides access to the sensor, and is available through the `Accelerometer.Default` property. Both the `IAccelerometer` interface and `Accelerometer` class are contained in the `Microsoft.Maui.Devices.Sensors` namespace.
+
 The detect shake API uses raw readings from the accelerometer to calculate acceleration. It uses a simple queue mechanism to detect if 3/4ths of the recent accelerometer events occurred in the last half second. Acceleration is calculated by adding the square of the X, Y, and Z ($x^2+y^2+z^2$) readings from the accelerometer and comparing it to a specific threshold.
 
 To start monitoring the accelerometer sensor, call the `IAccelerometer.Start` method. When a shake is detected, the `IAccelerometer.ShakeDetected` event is raised.  Use the `IAccelerometer.Stop` method to stop monitoring the sensor. You can detect the monitoring state of the accelerometer with the `IAccelerometer.IsMonitoring` property, which will be `true` if the accelerometer was started and is currently being monitored.
 
 It's recommended to use `Game` or faster for the `SensorSpeed`.
 
-The following code example demonstrates monitoring the accelerometer for the `ShakeDetected` event. The `Accelerometer.Default` instance would be passed to the `ToggleShake` method:
+The following code example demonstrates monitoring the accelerometer for the `ShakeDetected` event:
 
 :::code language="csharp" source="../snippets/shared_1/SensorsPage.xaml.cs" id="toggle_shake":::
 
@@ -169,9 +177,11 @@ There is no platform-specific information related to the accelerometer sensor.
 
 The gyroscope sensor measures the angular rotation speed around the device's three primary axes.
 
+The `IGyroscope` interface provides access to the sensor, and is available through the `Gyroscope.Default` property. Both the `IGyroscope` interface and `Gyroscope` class are contained in the `Microsoft.Maui.Devices.Sensors` namespace.
+
 To start monitoring the gyroscope sensor, call the `IGyroscope.Start` method. .NET MAUI sends gyroscope data changes to your app by raising the `IGyroscope.ReadingChanged` event. The data provided by this event is measured in rad/s (radian per second). Use the `IGyroscope.Stop` method to stop monitoring the sensor. You can detect the monitoring state of the gyroscope with the `IGyroscope.IsMonitoring` property, which will be `true` if the gyroscope was started and is currently being monitored.
 
-The following code example demonstrates monitoring the gyroscope. The `Gyroscope.Default` instance would be passed to the `ToggleGyroscope` method:
+The following code example demonstrates monitoring the gyroscope:
 
 :::code language="csharp" source="../snippets/shared_1/SensorsPage.xaml.cs" id="toggle_gyroscope":::
 
@@ -183,9 +193,11 @@ There is no platform-specific information related to the gyroscope sensor.
 
 The magnetometer sensor indicates the device's orientation relative to Earth's magnetic field.
 
+The `IMagnetometer` interface provides access to the sensor, and is available through the `Magnetometer.Default` property. Both the `IMagnetometer` interface and `Magnetometer` class are contained in the `Microsoft.Maui.Devices.Sensors` namespace.
+
 To start monitoring the magnetometer sensor, call the `IMagnetometer.Start` method. .NET MAUI sends magnetometer data changes to your app by raising the `IMagnetometer.ReadingChanged` event. The data provided by this event is measured in $µT$ (microteslas). Use the `IMagnetometer.Stop` method to stop monitoring the sensor. You can detect the monitoring state of the magnetometer with the `IMagnetometer.IsMonitoring` property, which will be `true` if the magnetometer was started and is currently being monitored.
 
-The following code example demonstrates monitoring the magnetometer. The `Magnetometer.Default` instance would be passed to the `ToggleMagnetometer` method:
+The following code example demonstrates monitoring the magnetometer:
 
 :::code language="csharp" source="../snippets/shared_1/SensorsPage.xaml.cs" id="toggle_magnetometer":::
 
@@ -200,9 +212,11 @@ The orientation sensor monitors the orientation of a device in 3D space.
 > [!NOTE]
 > This sensor isn't used for determining if the device's video display is in portrait or landscape mode. Use the `Orientation` property of the `ScreenMetrics` object available from the [`DeviceDisplay`](../device/display.md) class.
 
+The `IOrientationSensor` interface provides access to the sensor, and is available through the `OrientationSensor.Default` property. Both the `IOrientationSensor` interface and `OrientationSensor` class are contained in the `Microsoft.Maui.Devices.Sensors` namespace.
+
 To start monitoring the orientation sensor, call the `IOrientationSensor.Start` method. .NET MAUI sends orientation data changes to your app by raising the `IOrientationSensor.ReadingChanged` event. Use the `IOrientationSensor.Stop` method to stop monitoring the sensor. You can detect the monitoring state of the orientation with the `IOrientationSensor.IsMonitoring` property, which will be `true` if the orientation was started and is currently being monitored.
 
-The following code example demonstrates monitoring the orientation sensor. The `OrientationSensor.Default` instance would be passed to the `ToggleOrientation` method:
+The following code example demonstrates monitoring the orientation sensor:
 
 :::code language="csharp" source="../snippets/shared_1/SensorsPage.xaml.cs" id="toggle_orientation":::
 

--- a/docs/platform-integration/device/vibrate.md
+++ b/docs/platform-integration/device/vibrate.md
@@ -1,15 +1,15 @@
 ---
 title: "Vibration"
-description: "Learn how to use the .NET MAUI Vibration class, which lets you start and stop the vibrate functionality for a desired amount of time."
-ms.date: 05/23/2022
+description: "Learn how to use the .NET MAUI IVibration interface, which lets you start and stop the vibrate functionality for a desired amount of time."
+ms.date: 09/02/2022
 no-loc: ["Microsoft.Maui", "Microsoft.Maui.Devices"]
 ---
 
 # Vibration
 
-This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `Vibration` class. This class lets you start and stop the vibrate functionality for a desired amount of time.
+This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `IVibration` interface. This interface lets you start and stop the vibrate functionality for a desired amount of time.
 
-The `HapticFeedback` class is available in the `Microsoft.Maui.Devices` namespace.
+The default implementation of the `IVibration` interface is available through the `Vibration.Default` property. Both the `IVibration` interface and `Vibration` class are contained in the `Microsoft.Maui.Devices` namespace.
 
 ## Get started
 
@@ -58,7 +58,7 @@ No additional setup required.
 
 ## Vibrate the device
 
-Haptic feedback is accessed through default implementation of the `IVibration` interface, available from the `Microsoft.Maui.Devices.Vibration.Default` property. The vibration functionality can be requested for a set amount of time or the default of 500 milliseconds. The following code example randomly vibrates the device between one and seven seconds:
+The vibration functionality can be requested for a set amount of time or the default of 500 milliseconds. The following code example randomly vibrates the device between one and seven seconds:
 
 :::code language="csharp" source="../snippets/shared_1/DeviceDetailsPage.xaml.cs" id="vibrate":::
 

--- a/docs/platform-integration/snippets/shared_1/AppModelPage.xaml.cs
+++ b/docs/platform-integration/snippets/shared_1/AppModelPage.xaml.cs
@@ -465,19 +465,19 @@ public partial class AppModelPage : ContentPage
     //<version_read>
     private void ReadVersion_Clicked(object sender, EventArgs e)
     {
-        labelIsFirst.Text = VersionTracking.IsFirstLaunchEver.ToString();
-        labelCurrentVersionIsFirst.Text = VersionTracking.IsFirstLaunchForCurrentVersion.ToString();
-        labelCurrentBuildIsFirst.Text = VersionTracking.IsFirstLaunchForCurrentBuild.ToString();
-        labelCurrentVersion.Text = VersionTracking.CurrentVersion.ToString();
-        labelCurrentBuild.Text = VersionTracking.CurrentBuild.ToString();
-        labelFirstInstalledVer.Text = VersionTracking.FirstInstalledVersion.ToString();
-        labelFirstInstalledBuild.Text = VersionTracking.FirstInstalledBuild.ToString();
-        labelVersionHistory.Text = String.Join(',', VersionTracking.VersionHistory);
-        labelBuildHistory.Text = String.Join(',', VersionTracking.BuildHistory);
+        labelIsFirst.Text = VersionTracking.Default.IsFirstLaunchEver.ToString();
+        labelCurrentVersionIsFirst.Text = VersionTracking.Default.IsFirstLaunchForCurrentVersion.ToString();
+        labelCurrentBuildIsFirst.Text = VersionTracking.Default.IsFirstLaunchForCurrentBuild.ToString();
+        labelCurrentVersion.Text = VersionTracking.Default.CurrentVersion.ToString();
+        labelCurrentBuild.Text = VersionTracking.Default.CurrentBuild.ToString();
+        labelFirstInstalledVer.Text = VersionTracking.Default.FirstInstalledVersion.ToString();
+        labelFirstInstalledBuild.Text = VersionTracking.Default.FirstInstalledBuild.ToString();
+        labelVersionHistory.Text = String.Join(',', VersionTracking.Default.VersionHistory);
+        labelBuildHistory.Text = String.Join(',', VersionTracking.Default.BuildHistory);
 
         // These two properties may be null if this is the first version
-        labelPreviousVersion.Text = VersionTracking.PreviousVersion?.ToString() ?? "none";
-        labelPreviousBuild.Text = VersionTracking.PreviousBuild?.ToString() ?? "none";
+        labelPreviousVersion.Text = VersionTracking.Default.PreviousVersion?.ToString() ?? "none";
+        labelPreviousBuild.Text = VersionTracking.Default.PreviousBuild?.ToString() ?? "none";
     }
     //</version_read>
 

--- a/docs/platform-integration/snippets/shared_1/BatteryTestPage.xaml.cs
+++ b/docs/platform-integration/snippets/shared_1/BatteryTestPage.xaml.cs
@@ -9,20 +9,20 @@ public partial class BatteryTestPage : ContentPage
 
     //<watch_battery>
     private void BatterySwitch_Toggled(object sender, ToggledEventArgs e) =>
-        WatchBattery(Battery.Default);
+        WatchBattery();
 
     private bool _isBatteryWatched;
 
-    private void WatchBattery(IBattery battery)
+    private void WatchBattery()
     {
         
         if (!_isBatteryWatched)
         {
-            battery.BatteryInfoChanged += Battery_BatteryInfoChanged;
+            Battery.Default.BatteryInfoChanged += Battery_BatteryInfoChanged;
         }
         else
         {
-            battery.BatteryInfoChanged -= Battery_BatteryInfoChanged;
+            Battery.Default.BatteryInfoChanged -= Battery_BatteryInfoChanged;
         }
 
         _isBatteryWatched = !_isBatteryWatched;

--- a/docs/platform-integration/snippets/shared_1/DataPage.xaml.cs
+++ b/docs/platform-integration/snippets/shared_1/DataPage.xaml.cs
@@ -44,15 +44,15 @@ public partial class DataPage : ContentPage
 
     private async void ShareButton_Clicked(object sender, EventArgs e)
     {
-        await ShareText("Hello, welcome to the show.", Share.Default);
+        await ShareText("Hello, welcome to the show.");
         await ShareUri("http://www.microsoft.com", Share.Default);
-        await ShareFile(Share.Default);
-        await ShareMultipleFiles(Share.Default);
+        await ShareFile();
+        await ShareMultipleFiles();
     }
     //<share_text_uri>
-    public async Task ShareText(string text, IShare share)
+    public async Task ShareText(string text)
     {
-        await share.RequestAsync(new ShareTextRequest
+        await Share.Default.RequestAsync(new ShareTextRequest
         {
             Text = text,
             Title = "Share Text"
@@ -70,14 +70,14 @@ public partial class DataPage : ContentPage
     //</share_text_uri>
 
     //<share_file>
-    public async Task ShareFile(IShare share)
+    public async Task ShareFile()
     {
         string fn = "Attachment.txt";
         string file = Path.Combine(FileSystem.CacheDirectory, fn);
 
         File.WriteAllText(file, "Hello World");
 
-        await share.RequestAsync(new ShareFileRequest
+        await Share.Default.RequestAsync(new ShareFileRequest
         {
             Title = "Share text file",
             File = new ShareFile(file)
@@ -86,7 +86,7 @@ public partial class DataPage : ContentPage
     //</share_file>
 
     //<share_file_multiple>
-    public async Task ShareMultipleFiles(IShare share)
+    public async Task ShareMultipleFiles()
     {
         string file1 = Path.Combine(FileSystem.CacheDirectory, "Attachment1.txt");
         string file2 = Path.Combine(FileSystem.CacheDirectory, "Attachment2.txt");
@@ -94,7 +94,7 @@ public partial class DataPage : ContentPage
         File.WriteAllText(file1, "Content 1");
         File.WriteAllText(file2, "Content 2");
 
-        await share.RequestAsync(new ShareMultipleFilesRequest
+        await Share.Default.RequestAsync(new ShareMultipleFilesRequest
         {
             Title = "Share multiple files",
             Files = new List<ShareFile> { new ShareFile(file1), new ShareFile(file2) }

--- a/docs/platform-integration/snippets/shared_1/PlatformIntegration.csproj.user
+++ b/docs/platform-integration/snippets/shared_1/PlatformIntegration.csproj.user
@@ -3,10 +3,10 @@
   <PropertyGroup>
     <ActiveDebugFramework>net6.0-android</ActiveDebugFramework>
     <IsFirstTimeProjectOpen>False</IsFirstTimeProjectOpen>
-    <ActiveDebugProfile>Pixel 3a - API 30 (Android 11.0 - API 30)</ActiveDebugProfile>
+    <ActiveDebugProfile>Pixel 4 - API 33 (Android 13.0 - API 33)</ActiveDebugProfile>
     <SelectedDevice>pixel_3a_-_api_30</SelectedDevice>
     <SelectedPlatformGroup>Emulator</SelectedPlatformGroup>
-    <DefaultDevice>pixel_3a_-_api_30</DefaultDevice>
+    <DefaultDevice>pixel_4_-_api_33</DefaultDevice>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net6.0-android|AnyCPU'">
     <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>

--- a/docs/platform-integration/snippets/shared_1/SensorsPage.xaml.cs
+++ b/docs/platform-integration/snippets/shared_1/SensorsPage.xaml.cs
@@ -15,25 +15,25 @@ public partial class SensorsPage : ContentPage
     #region Accelerometer
     private void AccelSwitch_Toggled(object sender, ToggledEventArgs e)
     {
-        ToggleAccelerometer(Accelerometer.Default);
+        ToggleAccelerometer();
     }
 
     //<toggle_accelerometer>
-    public void ToggleAccelerometer(IAccelerometer accelerometer)
+    public void ToggleAccelerometer()
     {
-        if (accelerometer.IsSupported)
+        if (Accelerometer.Default.IsSupported)
         {
-            if (!accelerometer.IsMonitoring)
+            if (!Accelerometer.Default.IsMonitoring)
             {
                 // Turn on accelerometer
-                accelerometer.ReadingChanged += Accelerometer_ReadingChanged;
-                accelerometer.Start(SensorSpeed.UI);
+                Accelerometer.Default.ReadingChanged += Accelerometer_ReadingChanged;
+                Accelerometer.Default.Start(SensorSpeed.UI);
             }
             else
             {
                 // Turn off accelerometer
-                accelerometer.Stop();
-                accelerometer.ReadingChanged -= Accelerometer_ReadingChanged;
+                Accelerometer.Default.Stop();
+                Accelerometer.Default.ReadingChanged -= Accelerometer_ReadingChanged;
             }
         }    
     }
@@ -50,25 +50,25 @@ public partial class SensorsPage : ContentPage
     #region Barometer
     private void BarometerSwitch_Toggled(object sender, ToggledEventArgs e)
     {
-        ToggleBarometer(Barometer.Default);
+        ToggleBarometer();
     }
 
     //<toggle_barometer>
-    public void ToggleBarometer(IBarometer barometer)
+    public void ToggleBarometer()
     {
-        if (barometer.IsSupported)
+        if (Barometer.Default.IsSupported)
         {
-            if (!barometer.IsMonitoring)
+            if (!Barometer.Default.IsMonitoring)
             {
                 // Turn on accelerometer
-                barometer.ReadingChanged += Barometer_ReadingChanged;
-                barometer.Start(SensorSpeed.UI);
+                Barometer.Default.ReadingChanged += Barometer_ReadingChanged;
+                Barometer.Default.Start(SensorSpeed.UI);
             }
             else
             {
                 // Turn off accelerometer
-                barometer.Stop();
-                barometer.ReadingChanged -= Barometer_ReadingChanged;
+                Barometer.Default.Stop();
+                Barometer.Default.ReadingChanged -= Barometer_ReadingChanged;
             }
         }
     }
@@ -85,25 +85,25 @@ public partial class SensorsPage : ContentPage
     #region Compass
     private void CompassSwitch_Toggled(object sender, ToggledEventArgs e)
     {
-        ToggleCompass(Compass.Default);
+        ToggleCompass();
     }
 
     //<toggle_compass>
-    private void ToggleCompass(ICompass compass)
+    private void ToggleCompass()
     {
-        if (compass.IsSupported)
+        if (Compass.Default.IsSupported)
         {
-            if (!compass.IsMonitoring)
+            if (!Compass.Default.IsMonitoring)
             {
                 // Turn on compass
-                compass.ReadingChanged += Compass_ReadingChanged;
-                compass.Start(SensorSpeed.UI);
+                Compass.Default.ReadingChanged += Compass_ReadingChanged;
+                Compass.Default.Start(SensorSpeed.UI);
             }
             else
             {
                 // Turn off compass
-                compass.Stop();
-                compass.ReadingChanged -= Compass_ReadingChanged;
+                Compass.Default.Stop();
+                Compass.Default.ReadingChanged -= Compass_ReadingChanged;
             }
         }
     }
@@ -120,25 +120,25 @@ public partial class SensorsPage : ContentPage
     #region Gyroscope
     private void GyroscopeSwitch_Toggled(object sender, ToggledEventArgs e)
     {
-        ToggleGyroscope(Gyroscope.Default);
+        ToggleGyroscope();
     }
 
     //<toggle_gyroscope>
-    private void ToggleGyroscope(IGyroscope gyroscope)
+    private void ToggleGyroscope()
     {
-        if (gyroscope.IsSupported)
+        if (Gyroscope.Default.IsSupported)
         {
-            if (!gyroscope.IsMonitoring)
+            if (!Gyroscope.Default.IsMonitoring)
             {
                 // Turn on compass
-                gyroscope.ReadingChanged += Gyroscope_ReadingChanged;
-                gyroscope.Start(SensorSpeed.UI);
+                Gyroscope.Default.ReadingChanged += Gyroscope_ReadingChanged;
+                Gyroscope.Default.Start(SensorSpeed.UI);
             }
             else
             {
                 // Turn off compass
-                gyroscope.Stop();
-                gyroscope.ReadingChanged -= Gyroscope_ReadingChanged;
+                Gyroscope.Default.Stop();
+                Gyroscope.Default.ReadingChanged -= Gyroscope_ReadingChanged;
             }
         }
     }
@@ -155,25 +155,25 @@ public partial class SensorsPage : ContentPage
     #region Magnetometer
     private void MagnetometerSwitch_Toggled(object sender, ToggledEventArgs e)
     {
-        ToggleMagnetometer(Magnetometer.Default);
+        ToggleMagnetometer();
     }
 
     //<toggle_magnetometer>
-    private void ToggleMagnetometer(IMagnetometer magnetometer)
+    private void ToggleMagnetometer()
     {
-        if (magnetometer.IsSupported)
+        if (Magnetometer.Default.IsSupported)
         {
-            if (!magnetometer.IsMonitoring)
+            if (!Magnetometer.Default.IsMonitoring)
             {
                 // Turn on compass
-                magnetometer.ReadingChanged += Magnetometer_ReadingChanged;
-                magnetometer.Start(SensorSpeed.UI);
+                Magnetometer.Default.ReadingChanged += Magnetometer_ReadingChanged;
+                Magnetometer.Default.Start(SensorSpeed.UI);
             }
             else
             {
                 // Turn off compass
-                magnetometer.Stop();
-                magnetometer.ReadingChanged -= Magnetometer_ReadingChanged;
+                Magnetometer.Default.Stop();
+                Magnetometer.Default.ReadingChanged -= Magnetometer_ReadingChanged;
             }
         }
     }
@@ -190,25 +190,25 @@ public partial class SensorsPage : ContentPage
     #region Orientation
     private void OrientationSwitch_Toggled(object sender, ToggledEventArgs e)
     {
-        ToggleOrientation(OrientationSensor.Default);
+        ToggleOrientation();
     }
 
     //<toggle_orientation>
-    private void ToggleOrientation(IOrientationSensor orientation)
+    private void ToggleOrientation()
     {
-        if (orientation.IsSupported)
+        if (OrientationSensor.Default.IsSupported)
         {
-            if (!orientation.IsMonitoring)
+            if (!OrientationSensor.Default.IsMonitoring)
             {
                 // Turn on compass
-                orientation.ReadingChanged += Orientation_ReadingChanged;
-                orientation.Start(SensorSpeed.UI);
+                OrientationSensor.Default.ReadingChanged += Orientation_ReadingChanged;
+                OrientationSensor.Default.Start(SensorSpeed.UI);
             }
             else
             {
                 // Turn off compass
-                orientation.Stop();
-                orientation.ReadingChanged -= Orientation_ReadingChanged;
+                OrientationSensor.Default.Stop();
+                OrientationSensor.Default.ReadingChanged -= Orientation_ReadingChanged;
             }
         }
     }
@@ -225,25 +225,25 @@ public partial class SensorsPage : ContentPage
     #region Shake
     private void ShakeSwitch_Toggled(object sender, ToggledEventArgs e)
     {
-        ToggleShake(Accelerometer.Default);
+        ToggleShake();
     }
 
     //<toggle_shake>
-    private void ToggleShake(IAccelerometer accelerometer)
+    private void ToggleShake()
     {
-        if (accelerometer.IsSupported)
+        if (Accelerometer.Default.IsSupported)
         {
-            if (!accelerometer.IsMonitoring)
+            if (!Accelerometer.Default.IsMonitoring)
             {
                 // Turn on compass
-                accelerometer.ShakeDetected += Accelerometer_ShakeDetected;
-                accelerometer.Start(SensorSpeed.Game);
+                Accelerometer.Default.ShakeDetected += Accelerometer_ShakeDetected;
+                Accelerometer.Default.Start(SensorSpeed.Game);
             }
             else
             {
                 // Turn off compass
-                accelerometer.Stop();
-                accelerometer.ShakeDetected -= Accelerometer_ShakeDetected;
+                Accelerometer.Default.Stop();
+                Accelerometer.Default.ShakeDetected -= Accelerometer_ShakeDetected;
             }
         }
     }

--- a/docs/platform-integration/storage/file-picker.md
+++ b/docs/platform-integration/storage/file-picker.md
@@ -1,15 +1,15 @@
 ---
 title: "File picker"
-description: "Learn how to use the .NET MAUI FilePicker class in the Microsoft.Maui.Storage namespace, which lets a user choose one or more files from the device."
-ms.date: 05/23/2022
+description: "Learn how to use the .NET MAUI IFilePicker interface in the Microsoft.Maui.Storage namespace, which lets a user choose one or more files from the device."
+ms.date: 09/02/2022
 no-loc: ["Microsoft.Maui", "Microsoft.Maui.Storage", "FilePicker"]
 ---
 
 # File picker
 
-This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `IFilePicker` interface. With the `IFilePicker` interface, you can prompt the user to pick one or more files from the device. The `IFilePicker` interface is exposed through the `FilePicker.Default` property.
+This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `IFilePicker` interface. With the `IFilePicker` interface, you can prompt the user to pick one or more files from the device.
 
-The `FilePicker` and `IFilePicker` types are available in the `Microsoft.Maui.Storage` namespace.
+The default implementation of the `IFilePicker` interface is available through the `FilePicker.Default` property. Both the `IFilePicker` interface and `FilePicker` class are contained in the `Microsoft.Maui.Storage` namespace.
 
 ## Get started
 

--- a/docs/platform-integration/storage/file-system-helpers.md
+++ b/docs/platform-integration/storage/file-system-helpers.md
@@ -1,15 +1,15 @@
 ---
 title: "File system helpers"
-description: "Learn how to use the .NET MAUI FileSystem class in the Microsoft.Maui.Storage namespace. This class contains helper methods that access the application's cache and data directories, and helps open files in the app package."
-ms.date: 07/14/2022
+description: "Learn how to use the .NET MAUI IFileSystem interface in the Microsoft.Maui.Storage namespace. This interface contains helper methods that access the application's cache and data directories, and helps open files in the app package."
+ms.date: 09/02/2022
 no-loc: ["Microsoft.Maui", "Microsoft.Maui.Storage", "FileSystem"]
 ---
 
 # File system helpers
 
-This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `IFileSystem` interface. This interface provides helper methods that access the app's cache and data directories, and helps access files in the app package. The `IFileSystem` interface is exposed through the `FileSystem.Current` property.
+This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `IFileSystem` interface. This interface provides helper methods that access the app's cache and data directories, and helps access files in the app package.
 
-The `FileSystem` and `IFileSystem` types are available in the `Microsoft.Maui.Storage` namespace.
+The default implementation of the `IFileSystem` interface is available through the `FileSystem.Current` property. Both the `IFileSystem` interface and `FileSystem` class are contained in the `Microsoft.Maui.Storage` namespace.
 
 ## Using file system helpers
 

--- a/docs/platform-integration/storage/preferences.md
+++ b/docs/platform-integration/storage/preferences.md
@@ -1,15 +1,15 @@
 ---
 title: "Preferences"
-description: "Learn how to read and write application preferences, in .NET MAUI. The Preferences class can save and load application preferences in a key/value store."
-ms.date: 05/23/2022
+description: "Learn how to read and write application preferences, in .NET MAUI. The IPreferences interface can save and load application preferences in a key/value store."
+ms.date: 09/02/2022
 no-loc: ["Microsoft.Maui", "Microsoft.Maui.Storage", "Preferences"]
 ---
 
 # Preferences
 
-This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `IPreferences` interface. This interface helps store app preferences in a key/value store. The `IPreferences` interface is exposed through the `Preferences.Default` property.
+This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `IPreferences` interface. This interface helps store app preferences in a key/value store.
 
-The `Preferences` and `IPreferences` types are available in the `Microsoft.Maui.Storage` namespace.
+The default implementation of the `IPreferences` interface is available through the `Preferences.Default` property. Both the `IPreferences` interface and `Preferences` class are contained in the `Microsoft.Maui.Storage` namespace.
 
 ## Storage types
 

--- a/docs/platform-integration/storage/secure-storage.md
+++ b/docs/platform-integration/storage/secure-storage.md
@@ -1,16 +1,16 @@
 ---
 title: "Secure storage"
-description: "Learn how to use the .NET MAUI SecureStorage class, which helps securely store simple key/value pairs. This article discusses how to use the class, platform implementation specifics, and its limitations."
-ms.date: 05/23/2022
+description: "Learn how to use the .NET MAUI ISecureStorage interface, which helps securely store simple key/value pairs. This article discusses how to use the ISecureStorage, platform implementation specifics, and its limitations."
+ms.date: 09/02/2022
 no-loc: ["Microsoft.Maui", "Microsoft.Maui.Storage", "SecureStorage"]
 #acrolinx score 95
 ---
 
 # Secure storage
 
-This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `ISecureStorage` interface. This interface helps securely store simple key/value pairs. The `ISecureStorage` interface is exposed through the `SecureStorage.Default` property.
+This article describes how you can use the .NET Multi-platform App UI (.NET MAUI) `ISecureStorage` interface. This interface helps securely store simple key/value pairs.
 
-The `SecureStorage` and `ISecureStorage` types are available in the `Microsoft.Maui.Storage` namespace.
+The default implementation of the `ISecureStorage` interface is available through the `SecureStorage.Default` property. Both the `ISecureStorage` interface and `SecureStorage` class are contained in the `Microsoft.Maui.Storage` namespace.
 
 ## Get started
 


### PR DESCRIPTION
The essentials docs would describe the `IType` interface and it's implementation on `IType.Default/Current` in different ways. Some examples would also require passing in the interface. These have all been standardized to use the `Default/Current` property, as has the interface/class description for the types.

Fixes #840
Fixes #763