### PR TITLE
Remove mention of GenerateAppxPackageOnBuild

### DIFF
--- a/docs/windows/deployment/overview.md
+++ b/docs/windows/deployment/overview.md
@@ -91,7 +91,6 @@ Add the following `<PropertyGroup>` node to your project file. This property gro
 
 ```xml
 <PropertyGroup Condition="$(TargetFramework.Contains('-windows')) and '$(Configuration)' == 'Release'">
-    <GenerateAppxPackageOnBuild>true</GenerateAppxPackageOnBuild>
     <AppxPackageSigningEnabled>true</AppxPackageSigningEnabled>
     <PackageCertificateThumbprint>A10612AF095FD8F8255F4C6691D88F79EF2B135E</PackageCertificateThumbprint>
 </PropertyGroup>
@@ -100,8 +99,6 @@ Add the following `<PropertyGroup>` node to your project file. This property gro
 <!-- Place in PropertyGroup above once pfx export works: <PackageCertificateKeyFile>myCert.pfx</PackageCertificateKeyFile> <!-- Optional if you want to use the exported PFX file -->
 
 Replace the `<PackageCertificateThumbprint>` property value with the certificate thumbprint you previously generated. Alternatively, you can remove this setting from the project file and provide it on the command line. For example: `/p:PackageCertificateThumbprint=A10612AF095FD8F8255F4C6691D88F79EF2B135E`.
-
-Setting the `<GenerateAppxPackageOnBuild>` property to `true` packages the app and signs it with the certificate that matches the `<PackageCertificateThumbprint>` value. Signing only happens if the `<AppxPackageSigningEnabled>` setting is `true`.
 
 ## Publish
 

--- a/docs/windows/deployment/overview.md
+++ b/docs/windows/deployment/overview.md
@@ -90,15 +90,20 @@ The project file is a good place to put Windows-specific build settings. You may
 Add the following `<PropertyGroup>` node to your project file. This property group is only processed when the target framework is Windows and the configuration is set to `Release`. This config section runs whenever a build or publish in `Release` mode.
 
 ```xml
-<PropertyGroup Condition="$(TargetFramework.Contains('-windows')) and '$(Configuration)' == 'Release'">
+<PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows' and '$(Configuration)' == 'Release'">
     <AppxPackageSigningEnabled>true</AppxPackageSigningEnabled>
     <PackageCertificateThumbprint>A10612AF095FD8F8255F4C6691D88F79EF2B135E</PackageCertificateThumbprint>
+</PropertyGroup>
+<PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows' and '$(RuntimeIdentifierOverride)' != ''">
+    <RuntimeIdentifier>$(RuntimeIdentifierOverride)</RuntimeIdentifier>
 </PropertyGroup>
 ```
 
 <!-- Place in PropertyGroup above once pfx export works: <PackageCertificateKeyFile>myCert.pfx</PackageCertificateKeyFile> <!-- Optional if you want to use the exported PFX file -->
 
 Replace the `<PackageCertificateThumbprint>` property value with the certificate thumbprint you previously generated. Alternatively, you can remove this setting from the project file and provide it on the command line. For example: `/p:PackageCertificateThumbprint=A10612AF095FD8F8255F4C6691D88F79EF2B135E`.
+
+The second `<PropertyGroup>` in the example is required to workaround a bug in the Windows SDK. For more information about the bug, see [WindowsAppSDK Issue #2940](https://github.com/microsoft/WindowsAppSDK/issues/2940).
 
 ## Publish
 
@@ -108,6 +113,7 @@ To publish your app, open the **Developer Command Prompt for VS 2022** terminal 
 |------------------------------|-------------------------------------------------------------------------------------|
 | `-f net6.0-windows{version}` | The target framework, which is a Windows TFM, such as `net6.0-windows10.0.19041.0`. Ensure that this value is identical to the value in the `<TargetFrameworks>` node in your *.csproj* file.           |
 | `-c Release`                 | Sets the build configuration, which is `Release`.                                   |
+| `/p:RuntimeIdentifierOverride=win10-x64`<br>- or -<br>`/p:RuntimeIdentifierOverride=win10-x86` | Avoids the bug detailed in [WindowsAppSDK Issue #2940](https://github.com/microsoft/WindowsAppSDK/issues/2940). Choose the `-x64` or `-x86` version of the parameter based on your target platform.
 
 > [!WARNING]
 > Attempting to publish a .NET MAUI solution will result in the `dotnet publish` command attempting to publish each project in the solution individually, which can cause issues when you've added other project types to your solution. Therefore, the `dotnet publish` command should be scoped to your .NET MAUI app project.
@@ -115,7 +121,7 @@ To publish your app, open the **Developer Command Prompt for VS 2022** terminal 
 For example:
 
 ```console
-dotnet publish -f net6.0-windows10.0.19041.0 -c Release
+dotnet publish -f net6.0-windows10.0.19041.0 -c Release /p:RuntimeIdentifierOverride=win10-x64
 ```
 
 Publishing builds and packages the app, copying the signed package to the _bin\\Release\\net6.0-windows10.0.19041.0\\win10-x64\\AppPackages\\\<appname>\\_ folder. \<appname> is a folder named after both your project and version. In this folder, there's an _msix_ file, and that's the app package.


### PR DESCRIPTION
This was a bug before, but now `dotnet publish` is all that is needed. In fact, using that property passes it down to referenced class  libraries and fails the build.

See dotnet/maui#9879