### PR TITLE
Typo in the TOC page

### DIFF
--- a/docs/index.yml
+++ b/docs/index.yml
@@ -68,7 +68,7 @@ landingContent:
             url: xaml/namespaces/index.md
           - text: Pass arguments
             url: xaml/pass-arguments.md
-          - text: XAML Hot Reload`
+          - text: XAML Hot Reload
             url: xaml/hot-reload.md
   - title: Fundamentals
     linkLists:


### PR DESCRIPTION
There was a wrong backtick in the index page behing Hot Reload