### PR TITLE
Fix Typo: `RoundedRectangleGeometry` -> `RoundRectangleGeometry`

### DIFF
--- a/docs/user-interface/controls/shapes/geometries.md
+++ b/docs/user-interface/controls/shapes/geometries.md
@@ -19,7 +19,7 @@ The `Geometry` class is the parent class for several classes that define differe
 - `RectangleGeometry`, which represents the geometry of a rectangle or square.
 
 > [!NOTE]
-> There's also a `RoundedRectangleGeometry` class that derives from the `GeometryGroup` class. For more information, see [RoundRectangleGeometry](#roundrectanglegeometry).
+> There's also a `RoundRectangleGeometry` class that derives from the `GeometryGroup` class. For more information, see [RoundRectangleGeometry](#roundrectanglegeometry).
 
 The `Geometry` and `Shape` classes seem similar, in that they both describe 2D shapes, but have an important difference. The `Geometry` class derives from the `BindableObject` class, while the `Shape` class derives from the `View` class. Therefore, `Shape` objects can render themselves and participate in the layout system, while `Geometry` objects cannot. While `Shape` objects are more readily usable than `Geometry` objects, `Geometry` objects are more versatile. While a `Shape` object is used to render 2D graphics, a `Geometry` object can be used to define the geometric region for 2D graphics, and define a region for clipping.
 


### PR DESCRIPTION
This PR fixes the typo `RoundedRectangleGeometry` -> `RoundRectangleGeometry`