### PR TITLE
[BULK UPDATE] DocuTune - Rebranding links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # .NET MAUI Docs
 
-This repository contains the conceptual documentation for .NET Multi-platform App UI (MAUI). It's published at the [.NET MAUI documentation site](https://docs.microsoft.com/dotnet/maui).
+This repository contains the conceptual documentation for .NET Multi-platform App UI (MAUI). It's published at the [.NET MAUI documentation site](https://learn.microsoft.com/dotnet/maui).
 
 ## Code of Conduct
 

--- a/docs/fundamentals/controltemplate.md
+++ b/docs/fundamentals/controltemplate.md
@@ -435,7 +435,7 @@ The following XAML shows a control template named `TealTemplate` that contains a
                                  Margin="0,0,20,0"
                                  Text="Help"
                                  TextColor="White"
-                                 Url="https://docs.microsoft.com/dotnet/maui/"
+                                 Url="https://learn.microsoft.com/dotnet/maui/"
                                  HorizontalOptions="End"
                                  VerticalOptions="Center" />
     </Grid>

--- a/docs/fundamentals/shell/flyout.md
+++ b/docs/fundamentals/shell/flyout.md
@@ -316,7 +316,7 @@ The `MenuItem` class has a `Clicked` event, and a `Command` property. Therefore,
     <MenuItem Text="Help"
               IconImageSource="help.png"
               Command="{Binding HelpCommand}"
-              CommandParameter="https://docs.microsoft.com/dotnet/maui/fundamentals/shell" />    
+              CommandParameter="https://learn.microsoft.com/dotnet/maui/fundamentals/shell" />    
 </Shell>
 ```
 
@@ -352,7 +352,7 @@ The appearance of each `MenuItem` can be customized by setting the `Shell.MenuIt
     <MenuItem Text="Help"
               IconImageSource="help.png"
               Command="{Binding HelpCommand}"
-              CommandParameter="https://docs.microsoft.com/xamarin/xamarin-forms/app-fundamentals/shell" />  
+              CommandParameter="https://learn.microsoft.com/xamarin/xamarin-forms/app-fundamentals/shell" />  
 </Shell>
 ```
 

--- a/docs/user-interface/controls/label.md
+++ b/docs/user-interface/controls/label.md
@@ -324,7 +324,7 @@ The following example, shows a `Label` whose content is set from multiple `Span`
                   TextDecorations="Underline">
                 <Span.GestureRecognizers>
                     <TapGestureRecognizer Command="{Binding TapCommand}"
-                                          CommandParameter="https://docs.microsoft.com/dotnet/maui/" />
+                                          CommandParameter="https://learn.microsoft.com/dotnet/maui/" />
                 </Span.GestureRecognizers>
             </Span>
             <Span Text=" to view .NET MAUI documentation." />
@@ -406,7 +406,7 @@ The `HyperlinkSpan` class can be consumed by adding an instance of the class to 
                 <FormattedString>
                     <Span Text="Alternatively, click " />
                     <local:HyperlinkSpan Text="here"
-                                         Url="https://docs.microsoft.com/dotnet/" />
+                                         Url="https://learn.microsoft.com/dotnet/" />
                     <Span Text=" to view .NET documentation." />
                 </FormattedString>
             </Label.FormattedText>

--- a/docs/user-interface/controls/webview.md
+++ b/docs/user-interface/controls/webview.md
@@ -29,7 +29,7 @@ The `Source` property can be set to an `UrlWebViewSource` object or a `HtmlWebVi
 To display a remote web page, set the `Source` property to a `string` that specifies the URI:
 
 ```xaml
-<WebView Source="https://docs.microsoft.com/dotnet/maui" />
+<WebView Source="https://learn.microsoft.com/dotnet/maui" />
 ```
 
 The equivalent C# code is:
@@ -37,7 +37,7 @@ The equivalent C# code is:
 ```csharp
 WebView webvView = new WebView
 {
-    Source = "https://docs.microsoft.com/dotnet/maui"
+    Source = "https://learn.microsoft.com/dotnet/maui"
 };
 ```
 
@@ -214,7 +214,7 @@ Cookies can be set on a `WebView`, which are then sent with the web request to t
 using System.Net;
 
 CookieContainer cookieContainer = new CookieContainer();
-Uri uri = new Uri("https://docs.microsoft.com/dotnet/maui", UriKind.RelativeOrAbsolute);
+Uri uri = new Uri("https://learn.microsoft.com/dotnet/maui", UriKind.RelativeOrAbsolute);
 
 Cookie cookie = new Cookie
 {
@@ -270,7 +270,7 @@ function factorial(num) {
 It's possible to open a URI in the system web browser with the `Launcher` class, that's provided by `Microsoft.Maui.Essentials`. This is achieved by calling it's `OpenAsync` method, passing in a `string` or `Uri` argument that represents the URI to open:
 
 ```csharp
-await Launcher.OpenAsync("https://docs.microsoft.com/dotnet/maui");
+await Launcher.OpenAsync("https://learn.microsoft.com/dotnet/maui");
 ```
 
 For more information, see [Launcher](~/platform-integration/appmodel/launcher.md).


### PR DESCRIPTION
**Global effort for the Microsoft Learn platform rebrand**

The Microsoft team is applying changes to content for the Microsoft Learn platform rebrand. Changes include modifications to current Microsoft Learn and Microsoft Docs terminology as well as associated domain name and content URL path changes.

**DO NOT MERGE THIS PULL REQUEST WHILE IN DRAFT STATUS!** Some of the changes to links and other content are not valid until after go-live.

Please review this draft PR and provide any necessary comments as soon as possible. Because these fixes are tightly scoped, we have approval to automatically merge these changes to the default branch for publication.

This PR was generated via DocuTune. It includes only targeted fixes and minor formatting adjustments.

CorrelationId: d8c4c3ac-d49a-4c95-9ddc-9822ca297907
InitiativeId: docutune-rebranding-2022-09
PointOfContact: Alex Buck
