### PR TITLE
Typo fix - update to visual states article

### DIFF
--- a/docs/user-interface/visual-states.md
+++ b/docs/user-interface/visual-states.md
@@ -38,7 +38,7 @@ You can attach the Visual State Manager markup to an individual view, or you can
 
 ### Define visual states on a view
 
-The `VisualStateManager` class defines a `VisualStateGroups` attached property, that's used to attach visual states to a view. The `VisualStateGroups` property is of type `VisualStateGroupList`, which is a collection of `VisualStateGroup` objects. Therefore, the child of the `VisualStateManager.VisualStateGroup` attached property is a `VisualStateGroup` object. This object defines an `x:Name` attribute that indicates the name of the group. Alternatively, the `VisualStateGroup` class defines a `Name` property that you can use instead. For more information about attached properties, see [Attached properties](~/fundamentals/attached-properties.md).
+The `VisualStateManager` class defines a `VisualStateGroups` attached property, that's used to attach visual states to a view. The `VisualStateGroups` property is of type `VisualStateGroupList`, which is a collection of `VisualStateGroup` objects. Therefore, the child of the `VisualStateManager.VisualStateGroups` attached property is a `VisualStateGroup` object. This object defines an `x:Name` attribute that indicates the name of the group. Alternatively, the `VisualStateGroup` class defines a `Name` property that you can use instead. For more information about attached properties, see [Attached properties](~/fundamentals/attached-properties.md).
 
 The `VisualStateGroup` class defines a property named `States`, which is a collection of `VisualState` objects. `States` is the content property of the `VisualStateGroups` class so you can include the `VisualState` objects as children of the `VisualStateGroup`. Each `VisualState` object should be identified using `x:Name` or `Name`.
 
@@ -191,7 +191,7 @@ In this example, the `Normal` state is active when the `Button` isn't pressed, a
 
 :::image type="content" source="media/visualstates/button-pressed.png" alt-text="Screenshot of the Pressed state for a Button.":::
 
-Then, when the `Button` is released it's rescaled to its default value of 1 ,and the `Entry` displays any previously entered text.
+Then, when the `Button` is released it's rescaled to its default value of 1, and the `Entry` displays any previously entered text.
 
 > [!IMPORTANT]
 > Property paths are unsupported in `Setter` elements that specify the `TargetName` property.


### PR DESCRIPTION
- Change (... child of the VisualStateManager.VisualStateGroup attached property is a VisualStateGroup... ) to (... child of the VisualStateManager.VisualStateGroups... ).
- Fix spacing in punctuations in (... to its default value of 1 ,and... ) to (... value of 1, and... ).