### PR TITLE
Fix broken link on dotnet docs updates text in whats-new page

### DIFF
--- a/docs/whats-new/index.yml
+++ b/docs/whats-new/index.yml
@@ -61,7 +61,7 @@ landingContent:
   - linkListType: whats-new
     links:
     - text: .NET docs updates
-      url: /dotnet/docs/whats-new/
+      url: /dotnet/whats-new/
     - text: ASP.NET Core docs updates
       url: /aspnet/core/whats-new/
     - text: .NET MAUI release notes


### PR DESCRIPTION
Fixes broken link on dotnet docs updates text in the whats-new page that i found