### PR TITLE
Fix for error produced from example - update to image article

### DIFF
--- a/docs/user-interface/controls/image.md
+++ b/docs/user-interface/controls/image.md
@@ -106,7 +106,7 @@ To set a specific cache period, set the `Source` property to an `UriImageSource`
 <Image>
     <Image.Source>
         <UriImageSource Uri="https://aka.ms/campus.jpg"
-                        CacheValidity="10:00:00.0" />
+                        CacheValidity="10:00:00" />
     </Image.Source>
 </Image>
 ```


### PR DESCRIPTION
Change (CacheValidity="10:00:00.0") to (CacheValidity="10:00:00"). 
Reason: extra zero produces error:  "The TimeSpan could not be parsed because at least one of the numeric components is out of range or contains too many digits.". 
Project workload: .NET Maui 7.0.0.