### PR TITLE
Add necessary overrides in MainActivity

### DIFF
--- a/docs/platform-integration/appmodel/app-actions.md
+++ b/docs/platform-integration/appmodel/app-actions.md
@@ -19,7 +19,7 @@ To access the `AppActions` functionality, the following platform specific setup 
 
 # [Android](#tab/android)
 
-In the _Platforms/Android/MainActivity.cs_ file, add the following `IntentFilter` attribute to the `MainActivity` class:
+In the _Platforms/Android/MainActivity.cs_ file, add the `OnResume` and `OnNewIntent` methods to the `MainActivity` class, and the following `IntentFilter` attribute:
 
 :::code language="csharp" source="../snippets/shared_2/Platforms/Android/MainActivity.cs" id="intent_filter_1":::
 

--- a/docs/platform-integration/appmodel/app-actions.md
+++ b/docs/platform-integration/appmodel/app-actions.md
@@ -19,7 +19,7 @@ To access the `AppActions` functionality, the following platform specific setup 
 
 # [Android](#tab/android)
 
-In the _Platforms/Android/MainActivity.cs_ file, add the `OnResume` and `OnNewIntent` methods to the `MainActivity` class, and the following `IntentFilter` attribute:
+In the _Platforms/Android/MainActivity.cs_ file, add the `OnResume` and `OnNewIntent` overrides to the `MainActivity` class, and the following `IntentFilter` attribute:
 
 :::code language="csharp" source="../snippets/shared_2/Platforms/Android/MainActivity.cs" id="intent_filter_1":::
 

--- a/docs/platform-integration/snippets/shared_2/Platforms/Android/MainActivity.cs
+++ b/docs/platform-integration/snippets/shared_2/Platforms/Android/MainActivity.cs
@@ -9,7 +9,23 @@ namespace PlatformIntegration;
 [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 [IntentFilter(new[] { Platform.Intent.ActionAppAction },
               Categories = new[] { global::Android.Content.Intent.CategoryDefault })]
-public class MainActivity : MauiAppCompatActivity
+public class MainActivity : MauiAppCompatActivity {
+
+    protected override void OnResume()
+    {
+        base.OnResume();
+
+        Platform.OnResume(this);
+    }
+
+    protected override void OnNewIntent(Android.Content.Intent intent)
+    {
+        base.OnNewIntent(intent);
+
+        Platform.OnNewIntent(intent);
+    }
+
+}
 //</intent_filter_1>
 {
 


### PR DESCRIPTION
The docs at https://learn.microsoft.com/en-us/dotnet/maui/platform-integration/appmodel/app-actions?tabs=android on App Actions seem to have an incomplete `MainActivity` code sample for Android.
The App Actions do not get triggered unless the app is already running.

Adding the suggested overrides for `OnResume()` and `OnNewIntent()` to `MainActivity` remedies this.