### PR TITLE
Add caution about iOS AppIcon background color

### DIFF
--- a/docs/user-interface/images/app-icons.md
+++ b/docs/user-interface/images/app-icons.md
@@ -101,7 +101,7 @@ If the background image used in composing the app icon uses transparency, it can
 Color values can be specified in hexadecimal, using the format: `#RRGGBB` or `#AARRGGBB`. The value of `RR` represents the red channel, `GG` the green channel, `BB` the blue channel, and `AA` the alpha channel. Instead of a hexadecimal value, you may use a named .NET MAUI color, such as `Red` or `PaleVioletRed`.
 
 > [!CAUTION]
-> If you don't define a background color for your app icon, the background is considered to be tranparent on iOS and Mac Catalyst. This will cause an error during App Store Connect verification and you won't be able to upload your app.
+> If you don't define a background color for your app icon the background is considered to be tranparent on iOS and Mac Catalyst. This will cause an error during App Store Connect verification and you won't be able to upload your app.
 
 ## Recolor the foreground
 

--- a/docs/user-interface/images/app-icons.md
+++ b/docs/user-interface/images/app-icons.md
@@ -208,6 +208,9 @@ The transformed name, the resource without the path or extension, is `healthapp`
 > [!TIP]
 > Instead of creating new image files for the icon, simply replace the two image files provided by the .NET MAUI template: _Resources\\AppIcon\\appicon.svg_ for the background and _Resources\\AppIcon\\appiconfg.svg_ for the foreground.
 
+> [!CAUTION]
+> If you don't define any `Color` value, the background is considered as tranparent. This will cause an error during App Store Connect verifications and you will not be able to upload your application.
+
 # [Windows](#tab/windows)
 
 There aren't any other settings to configure for Windows.

--- a/docs/user-interface/images/app-icons.md
+++ b/docs/user-interface/images/app-icons.md
@@ -101,7 +101,7 @@ If the background image used in composing the app icon uses transparency, it can
 Color values can be specified in hexadecimal, using the format: `#RRGGBB` or `#AARRGGBB`. The value of `RR` represents the red channel, `GG` the green channel, `BB` the blue channel, and `AA` the alpha channel. Instead of a hexadecimal value, you may use a named .NET MAUI color, such as `Red` or `PaleVioletRed`.
 
 > [!CAUTION]
-> If you don't define a background color for your app icon on iOS and Mac Catalyst, the background is considered to be tranparent. This will cause an error during App Store Connect verification and you won't be able to upload your app.
+> If you don't define a background color for your app icon, the background is considered to be tranparent on iOS and Mac Catalyst. This will cause an error during App Store Connect verification and you won't be able to upload your app.
 
 ## Recolor the foreground
 

--- a/docs/user-interface/images/app-icons.md
+++ b/docs/user-interface/images/app-icons.md
@@ -100,6 +100,9 @@ If the background image used in composing the app icon uses transparency, it can
 
 Color values can be specified in hexadecimal, using the format: `#RRGGBB` or `#AARRGGBB`. The value of `RR` represents the red channel, `GG` the green channel, `BB` the blue channel, and `AA` the alpha channel. Instead of a hexadecimal value, you may use a named .NET MAUI color, such as `Red` or `PaleVioletRed`.
 
+> [!CAUTION]
+> If you don't define a background color for your app icon on iOS and Mac Catalyst, the background is considered to be tranparent. This will cause an error during App Store Connect verification and you won't be able to upload your app.
+
 ## Recolor the foreground
 
 If the app icon is composed of a background (`Include`) image and a foreground (`ForegroundFile`) image, the foreground image can be tinted. To tint the foreground image, specify a color with the `TintColor` attribute. The following example tints the foreground image yellow:
@@ -207,9 +210,6 @@ The transformed name, the resource without the path or extension, is `healthapp`
 
 > [!TIP]
 > Instead of creating new image files for the icon, simply replace the two image files provided by the .NET MAUI template: _Resources\\AppIcon\\appicon.svg_ for the background and _Resources\\AppIcon\\appiconfg.svg_ for the foreground.
-
-> [!CAUTION]
-> If you don't define any `Color` value, the background is considered as tranparent. This will cause an error during App Store Connect verifications and you will not be able to upload your application.
 
 # [Windows](#tab/windows)
 


### PR DESCRIPTION
Currently, App Store Connects upload systematically fails when a `<MauiIcon>` is added without any `Color` value. By default, the background is then considered as transparent, which triggers a 100% fail while uploading the archive to App Store Connect (even by using Xcode or command line tools provided by Apple). In order to fix that, related to this [issue](https://github.com/dotnet/maui/issues/11124) in the `maui` repository, it can be very helpful to warn users that a background must be provided. I tested on `svg` and `png` format, this solved the issue as mentioned in the linked issue.

I don't think this is an issue on it's own, it's the behavior of the framework. However, Apple is enforcing a non-transparent background.

For this reason, applying a **CAUTION** is, in my opinion, relevant. We are saving lot's of time to developers and avoiding tremendous frustration. Or perhaps a `WARN` may be good enough to catch user attention while reading iOS tab. But something must be told! :)
