### PR TITLE
Typo fixes - update to accessing device sensors article

### DIFF
--- a/docs/platform-integration/device/sensors.md
+++ b/docs/platform-integration/device/sensors.md
@@ -238,7 +238,7 @@ The `Quaternion` describes the rotation of the device's coordinate system relati
 
 A `Quaternion` value is closely related to rotation around an axis. If an axis of rotation is the normalized vector ($a_x, a_y, a_z$), and the rotation angle is $\theta$, then the (X, Y, Z, W) components of the quaternion are:
 
-$(a_x \times \sin(\theta/2), a_y \times \sin(\theta/2), a_z \times \sin(\theta/2), \cos(\theta/2)$
+$(a_x \times \sin(\theta/2), a_y \times \sin(\theta/2), a_z \times \sin(\theta/2), \cos(\theta/2))$
 
 These are right-hand coordinate systems, so with the thumb of the right hand pointed in the positive direction of the rotation axis, the curve of the fingers indicate the direction of rotation for positive angles.
 

--- a/docs/platform-integration/device/sensors.md
+++ b/docs/platform-integration/device/sensors.md
@@ -10,7 +10,7 @@ no-loc: ["Microsoft.Maui", "Microsoft.Maui.Devices", "Microsoft.Maui.Devices.Sen
 
 # Accessing device sensors
 
-Devices have all sorts of sensors that are available to you. Some sensors can detect movement, others changes in the environment, such as light. Monitoring and reacting to these sensors makes your app dynamic in adapting to how the device is being used. You can also respond to changes in the sensors and alert the user. This article gives you a brief overview of the common sensors supported by .NET Multi-User Application (.NET MAUI).
+Devices have all sorts of sensors that are available to you. Some sensors can detect movement, others changes in the environment, such as light. Monitoring and reacting to these sensors makes your app dynamic in adapting to how the device is being used. You can also respond to changes in the sensors and alert the user. This article gives you a brief overview of the common sensors supported by .NET Multi-platform App UI (.NET MAUI).
 
 Device sensor-related types are available in the `Microsoft.Maui.Devices.Sensors` namespace.
 
@@ -59,7 +59,7 @@ Examples:
 
 - When the device lies flat on a table and is pushed on its left side toward the right, the **X** acceleration value is positive.
 
-- When the device lies flat on a table, the acceleration value is +1.00 G or $(+9.81 m/s^2)$, which correspond to the acceleration of the device $(0 m/s^2)$ minus the force of gravity $(-9.81 m/s^2)$ and normalized as in G.
+- When the device lies flat on a table, the acceleration value is +1.00 G or $(+9.81 m/s^2)$, which corresponds to the acceleration of the device $(0 m/s^2)$ minus the force of gravity $(-9.81 m/s^2)$ and normalized as in G.
 
 <!-- TODO: Why are A and G mentioned here as if they're XYZ properties from the data? -->
 - When the device lies flat on a table and is pushed toward the sky with an acceleration of **A** $m/s^2$, the acceleration value is equal to $A+9.81$ which corresponds to the acceleration of the device $(+A m/s^2)$ minus the force of gravity $(-9.81 m/s^2)$ and normalized in **G**.


### PR DESCRIPTION
* Change (... brief overview of the common sensors supported by .NET Multi-User Application (.NET MAUI).) to (... by .NET Multi-Platform App UI...).
* Change (... which correspond to the acceleration of the device...) to (... which corresponds...).
* Add close parenthesis to orientation quaternion value.
