### PR TITLE
Replace method name `Load` with `Delete`

### DIFF
--- a/docs/tutorials/notes-mvvm/includes/viewmodel-note.md
+++ b/docs/tutorials/notes-mvvm/includes/viewmodel-note.md
@@ -65,7 +65,7 @@ Create the **Note viewmodel**:
 
     The constructors also setup the commands for the viewmodel. Next, add the code for these commands.
 
-01. Add the `Save` and `Load` methods:
+01. Add the `Save` and `Delete` methods:
 
     :::code language="csharp" source="../snippets/viewmodel-shared/csharp/Notes/ViewModels/NoteViewModel.cs" id="command_methods":::
 


### PR DESCRIPTION
Hey, I was reading the MVVM tutorial and on the page for [creating the Note viewmodel](https://learn.microsoft.com/en-us/dotnet/maui/tutorials/notes-mvvm/?view=net-maui-7.0&tutorial-step=5) I noticed that it says to add the `Save` and `Load` methods, but provided the implementation for `Save` and `Delete` methods. I think this may be a mistake? If not please correct me! Thank you