### PR TITLE
Fixed .NET Upgrade Assistant installation instruction

### DIFF
--- a/docs/migration/upgrade-assistant.md
+++ b/docs/migration/upgrade-assistant.md
@@ -40,7 +40,7 @@ For more information about .NET Upgrade Assistant, including the other app types
 Install the .NET Upgrade Assistant globally with the following command:
 
 ```dotnetcli
-dotnet tool update -g upgrade-assistant
+dotnet tool install -g upgrade-assistant
 ```
 
 Similarly, because the .NET Upgrade Assistant is installed as a .NET tool, it can be easily updated by running:


### PR DESCRIPTION
There was a copy/paste error in the installation section for .NET Upgrade Assistant. The installation instructions said that the tool should be installed with the following command:

`dotnet tool update -g upgrade-assistant`

In order to install the tool you have to use `install` instead of `update`. So the correct command is:

`dotnet tool install -g upgrade-assistant`