### PR TITLE
LocationWhenInUse can return restricted on Android

### DIFF
--- a/docs/android/device/setup.md
+++ b/docs/android/device/setup.md
@@ -51,7 +51,7 @@ It's possible to debug an android device over WiFi, without keeping the device p
 
 ### Connecting over WiFi
 
-By default, the [Android Debug Bridge](https://developer.android.com/tools/help/adb.html) (adb) is configured to communicate with an Android device via USB. It's possible to reconfigure it to use TCP/IP instead of USB. To do this, both the device and the computer must be on the same WiFi network.
+By default, the Android Debug Bridge (adb) is configured to communicate with an Android device via USB. It's possible to reconfigure it to use TCP/IP instead of USB. To do this, both the device and the computer must be on the same WiFi network.
 
 First, enable Wireless debugging on your Android device:
 

--- a/docs/platform-integration/appmodel/permissions.md
+++ b/docs/platform-integration/appmodel/permissions.md
@@ -94,7 +94,7 @@ The feature is disabled on the device.
 The user granted permission or is automatically granted.
 
 - <xref:Microsoft.Maui.ApplicationModel.PermissionStatus.Restricted>\
-In a restricted state. Only iOS returns this status.
+In a restricted state.
 
 - <xref:Microsoft.Maui.ApplicationModel.PermissionStatus.Limited>\
 In a limited state. Only iOS returns this status.


### PR DESCRIPTION
Fixes #530 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/android/device/setup.md](https://github.com/dotnet/docs-maui/blob/ec8d08f5d05b86347d6835605040c82fdf804e40/docs/android/device/setup.md) | [docs/android/device/setup](https://review.learn.microsoft.com/en-us/dotnet/maui/android/device/setup?branch=pr-en-us-1395) |
| [docs/platform-integration/appmodel/permissions.md](https://github.com/dotnet/docs-maui/blob/ec8d08f5d05b86347d6835605040c82fdf804e40/docs/platform-integration/appmodel/permissions.md) | [docs/platform-integration/appmodel/permissions](https://review.learn.microsoft.com/en-us/dotnet/maui/platform-integration/appmodel/permissions?branch=pr-en-us-1395) |


<!-- PREVIEW-TABLE-END -->