### PR TITLE
Don't set RuntimeIdentifier build property for MAS apps

### DIFF
--- a/docs/mac-catalyst/deployment/publish-ad-hoc.md
+++ b/docs/mac-catalyst/deployment/publish-ad-hoc.md
@@ -163,23 +163,7 @@ To publish your Mac Catalyst app from the command line on a Mac, open a terminal
 | `/p:CodesignEntitlements`    | The path to the entitlements file that specifies the entitlements the app requires. Set to `Platforms\MacCatalyst\Entitlements.plist`. |
 | `/p:UseHardenedRuntime`      | Set to `true` to enable the hardened runtime, which is required for Mac Catalyst apps that are distributed outside of the Mac App Store. |
 
-> [!WARNING]
-> Attempting to publish a .NET MAUI solution will result in the `dotnet publish` command attempting to publish each project in the solution individually, which can cause issues when you've added other project types to your solution. Therefore, the `dotnet publish` command should be scoped to your .NET MAUI app project.
-
-Additional build parameters can be specified on the command line, if they aren't provided in a `<PropertyGroup>` in your project file. The following table lists some of the common parameters:
-
-| Parameter                    | Value                                                                                           |
-|------------------------------|-------------------------------------------------------------------------------------------------|
-| `/p:ApplicationTitle` | The user-visible name for the app. |
-| `/p:ApplicationId` | The unique identifier for the app, such as `com.companyname.mymauiapp`. |
-| `/p:ApplicationVersion` | The version of the build that identifies an iteration of the app. |
-| `/p:ApplicationDisplayVersion` | The version number of the app. |
-| `/p:RuntimeIdentifier` | The runtime identifier (RID) for the project. Release builds of .NET MAUI Mac Catalyst apps default to using `maccatalyst-x64` and `maccatalyst-arm64` as runtime identifiers, to support universal apps. To support only a single architecture, specify `maccatalyst-x64` or `maccatalyst-arm64`. |
-
-For a full list of build properties, see [Project file properties](https://github.com/xamarin/xamarin-macios/wiki/Project-file-properties).
-
-> [!IMPORTANT]
-> Values for all of these parameters don't have to be provided on the command line. They can also be provided in the project file. When a parameter is provided on the command line and in the project file, the command line parameter takes precedence. For more information about providing build properties in your project file, see [Define build properties in your project file](#define-build-properties-in-your-project-file).
+[!INCLUDE [Additional build parameters](../includes/additional-build-parameters.md)]
 
 For example, use the following command to build and sign a *.pkg* on a Mac, for ad-hoc distribution to users on registered devices:
 

--- a/docs/mac-catalyst/deployment/publish-app-store.md
+++ b/docs/mac-catalyst/deployment/publish-app-store.md
@@ -182,7 +182,22 @@ To publish your Mac Catalyst app from the command line on a Mac, open a terminal
 | `/p:CodesignEntitlements`    | The path to the entitlements file that specifies the entitlements the app requires. Set to `Platforms\MacCatalyst\Entitlements.plist`. |
 | `/p:PackageSigningKey`       | The package signing key to use when signing the package. Set to the name of your installer certificate, as displayed in Keychain Access. |
 
-[!INCLUDE [Additional build parameters](../includes/additional-build-parameters.md)]
+> [!WARNING]
+> Attempting to publish a .NET MAUI solution will result in the `dotnet publish` command attempting to publish each project in the solution individually, which can cause issues when you've added other project types to your solution. Therefore, the `dotnet publish` command should be scoped to your .NET MAUI app project.
+
+Additional build parameters can be specified on the command line, if they aren't provided in a `<PropertyGroup>` in your project file. The following table lists some of the common parameters:
+
+| Parameter                    | Value                                                                                           |
+|------------------------------|-------------------------------------------------------------------------------------------------|
+| `/p:ApplicationTitle` | The user-visible name for the app. |
+| `/p:ApplicationId` | The unique identifier for the app, such as `com.companyname.mymauiapp`. |
+| `/p:ApplicationVersion` | The version of the build that identifies an iteration of the app. |
+| `/p:ApplicationDisplayVersion` | The version number of the app. |
+
+For a full list of build properties, see [Project file properties](https://github.com/xamarin/xamarin-macios/wiki/Project-file-properties).
+
+> [!IMPORTANT]
+> Values for all of these parameters don't have to be provided on the command line. They can also be provided in the project file. When a parameter is provided on the command line and in the project file, the command line parameter takes precedence. For more information about providing build properties in your project file, see [Define build properties in your project file](#define-build-properties-in-your-project-file).
 
 For example, use the following command to build and sign a *.pkg* on a Mac, for distribution through the Mac App Store:
 

--- a/docs/mac-catalyst/deployment/publish-app-store.md
+++ b/docs/mac-catalyst/deployment/publish-app-store.md
@@ -225,7 +225,6 @@ An alternative to specifying build parameters on the command line is to specify 
 | `<EnablePackageSigning>`    | Set to `true` so that the package that's created gets signed.                                   |
 | `<MtouchLink>`              | The link mode for the project, which can be `None`, `SdkOnly`, or `Full`.                       |
 | `<PackageSigningKey>`       | The package signing key to use when signing the package. Set to the name of your installer certificate, as displayed in Keychain Access. |
-| `<RuntimeIdentifier>` | The runtime identifier (RID) for the project. Release builds of .NET MAUI Mac Catalyst apps default to using `maccatalyst-x64` and `maccatalyst-arm64` as runtime identifiers, to support universal apps. To support only a single architecture, specify `maccatalyst-x64` or `maccatalyst-arm64`. |
 
 For a full list of build properties, see [Project file properties](https://github.com/xamarin/xamarin-macios/wiki/Project-file-properties).
 

--- a/docs/mac-catalyst/deployment/publish-outside-app-store.md
+++ b/docs/mac-catalyst/deployment/publish-outside-app-store.md
@@ -210,23 +210,7 @@ To publish your Mac Catalyst app from the command line on a Mac, open a terminal
 | `/p:PackageSigningKey`       | The package signing key to use when signing the package. Set to the name of your installer certificate, as displayed in Keychain Access. |
 | `/p:UseHardenedRuntime`      | Set to `true` to enable the hardened runtime, which is required for Mac Catalyst apps that are distributed outside of the Mac App Store. |
 
-> [!WARNING]
-> Attempting to publish a .NET MAUI solution will result in the `dotnet publish` command attempting to publish each project in the solution individually, which can cause issues when you've added other project types to your solution. Therefore, the `dotnet publish` command should be scoped to your .NET MAUI app project.
-
-Additional build parameters can be specified on the command line, if they aren't provided in a `<PropertyGroup>` in your project file. The following table lists some of the common parameters:
-
-| Parameter                    | Value                                                                                           |
-|------------------------------|-------------------------------------------------------------------------------------------------|
-| `/p:ApplicationTitle` | The user-visible name for the app. |
-| `/p:ApplicationId` | The unique identifier for the app, such as `com.companyname.mymauiapp`. |
-| `/p:ApplicationVersion` | The version of the build that identifies an iteration of the app. |
-| `/p:ApplicationDisplayVersion` | The version number of the app. |
-| `/p:RuntimeIdentifier` | The runtime identifier (RID) for the project. Release builds of .NET MAUI Mac Catalyst apps default to using `maccatalyst-x64` and `maccatalyst-arm64` as runtime identifiers, to support universal apps. To support only a single architecture, specify `maccatalyst-x64` or `maccatalyst-arm64`. |
-
-For a full list of build properties, see [Project file properties](https://github.com/xamarin/xamarin-macios/wiki/Project-file-properties).
-
-> [!IMPORTANT]
-> Values for all of these parameters don't have to be provided on the command line. They can also be provided in the project file. When a parameter is provided on the command line and in the project file, the command line parameter takes precedence. For more information about providing build properties in your project file, see [Define build properties in your project file](#define-build-properties-in-your-project-file).
+[!INCLUDE [Additional build parameters](../includes/additional-build-parameters.md)]
 
 For example, use the following command to build and sign a *.pkg* on a Mac, for distribution outside the Mac App Store:
 


### PR DESCRIPTION
Fixes #1399 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/mac-catalyst/deployment/publish-ad-hoc.md](https://github.com/dotnet/docs-maui/blob/86c2e01d334aa21bc2acc265206ef2c4d45f4b6d/docs/mac-catalyst/deployment/publish-ad-hoc.md) | [docs/mac-catalyst/deployment/publish-ad-hoc](https://review.learn.microsoft.com/en-us/dotnet/maui/mac-catalyst/deployment/publish-ad-hoc?branch=pr-en-us-1401) |
| [docs/mac-catalyst/deployment/publish-app-store.md](https://github.com/dotnet/docs-maui/blob/86c2e01d334aa21bc2acc265206ef2c4d45f4b6d/docs/mac-catalyst/deployment/publish-app-store.md) | [docs/mac-catalyst/deployment/publish-app-store](https://review.learn.microsoft.com/en-us/dotnet/maui/mac-catalyst/deployment/publish-app-store?branch=pr-en-us-1401) |
| [docs/mac-catalyst/deployment/publish-outside-app-store.md](https://github.com/dotnet/docs-maui/blob/86c2e01d334aa21bc2acc265206ef2c4d45f4b6d/docs/mac-catalyst/deployment/publish-outside-app-store.md) | [docs/mac-catalyst/deployment/publish-outside-app-store](https://review.learn.microsoft.com/en-us/dotnet/maui/mac-catalyst/deployment/publish-outside-app-store?branch=pr-en-us-1401) |


<!-- PREVIEW-TABLE-END -->