### PR TITLE
Update upgrade-assistant.md

### DIFF
--- a/docs/migration/upgrade-assistant.md
+++ b/docs/migration/upgrade-assistant.md
@@ -61,7 +61,7 @@ dotnet tool update -g upgrade-assistant
 Open a terminal and navigate to the folder where the target project or solution is located. Run the `upgrade-assistant upgrade` command, passing in the name of the project or solution you're upgrading:
 
 ```dotnetcli
-upgrade-assistant upgrade <sln or csproj> --non-interactive --entry-point *
+upgrade-assistant upgrade <sln or csproj> --non-interactive
 ```
 
 This command runs the tool in non-interactive mode. It will update all eligible projects in the solution and dependent projects.


### PR DESCRIPTION
To update all eligible projects in the solution and dependent projects, --entry-point * is now optional; omitting the --entry-point option will do the same. 

The change can be found [here](https://github.com/dotnet/upgrade-assistant/pull/1469). 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/migration/upgrade-assistant.md](https://github.com/dotnet/docs-maui/blob/5d1fd431ee9a7f465647938be575a6ac1c586c46/docs/migration/upgrade-assistant.md) | [Upgrade a Xamarin.Forms app to .NET MAUI with the .NET Upgrade Assistant](https://review.learn.microsoft.com/en-us/dotnet/maui/migration/upgrade-assistant?branch=pr-en-us-1416) |

<!-- PREVIEW-TABLE-END -->