### PR TITLE
Use consistent MSBuild parameters

### DIFF
--- a/docs/android/deployment/publish-cli.md
+++ b/docs/android/deployment/publish-cli.md
@@ -120,8 +120,8 @@ To publish your app, open a terminal and navigate to the folder for your .NET MA
 |------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
 | `-f` or `--framework`        | The target framework, which is `net6.0-android` or `net7.0-android`.                                                                      |
 | `-c` or `--configuration`    | The build configuration, which is `Release`.                                                                                              |
-| `/p:AndroidSigningKeyPass`   | This is the value used for the `<AndroidSigningKeyPass>` project setting, the password you provided when you created the keystore file.   |
-| `/p:AndroidSigningStorePass` | This is the value used for the `<AndroidSigningStorePass>` project setting, the password you provided when you created the keystore file. |
+| `-p:AndroidSigningKeyPass`   | This is the value used for the `<AndroidSigningKeyPass>` project setting, the password you provided when you created the keystore file.   |
+| `-p:AndroidSigningStorePass` | This is the value used for the `<AndroidSigningStorePass>` project setting, the password you provided when you created the keystore file. |
 
 > [!WARNING]
 > Attempting to publish a .NET MAUI solution will result in the `dotnet publish` command attempting to publish each project in the solution individually, which can cause issues when you've added other project types to your solution. Therefore, the `dotnet publish` command should be scoped to your .NET MAUI app project.
@@ -131,7 +131,7 @@ To publish your app, open a terminal and navigate to the folder for your .NET MA
 For example:
 
 ```console
-dotnet publish -f:net6.0-android -c:Release /p:AndroidSigningKeyPass=mypassword /p:AndroidSigningStorePass=mypassword
+dotnet publish -f net6.0-android -c Release -p:AndroidSigningKeyPass=mypassword -p:AndroidSigningStorePass=mypassword
 ```
 
 Publishing builds the app, and then copies the _aab_ and _apk_ files to the _bin\\Release\\net6.0-android\\publish_ folder. There are two _aab_ files, one unsigned and another signed. The signed variant has **-signed** in the file name.
@@ -143,7 +143,7 @@ Publishing builds the app, and then copies the _aab_ and _apk_ files to the _bin
 For example:
 
 ```console
-dotnet publish -f:net7.0-android -c:Release /p:AndroidSigningKeyPass=mypassword /p:AndroidSigningStorePass=mypassword
+dotnet publish -f net7.0-android -c Release -p:AndroidSigningKeyPass=mypassword -p:AndroidSigningStorePass=mypassword
 ```
 
 Publishing builds the app, and then copies the _aab_ and _apk_ files to the _bin\\Release\\net7.0-android\\publish_ folder. There are two _aab_ files, one unsigned and another signed. The signed variant has **-signed** in the file name.


### PR DESCRIPTION
* Don't mix `/` and `-`
* Don't use `:` in switches where it is not needed

Just generally makes the examples cleaner.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/android/deployment/publish-cli.md](https://github.com/dotnet/docs-maui/blob/f7cf48f4fb4a956ca9b05b99becfbdcce01f0270/docs/android/deployment/publish-cli.md) | [Publish a .NET MAUI app for Android with the CLI](https://review.learn.microsoft.com/en-us/dotnet/maui/android/deployment/publish-cli?branch=pr-en-us-1428) |

<!-- PREVIEW-TABLE-END -->