### PR TITLE
Add some more Android documentation

### DIFF
--- a/docs/android/deployment/publish-cli.md
+++ b/docs/android/deployment/publish-cli.md
@@ -44,7 +44,7 @@ The following table describes how each project setting maps to the manifest file
 | Project setting | Manifest setting |
 | --- | --- |
 | `ApplicationId` | The `package` attribute of the `<manifest>` node: `<manifest ... package="com.companyname.myproject>"`. |
-| `ApplicationVersion` | The `android:versionCode` attribute of the `<manifest>` node: `<manifest ... android:versionCode="1">`. Should be an integer value. |
+| `ApplicationVersion` | The `android:versionCode` attribute of the `<manifest>` node: `<manifest ... android:versionCode="1">`. This should be an integer value. |
 
 Here's an example of an automatically generated manifest file with the package and version information specified:
 
@@ -146,7 +146,7 @@ For example:
 dotnet publish -f net7.0-android -c Release -p:AndroidSigningKeyPass=mypassword -p:AndroidSigningStorePass=mypassword
 ```
 
-Both the `AndroidSigningKeyPass` and `AndroidSigningStorePass` properties support `env:` and `file:` prefixes that can be used to specify an environment variable or file that contains the password. These options provide a way to prevent the password from appearing in build logs.
+Both the `AndroidSigningKeyPass` and `AndroidSigningStorePass` properties support `env:` and `file:` prefixes that can be used to specify an environment variable or file that contains the password. This provide a way to prevent the password from appearing in build logs.
 
 For example, to use an environment variable named `AndroidSigningPassword`:
 

--- a/docs/android/deployment/publish-cli.md
+++ b/docs/android/deployment/publish-cli.md
@@ -160,6 +160,9 @@ To use a file located at C:\Users\user1\AndroidSigningPassword.txt:
 dotnet publish -f net7.0-android -c Release -p:AndroidSigningKeyPass=file:C:\Users\user1\AndroidSigningPassword.txt -p:AndroidSigningStorePass=file:C:\Users\user1\AndroidSigningPassword.txt
 ```
 
+> [!NOTE]
+> The env: prefix is not supported when $(AndroidPackageFormat) is set to aab.
+
 Publishing builds the app, and then copies the _aab_ and _apk_ files to the _bin\\Release\\net7.0-android\\publish_ folder. There are two _aab_ files, one unsigned and another signed. The signed variant has **-signed** in the file name.
 
 ::: moniker-end

--- a/docs/android/deployment/publish-cli.md
+++ b/docs/android/deployment/publish-cli.md
@@ -134,6 +134,23 @@ For example:
 dotnet publish -f net6.0-android -c Release -p:AndroidSigningKeyPass=mypassword -p:AndroidSigningStorePass=mypassword
 ```
 
+Both the `AndroidSigningKeyPass` and `AndroidSigningStorePass` properties support `env:` and `file:` prefixes that can be used to specify an environment variable or file that contains the password. This provide a way to prevent the password from appearing in build logs.
+
+For example, to use an environment variable named `AndroidSigningPassword`:
+
+```console
+dotnet publish -f net6.0-android -c Release -p:AndroidSigningKeyPass=env:AndroidSigningPassword -p:AndroidSigningStorePass=env:AndroidSigningPassword
+```
+
+To use a file located at C:\Users\user1\AndroidSigningPassword.txt:
+
+```console
+dotnet publish -f net6.0-android -c Release -p:AndroidSigningKeyPass=file:C:\Users\user1\AndroidSigningPassword.txt -p:AndroidSigningStorePass=file:C:\Users\user1\AndroidSigningPassword.txt
+```
+
+> [!NOTE]
+> The env: prefix is not supported when $(AndroidPackageFormat) is set to aab.
+
 Publishing builds the app, and then copies the _aab_ and _apk_ files to the _bin\\Release\\net6.0-android\\publish_ folder. There are two _aab_ files, one unsigned and another signed. The signed variant has **-signed** in the file name.
 
 ::: moniker-end

--- a/docs/android/deployment/publish-cli.md
+++ b/docs/android/deployment/publish-cli.md
@@ -44,7 +44,7 @@ The following table describes how each project setting maps to the manifest file
 | Project setting | Manifest setting |
 | --- | --- |
 | `ApplicationId` | The `package` attribute of the `<manifest>` node: `<manifest ... package="com.companyname.myproject>"`. |
-| `ApplicationVersion` | The `android:versionCode` attribute of the `<manifest>` node: `<manifest ... android:versionCode="1">`. |
+| `ApplicationVersion` | The `android:versionCode` attribute of the `<manifest>` node: `<manifest ... android:versionCode="1">`. Should be an integer value. |
 
 Here's an example of an automatically generated manifest file with the package and version information specified:
 
@@ -144,6 +144,20 @@ For example:
 
 ```console
 dotnet publish -f net7.0-android -c Release -p:AndroidSigningKeyPass=mypassword -p:AndroidSigningStorePass=mypassword
+```
+
+Both the `AndroidSigningKeyPass` and `AndroidSigningStorePass` properties support `env:` and `file:` prefixes that can be used to specify an environment variable or file that contains the password. These options provide a way to prevent the password from appearing in build logs.
+
+For example, to use an environment variable named `AndroidSigningPassword`:
+
+```console
+dotnet publish -f net7.0-android -c Release -p:AndroidSigningKeyPass=env:AndroidSigningPassword -p:AndroidSigningStorePass=env:AndroidSigningPassword
+```
+
+To use a file located at C:\Users\user1\AndroidSigningPassword.txt:
+
+```console
+dotnet publish -f net7.0-android -c Release -p:AndroidSigningKeyPass=file:C:\Users\user1\AndroidSigningPassword.txt -p:AndroidSigningStorePass=file:C:\Users\user1\AndroidSigningPassword.txt
 ```
 
 Publishing builds the app, and then copies the _aab_ and _apk_ files to the _bin\\Release\\net7.0-android\\publish_ folder. There are two _aab_ files, one unsigned and another signed. The signed variant has **-signed** in the file name.


### PR DESCRIPTION
1. Add some notes that the `ApplicationVersion` MSbuild property should be an integer value.
2. Add some additional documentation around using the `env` and `file` prefixes for the `AndroidSigningKeyPass` and `AndroidSigningStorePass` properties.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/android/deployment/publish-cli.md](https://github.com/dotnet/docs-maui/blob/d2902b57a2e3dfaf122b6b49fa14b7252285c11d/docs/android/deployment/publish-cli.md) | [Publish a .NET MAUI app for Android with the CLI](https://review.learn.microsoft.com/en-us/dotnet/maui/android/deployment/publish-cli?branch=pr-en-us-1431) |


<!-- PREVIEW-TABLE-END -->