### PR TITLE
Update page-safe-area-layout.md

### DIFF
--- a/docs/ios/platform-specifics/page-safe-area-layout.md
+++ b/docs/ios/platform-specifics/page-safe-area-layout.md
@@ -34,15 +34,4 @@ The `Page.On<iOS>` method specifies that this platform-specific will only run on
 > [!NOTE]
 > The <xref:Microsoft.Maui.Controls.Layout> class defines a <xref:Microsoft.Maui.Controls.Layout.IgnoreSafeArea> property that ensures that content is positioned on an area of the screen that is safe for all iOS devices. This property can be set to `false` on any layout class, such as a <xref:Microsoft.Maui.Controls.Grid> or <Microsoft.Maui.Controls.StackLayout>, to perform the equivalent of this platform-specific.
 
-The safe area can be customized by retrieving its `Thickness` value with the `Page.SafeAreaInsets` method from the `Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific` namespace. It can then be modified as required and assigned to the page's `Padding` property in the `OnAppearing` override:
 
-```csharp
-protected override void OnAppearing()
-{
-    base.OnAppearing();
-
-    var safeInsets = On<iOS>().SafeAreaInsets();
-    safeInsets.Left = 20;
-    Padding = safeInsets;
-}
-```

--- a/docs/ios/platform-specifics/page-safe-area-layout.md
+++ b/docs/ios/platform-specifics/page-safe-area-layout.md
@@ -33,5 +33,3 @@ The `Page.On<iOS>` method specifies that this platform-specific will only run on
 
 > [!NOTE]
 > The <xref:Microsoft.Maui.Controls.Layout> class defines a <xref:Microsoft.Maui.Controls.Layout.IgnoreSafeArea> property that ensures that content is positioned on an area of the screen that is safe for all iOS devices. This property can be set to `false` on any layout class, such as a <xref:Microsoft.Maui.Controls.Grid> or <Microsoft.Maui.Controls.StackLayout>, to perform the equivalent of this platform-specific.
-
-


### PR DESCRIPTION
The section about updating the safe area insets by retrieving them and modifying the Page `Padding` property no longer applies - the safe area layout in MAUI is no longer based on Padding.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/ios/platform-specifics/page-safe-area-layout.md](https://github.com/dotnet/docs-maui/blob/33f61574c88518fb3829203be9a2438d16f6ef0f/docs/ios/platform-specifics/page-safe-area-layout.md) | [Disable the safe area layout guide on iOS](https://review.learn.microsoft.com/en-us/dotnet/maui/ios/platform-specifics/page-safe-area-layout?branch=pr-en-us-1471) |


<!-- PREVIEW-TABLE-END -->