### PR TITLE
The block of code following the if statement does not have curly braces {}, but this is a syntax error, not a shorthand feature.

### DIFF
--- a/docs/tutorials/notes-app/snippets/navigation/csharp/Notes/Views/NotePage.xaml.cs
+++ b/docs/tutorials/notes-app/snippets/navigation/csharp/Notes/Views/NotePage.xaml.cs
@@ -44,8 +44,9 @@ public partial class NotePage : ContentPage
     private async void SaveButton_Clicked(object sender, EventArgs e)
     {
         if (BindingContext is Models.Note note)
+        {
             File.WriteAllText(note.Filename, TextEditor.Text);
-
+        }
         await Shell.Current.GoToAsync("..");
     }
 

--- a/docs/tutorials/notes-mvvm/snippets/model/csharp/Notes/Views/NotePage.xaml.cs
+++ b/docs/tutorials/notes-mvvm/snippets/model/csharp/Notes/Views/NotePage.xaml.cs
@@ -44,7 +44,10 @@ public partial class NotePage : ContentPage
     private async void SaveButton_Clicked(object sender, EventArgs e)
     {
         if (BindingContext is Models.Note note)
+        {
             File.WriteAllText(note.Filename, TextEditor.Text);
+        }
+            
 
         await Shell.Current.GoToAsync("..");
     }


### PR DESCRIPTION
Bing AI told me that this is a syntax error, not a shorthand feature. In C#, if you use an if statement, you must use curly braces {} to indicate the code block that follows, even if there is only one line of code, you cannot omit the curly braces {}. Otherwise, beginners who follow the example documentation to modify the code can easily cause logic errors or variable scope problems.