### PR TITLE
Fixed readme for MAUI Images that states resource names must be end with a letter.

### DIFF
--- a/docs/user-interface/images/images.md
+++ b/docs/user-interface/images/images.md
@@ -26,7 +26,7 @@ An image can be added to your app project by dragging it into the *Resources\Ima
 > [!NOTE]
 > Images can also be added to other folders of your app project. However, in this scenario their build action must be manually set to **MauiImage** in the **Properties** window.
 
-To comply with Android resource naming rules, image filenames must be lowercase, start and end with a letter character, and contain only alphanumeric characters or underscores. For more information, see [App resources overview](https://developer.android.com/guide/topics/resources/providing-resources) on developer.android.com.
+To comply with Android resource naming rules, image filenames must be lowercase, start with a letter and end with an alphanumeric character, and contain only alphanumeric characters or underscores. For more information, see [App resources overview](https://developer.android.com/guide/topics/resources/providing-resources) on developer.android.com.
 
 The base size of the image can be specified by setting the `BaseSize` attribute to values that are divisible by 8:
 


### PR DESCRIPTION
Android resource names can end with a number therefore MAUI images can also ends with a number. I have used number at the end of my MAUI images and so far no issues found.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/user-interface/images/images.md](https://github.com/dotnet/docs-maui/blob/0e19aff5afae2230ec4ea7f493aa9aaef4c0d2cd/docs/user-interface/images/images.md) | [Add images to a .NET MAUI app project](https://review.learn.microsoft.com/en-us/dotnet/maui/user-interface/images/images?branch=pr-en-us-1538) |

<!-- PREVIEW-TABLE-END -->