### PR TITLE
Add a table index to Upgrade overview

### DIFF
--- a/docs/migration/index.md
+++ b/docs/migration/index.md
@@ -6,9 +6,9 @@ ms.date: 02/15/2023
 
 # Upgrade from Xamarin to .NET
 
-Xamarin projects can run on .NET, starting with .NET 6, after completing an upgrade process. This series of articles describe the process for upgrading your Xamarin projects to .NET.
+Xamarin projects can run on .NET, starting with .NET 6, after completing an upgrade process. The following table lists the Xamarin project types that can be upgraded to .NET:
 
-| Project Type            | Upgrade | Guide                                             |
+| Project type            | Upgrade | Guide                                             |
 |-------------------------|---------|---------------------------------------------------|
 | Xamarin.Android         | ✅       | [Upgrade Xamarin native projects](native-projects.md) |
 | Xamarin.iOS             | ✅       | [Upgrade Xamarin native projects](native-projects.md) |

--- a/docs/migration/index.md
+++ b/docs/migration/index.md
@@ -6,11 +6,28 @@ ms.date: 02/15/2023
 
 # Upgrade from Xamarin to .NET
 
-Xamarin projects can run on .NET, starting with .NET 6, after completing an upgrade process. This series of articles describe the process for migrating your Xamarin projects to .NET.
+Xamarin projects can run on .NET, starting with .NET 6, after completing an upgrade process. This series of articles describe the process for upgrading your Xamarin projects to .NET.
+
+| Project Type            | Upgrade | Guide                                             |
+|-------------------------|---------|---------------------------------------------------|
+| Xamarin.Android         | ✅       | [Upgrade Xamarin native projects](native-projects.md) |
+| Xamarin.iOS             | ✅       | [Upgrade Xamarin native projects](native-projects.md) |
+| Xamarin.Mac             | ✅       | [Upgrade Xamarin native projects](native-projects.md) |
+| Xamarin.tvOS            | ✅       | [Upgrade Xamarin native projects](native-projects.md) |
+| Xamarin.Forms           | ✅       | [Upgrade Xamarin.Forms projects](forms-projects.md) |
+| iOS App Extensions      | ✅       | [Upgrade Xamarin native projects](native-projects.md) |
+| Android Wear            | ✅       | [Upgrade Xamarin native projects](native-projects.md) |
+| Android Binding Library | ✅       | Upgrade to SDK Style projects                     |
+| iOS Binding Library     | ✅       | Upgrade to SDK Style projects                     |
+| SpriteKit               | ✅       | [Upgrade Xamarin native projects](native-projects.md) |
+| SceneKit                | ✅       | [Upgrade Xamarin native projects](native-projects.md) |
+| Metal                   | ✅       | [Upgrade Xamarin native projects](native-projects.md) |
+| OpenGL                  | ❌ (iOS) | Removed from iOS since OpenTK isn't available |
+| Xamarin.watchOS         | ❌       | Recommendation: bundle Swift extensions with .NET for iOS apps |
 
 <!-- markdownlint-disable MD032 -->
 > [!IMPORTANT]
-> To migrate an app from Xamarin to .NET:
+> To upgrade an app from Xamarin to .NET:
 > - All projects **do** need to become SDK-style.
 > - Projects **don't** need to be rewritten.
 > - Multi-project solutions **don't** need to become a multi-targeted single project.
@@ -18,7 +35,7 @@ Xamarin projects can run on .NET, starting with .NET 6, after completing an upgr
 
 To upgrade your Xamarin native projects to .NET, you'll first have to update the projects to be SDK-style projects and then update your dependencies to .NET 6+. For more information, see [Upgrade Xamarin.Android, Xamarin.iOS, and Xamarin.Mac apps to .NET](native-projects.md).
 
-The .NET Upgrade Assistant is a command-line tool that can help you upgrade Xamarin.Forms projects to .NET Multi-platform App UI (.NET MAUI). After running the tool, in most cases the app will require additional effort to complete the migration. For more information, see [Upgrade a Xamarin.Forms app to .NET MAUI with the .NET Upgrade Assistant](upgrade-assistant.md).
+The .NET Upgrade Assistant is a command-line tool that can help you upgrade Xamarin.Forms projects to .NET Multi-platform App UI (.NET MAUI). After running the tool, in most cases the app will require additional effort to complete the upgrade. For more information, see [Upgrade a Xamarin.Forms app to .NET MAUI with the .NET Upgrade Assistant](upgrade-assistant.md).
 
 Alternatively, you can manually upgrade a Xamarin.Forms project to .NET MAUI with a two-step process:
 


### PR DESCRIPTION
From feedback there tends to be a lot of questions about what can and cannot upgrade from Xamarin to .NET. This adds a table that a reader can quickly scan and navigate to the relevant documentation.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/migration/index.md](https://github.com/dotnet/docs-maui/blob/aa8f0cb2560e44d2bcc1b0bec6ec6ce307109520/docs/migration/index.md) | [Upgrade from Xamarin to .NET](https://review.learn.microsoft.com/en-us/dotnet/maui/migration/index?branch=pr-en-us-1586) |


<!-- PREVIEW-TABLE-END -->