### PR TITLE
Correct maui workload for VSCode on Linux

### DIFF
--- a/docs/get-started/first-app.md
+++ b/docs/get-started/first-app.md
@@ -365,7 +365,7 @@ To create a new .NET MAUI app:
 1. Name the project.
 1. Ensure the project loads successfully in the Solution Explorer, and then open a C# or XAML file.
 
-You can also open an existing .NET MAUI project in VS Code via **File > Open...**.
+You can also open an existing .NET MAUI project in Visual Studio Code via **File > Open...**.
 
 You should now see your app in [C# Dev Kit's](/visualstudio/subscriptions/vs-c-sharp-dev-kit) Solution Explorer in Visual Studio Code. Since the .NET MAUI extension depends on C# Dev Kit, you can use [all of its features](https://code.visualstudio.com/docs/csharp/get-started) alongside the .NET MAUI extension.
 
@@ -373,7 +373,7 @@ You should now see your app in [C# Dev Kit's](/visualstudio/subscriptions/vs-c-s
 
 Click on the curly brackets symbol `{ }` in the bottom right corner of Visual Studio Code. Here, you can change your Startup Project, change your Debug Target to anything valid on your development machine, and pin either setting to the Visual Studio Code status bar:
 
-:::image type="content" source="media/first-app/vscode/debug-target-picker.png" alt-text="A screenshot of the bottom right of VS Code, showing the debug target picker open":::
+:::image type="content" source="media/first-app/vscode/debug-target-picker.png" alt-text="A screenshot of the bottom right of Visual Studio Code, showing the debug target picker open":::
 
 You can also set the Startup Project and Debug Target in the command palette, using `CTRL/CMD+SHIFT+P` and searching for ".NET MAUI".
 

--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -98,7 +98,7 @@ To install Visual Studio 2022 for Mac behind a firewall, certain endpoints must 
 1. Install [Visual Studio Code](https://code.visualstudio.com/).
 1. In the Extensions tab, search for ".NET MAUI" and install the [.NET MAUI extension](https://aka.ms/mauidevkit-marketplace). The .NET MAUI extension automatically installs the [C# Dev Kit](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csdevkit) and [C#](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) extensions, which are required for the .NET MAUI extension to run.  
 
-    :::image type="content" source="media/installation/vscode/maui-extension-preview.png" alt-text="Screenshot of the VS Code extension pane showing the .NET MAUI extension":::
+    :::image type="content" source="media/installation/vscode/maui-extension-preview.png" alt-text="Screenshot of the Visual Studio Code extension pane showing the .NET MAUI extension":::
 
 > [!NOTE]
 > The .NET MAUI extension requires the C# Dev Kit and prerelease C# extensions. You must sign into C# Dev Kit to use the .NET MAUI extension's functionality. See [this blog post](https://devblogs.microsoft.com/visualstudio/announcing-csharp-dev-kit-for-visual-studio-code/) for more information about C# Dev Kit and its family of extensions.
@@ -121,7 +121,7 @@ If you don't want to install Visual Studio, you can still get set up for .NET MA
 
 1. Install [.NET 7 or greater](/dotnet/core/install/windows?tabs=net70).
 1. After .NET has finished installing, run `dotnet workload install maui` in a terminal.
-1. If you'd like to debug Android in VS Code, you also have to:
+1. If you'd like to debug Android in Visual Studio Code, you also have to:
     1. Install [Microsoft OpenJDK 11](/java/openjdk/download#openjdk-11).
     1. Install the Android SDK. You can acquire the correct versions of the Android SDK and build tools by creating a new .NET MAUI project (`dotnet new maui`) and running the following command in your terminal:  
     `dotnet build -t:InstallAndroidDependencies -f:net7.0-android -p:AndroidSdkDirectory="<ANDROID SDK DIRECTORY>" -p:AcceptAndroidSDKLicenses=True`  
@@ -136,7 +136,7 @@ If you don't want to install Visual Studio, you can still get set up for .NET MA
 1. Install the [latest stable Xcode](https://apps.apple.com/us/app/xcode/id497799835?mt=12).
 1. After Xcode has finished installing, run `xcode-select --install` in a terminal to acquire the Xcode command line tools.
 1. Run `dotnet workload install maui` in a terminal.
-1. If you'd like to debug to Android in VS Code, you also have to:
+1. If you'd like to debug to Android in Visual Studio Code, you also have to:
     1. Install [Microsoft OpenJDK 11](/java/openjdk/download#openjdk-11).
     1. Install the Android SDK. You can acquire the correct versions of the Android SDK and build tools by creating a new .NET MAUI project (`dotnet new maui`) and running the following command in your terminal:  
     `dotnet build -t:InstallAndroidDependencies -f:net7.0-android -p:AndroidSdkDirectory="<ANDROID SDK DIRECTORY>" -p:AcceptAndroidSDKLicenses=True`  
@@ -145,8 +145,8 @@ If you don't want to install Visual Studio, you can still get set up for .NET MA
 ### Linux
 
 1. Install [.NET 7 or greater](/dotnet/core/install/linux).
-1. After .NET has installed, run `dotnet workload install maui` in a terminal.
-1. If you'd like to debug to Android in VS Code, you also have to:
+1. After .NET has installed, run `dotnet workload install maui-android` in a terminal.
+1. If you'd like to debug to Android in Visual Studio Code, you also have to:
     1. Install [Microsoft OpenJDK 11](/java/openjdk/download#openjdk-11).
     1. Install the Android SDK from your preferred package manager, or from the [Android website](https://developer.android.com/about/versions/13/setup-sdk).
 
@@ -208,7 +208,7 @@ This is a known issue if you install to `%APPDATA%` on Windows and will be fixed
 ### Debugging issues
 
 * Debugging can fail to start for multiple reasons. If there isn't a clear error in the Output window, first double check that you are using the ".NET MAUI" run configuration in Visual Studio Code.
-* You can try a command line build from the terminal to see if the error is with your code or the .NET MAUI extension. For example, you could run `dotnet build -f:net7.0-android` to see if your Android build succeeds outside of VS Code. If this build succeeds, please [Report an Issue](https://github.com/microsoft/vscode-dotnettools/issues)
+* You can try a command line build from the terminal to see if the error is with your code or the .NET MAUI extension. For example, you could run `dotnet build -f:net7.0-android` to see if your Android build succeeds outside of Visual Studio Code. If this build succeeds, please [Report an Issue](https://github.com/microsoft/vscode-dotnettools/issues)
 
 ## Known Limitations
 
@@ -224,7 +224,7 @@ Please [give us your feedback](#provide-feedback) on other features you'd like t
 
 Please read the [C# Dev Kit FAQs](https://code.visualstudio.com/docs/csharp/cs-dev-kit-faq) and check existing [Known Issues](https://github.com/microsoft/vscode-dotnettools/issues) before filing a new issue or suggestion. You can file suggestions and issues from inside Visual Studio Code through through the **Help > Report Issue** dialog. Ensure you select “An extension” then the .NET MAUI extension in the dropdown.
 
-:::image type="content" source="media/installation/vscode/report-issue.png" alt-text="Picture of the report issue dialog in VS Code":::
+:::image type="content" source="media/installation/vscode/report-issue.png" alt-text="Picture of the report issue dialog in Visual Studio Code":::
 
 ---
 


### PR DESCRIPTION
Fixes #1600 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/get-started/first-app.md](https://github.com/dotnet/docs-maui/blob/eedba6b2b22a1fea89d05d7317b97698b5e24e65/docs/get-started/first-app.md) | [Build your first app](https://review.learn.microsoft.com/en-us/dotnet/maui/get-started/first-app?branch=pr-en-us-1621) |
| [docs/get-started/installation.md](https://github.com/dotnet/docs-maui/blob/eedba6b2b22a1fea89d05d7317b97698b5e24e65/docs/get-started/installation.md) | [[Visual Studio](#tab/vswin)](https://review.learn.microsoft.com/en-us/dotnet/maui/get-started/installation?branch=pr-en-us-1621) |

<!-- PREVIEW-TABLE-END -->