### PR TITLE
Rename AddMauiBlazorWebViewDeveloperTools to AddBlazorWebViewDeveloperTools

### DIFF
--- a/docs/user-interface/controls/blazorwebview.md
+++ b/docs/user-interface/controls/blazorwebview.md
@@ -112,7 +112,7 @@ The process to add a <xref:Microsoft.AspNetCore.Components.WebView.Maui.BlazorWe
 
             builder.Services.AddMauiBlazorWebView();
     #if DEBUG
-            builder.Services.AddMauiBlazorWebViewDeveloperTools();
+            builder.Services.AddBlazorWebViewDeveloperTools();
     #endif
             // Register any app services on the IServiceCollection object
             // e.g. builder.Services.AddSingleton<WeatherForecastService>();


### PR DESCRIPTION
See https://github.com/dotnet/maui/blob/c92d44c68fe81c57ef8caec2506e6788309b8ff4/src/BlazorWebView/src/SharedSource/BlazorWebViewServiceCollectionExtensions.cs#L62

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/user-interface/controls/blazorwebview.md](https://github.com/dotnet/docs-maui/blob/bce45636545ed40bfaeb2278644813706be27ddc/docs/user-interface/controls/blazorwebview.md) | [Host a Blazor web app in a .NET MAUI app using BlazorWebView](https://review.learn.microsoft.com/en-us/dotnet/maui/user-interface/controls/blazorwebview?branch=pr-en-us-1629) |

<!-- PREVIEW-TABLE-END -->