### PR TITLE
Update iOS Info.plist Example for GeoLocation Docs

### DIFF
--- a/docs/platform-integration/device/geolocation.md
+++ b/docs/platform-integration/device/geolocation.md
@@ -88,12 +88,10 @@ If you're going to request full accuracy with the <xref:Microsoft.Maui.Devices.S
 
 ```xml
 <key>NSLocationTemporaryUsageDescriptionDictionary</key>
-<array>
-  <dict>
-    <key>TemporaryFullAccuracyUsageDescription</key>
-    <string>Fill in a reason why your app needs full accuracy</string>
-  </dict>
-</array>
+<dict>
+  <key>TemporaryFullAccuracyUsageDescription</key>
+  <string>Fill in a reason why your app needs full accuracy</string>
+</dict>
 ```
 
 The `<string>` element is the reason the app is requesting access to location information with full accuracy. This text is shown to the user.


### PR DESCRIPTION
Update iOS Info.plist example for TemporaryFullAccuracyUsageDescription

The original example causes issues when using RequestFullAccuracy = true with an error that the dictionary could not be found if Precise Location is disabled for the app

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/platform-integration/device/geolocation.md](https://github.com/dotnet/docs-maui/blob/6fd436599286c83a987149deb7f4139b97023ecd/docs/platform-integration/device/geolocation.md) | [Geolocation](https://review.learn.microsoft.com/en-us/dotnet/maui/platform-integration/device/geolocation?branch=pr-en-us-1685) |

<!-- PREVIEW-TABLE-END -->