### PR TITLE
GetPosition of drag/drop gesture

### DIFF
--- a/docs/fundamentals/gestures/drag-and-drop.md
+++ b/docs/fundamentals/gestures/drag-and-drop.md
@@ -1,7 +1,7 @@
 ---
 title: "Recognize a drag and drop gesture"
 description: "This article explains how to recognize drag and drop gestures with .NET MAUI."
-ms.date: 02/22/2022
+ms.date: 10/09/2023
 ---
 
 # Recognize a drag and drop gesture
@@ -9,9 +9,6 @@ ms.date: 02/22/2022
 A .NET Multi-platform App UI (.NET MAUI) drag and drop gesture recognizer enables items, and their associated data packages, to be dragged from one onscreen location to another location using a continuous gesture. Drag and drop can take place in a single application, or it can start in one application and end in another.
 
 The *drag source*, which is the element on which the drag gesture is initiated, can provide data to be transferred by populating a data package object. When the drag source is released, drop occurs. The *drop target*, which is the element under the drag source, then processes the data package.
-
-> [!IMPORTANT]
-> On iOS a minimum platform of iOS 11 is required.
 
 The process for enabling drag and drop in an app is as follows:
 
@@ -291,3 +288,24 @@ void OnDrop(object sender, DropEventArgs e)
 ```
 
 In this example, the `Square` object is retrieved from the property bag of the data package, by specifying the "Square" dictionary key. An action based on the retrieved value can then be taken.
+
+::: moniker range=">=net-maui-8.0"
+
+## Get the gesture position
+
+The position at which a drag or drop gesture occurred can be obtained by calling the `GetPosition` method on a <xref:Microsoft.Maui.Controls.DragEventArgs>, <xref:Microsoft.Maui.Controls.DragStartingEventArgs>, or <xref:Microsoft.Maui.DropEventArgs> object. The `GetPosition` method accepts an `Element?` argument, and returns a position as a `Point?` object:
+
+```csharp
+void OnDragStarting(object sender, DragStartingEventArgs e)
+{
+    // Position relative to screen
+    Point? screenPosition = e.GetPosition(null);
+
+    // Position relative to specified element
+    Point? relativeToImagePosition = e.GetPosition(image);
+}
+```
+
+The `Element?` argument defines the element the position should be obtained relative to. Supplying a `null` value as this argument means that the `GetPosition` method returns a `Point?` object that defines the position of the drag or drop gesture relative to the screen.
+
+::: moniker-end

--- a/docs/fundamentals/gestures/drag-and-drop.md
+++ b/docs/fundamentals/gestures/drag-and-drop.md
@@ -293,7 +293,7 @@ In this example, the `Square` object is retrieved from the property bag of the d
 
 ## Get the gesture position
 
-The position at which a drag or drop gesture occurred can be obtained by calling the `GetPosition` method on a <xref:Microsoft.Maui.Controls.DragEventArgs>, <xref:Microsoft.Maui.Controls.DragStartingEventArgs>, or <xref:Microsoft.Maui.DropEventArgs> object. The `GetPosition` method accepts an `Element?` argument, and returns a position as a `Point?` object:
+The position at which a drag or drop gesture occurred can be obtained by calling the `GetPosition` method on a <xref:Microsoft.Maui.Controls.DragEventArgs>, <xref:Microsoft.Maui.Controls.DragStartingEventArgs>, or <xref:Microsoft.Maui.Controls.DropEventArgs> object. The `GetPosition` method accepts an `Element?` argument, and returns a position as a `Point?` object:
 
 ```csharp
 void OnDragStarting(object sender, DragStartingEventArgs e)

--- a/docs/whats-new/dotnet-8.md
+++ b/docs/whats-new/dotnet-8.md
@@ -21,7 +21,7 @@ For information about what's new in .NET 8, see [What's new in .NET 8](/dotnet/c
 - <xref:Microsoft.Maui.Devices.Flashlight> gains a `IsSupportedAsync` method that determines whether a flashlight is available on the device. For more information, see [Flashlight](~/platform-integration/device/flashlight.md).
 - <xref:Microsoft.Maui.Devices.Sensors.SensorSpeed> intervals have been unified across all platforms. For more information, see [Accessing device sensors](~/platform-integration/device/sensors.md).
 - <xref:Microsoft.Maui.Controls.SolidColorBrush.Color> is the [`ContentProperty`](xref:Microsoft.Maui.Controls.ContentPropertyAttribute) of the <xref:Microsoft.Maui.Controls.SolidColorBrush> class, and therefore does not need to be explicitly set from XAML.
-- The position at which a drag or drop gesture occurred can be obtained by calling the `GetPosition` method on a <xref:Microsoft.Maui.Controls.DragEventArgs>, <xref:Microsoft.Maui.Controls.DragStartingEventArgs>, or <xref:Microsoft.Maui.DropEventArgs> object. For more information, see [Recognize a drag and drop gesture](~/fundamentals/gestures/drag-and-drop.md).
+- The position at which a drag or drop gesture occurred can be obtained by calling the `GetPosition` method on a <xref:Microsoft.Maui.Controls.DragEventArgs>, <xref:Microsoft.Maui.Controls.DragStartingEventArgs>, or <xref:Microsoft.Maui.Controls.DropEventArgs> object. For more information, see [Recognize a drag and drop gesture](~/fundamentals/gestures/drag-and-drop.md).
 
 The following types or members have been deprecated:
 

--- a/docs/whats-new/dotnet-8.md
+++ b/docs/whats-new/dotnet-8.md
@@ -21,6 +21,7 @@ For information about what's new in .NET 8, see [What's new in .NET 8](/dotnet/c
 - <xref:Microsoft.Maui.Devices.Flashlight> gains a `IsSupportedAsync` method that determines whether a flashlight is available on the device. For more information, see [Flashlight](~/platform-integration/device/flashlight.md).
 - <xref:Microsoft.Maui.Devices.Sensors.SensorSpeed> intervals have been unified across all platforms. For more information, see [Accessing device sensors](~/platform-integration/device/sensors.md).
 - <xref:Microsoft.Maui.Controls.SolidColorBrush.Color> is the [`ContentProperty`](xref:Microsoft.Maui.Controls.ContentPropertyAttribute) of the <xref:Microsoft.Maui.Controls.SolidColorBrush> class, and therefore does not need to be explicitly set from XAML.
+- The position at which a drag or drop gesture occurred can be obtained by calling the `GetPosition` method on a <xref:Microsoft.Maui.Controls.DragEventArgs>, <xref:Microsoft.Maui.Controls.DragStartingEventArgs>, or <xref:Microsoft.Maui.DropEventArgs> object. For more information, see [Recognize a drag and drop gesture](~/fundamentals/gestures/drag-and-drop.md).
 
 The following types or members have been deprecated:
 


### PR DESCRIPTION
Fixes #1731 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/gestures/drag-and-drop.md](https://github.com/dotnet/docs-maui/blob/5064572b0c27df9c2aaeceaf8ceeb26e4a62bf9c/docs/fundamentals/gestures/drag-and-drop.md) | [Recognize a drag and drop gesture](https://review.learn.microsoft.com/en-us/dotnet/maui/fundamentals/gestures/drag-and-drop?branch=pr-en-us-1778) |
| [docs/whats-new/dotnet-8.md](https://github.com/dotnet/docs-maui/blob/5064572b0c27df9c2aaeceaf8ceeb26e4a62bf9c/docs/whats-new/dotnet-8.md) | [What's new in .NET MAUI for .NET 8](https://review.learn.microsoft.com/en-us/dotnet/maui/whats-new/dotnet-8?branch=pr-en-us-1778) |


<!-- PREVIEW-TABLE-END -->