### PR TITLE
Shell tab color appearance

### DIFF
--- a/docs/fundamentals/shell/tabs.md
+++ b/docs/fundamentals/shell/tabs.md
@@ -174,6 +174,24 @@ The <xref:Microsoft.Maui.Controls.Shell> class defines the following attached pr
 
 All of these properties are backed by <xref:Microsoft.Maui.Controls.BindableProperty> objects, which means that the properties can be targets of data bindings, and styled.
 
+::: moniker range=">=net-maui-8.0"
+
+The three properties that most influence the color of a tab are `TabBarForegroundColor`, `TabBarTitleColor`, and `TabBarUnselectedColor`:
+
+- If only the `TabBarTitleColor` property is set then its value will be used to color the title and icon of the selected tab. If `TabBarTitleColor` isn't set then the title color will match the value of the `TabBarForegroundColor` property.
+- If the `TabBarForegroundColor` property is set and the `TabBarUnselectedColor` property isn't set then the value of the `TabBarForegroundColor` property will be used to color the title and icon of the selected tab.
+- If only the `TabBarUnselectedColor` property is set then its value will be used to color the title and icon of the unselected tab.
+
+For example:
+
+- When the `TabBarTitleColor` property is set to `Green` the title and icon for the selected tab is green, and unselected tabs match system colors.
+- When the `TabBarForegroundColor` property is set to `Blue` the title and icon for the selected tab is blue, and unselected tabs match system colors.
+- When the `TabBarTitleColor` property is set to `Green` and the `TabBarForegroundColor` property is set to `Blue` the title is green and the icon is blue for the selected tab, and unselected tabs match system colors.
+- When the `TabBarTitleColor` property is set to `Green` and the `Shell.ForegroundColor` property is set to `Blue` the title is green and the icon is blue for the selected tab, and unselected tabs match system colors. This occurs because the `Shell.ForegroundColor` property value propagates to the `TabBarForegroundColor` property.
+- When the `TabBarTitleColor` property is set to `Green`, the `TabBarForegroundColor` property is set to `Blue`, and the `TabBarUnselectedColor` property is set to `Red`, the title is green and the icon is blue for the selected tab, and unselected tab titles and icons are red.
+
+::: moniker-end
+
 The following example shows a XAML style that sets different tab bar color properties:
 
 ```xaml

--- a/docs/whats-new/dotnet-8.md
+++ b/docs/whats-new/dotnet-8.md
@@ -58,6 +58,7 @@ The following behavior has changed from the previous release:
 - Use of the <xref:Microsoft.Maui.Controls.Maps.Map> control from XAML now requires the following `xmlns` namespace declaration: `xmlns:maps="http://schemas.microsoft.com/dotnet/2021/maui/maps"`.
 - Image caching is disabled on Android when loading an image from a stream with the [`ImageSource.FromStream`](xref:Microsoft.Maui.Controls.ImageSource.FromStream%2A) method. This is due to the lack of data from which to create a reasonable cache key.
 - On iOS, pages automatically scroll when the soft input keyboard would cover a text entry field, so that the field is above the soft input keyboard. The `KeyboardAutoManagerScroll.Disconnect` method, in the `Microsoft.Maui.Platform` namespace, can be called to disable this default behavior. The `KeyboardAutoManagerScroll.Connect` method can be called to re-enable the behavior after it's been disabled.
+- How the color of a tab is set in a Shell app has changed on some platforms. For more information, see [Tab appearance](~/fundamentals/shell/tab.md#tab-appearance).
 
 <!-- ## Performance
 

--- a/docs/whats-new/dotnet-8.md
+++ b/docs/whats-new/dotnet-8.md
@@ -58,7 +58,7 @@ The following behavior has changed from the previous release:
 - Use of the <xref:Microsoft.Maui.Controls.Maps.Map> control from XAML now requires the following `xmlns` namespace declaration: `xmlns:maps="http://schemas.microsoft.com/dotnet/2021/maui/maps"`.
 - Image caching is disabled on Android when loading an image from a stream with the [`ImageSource.FromStream`](xref:Microsoft.Maui.Controls.ImageSource.FromStream%2A) method. This is due to the lack of data from which to create a reasonable cache key.
 - On iOS, pages automatically scroll when the soft input keyboard would cover a text entry field, so that the field is above the soft input keyboard. The `KeyboardAutoManagerScroll.Disconnect` method, in the `Microsoft.Maui.Platform` namespace, can be called to disable this default behavior. The `KeyboardAutoManagerScroll.Connect` method can be called to re-enable the behavior after it's been disabled.
-- How the color of a tab is set in a Shell app has changed on some platforms. For more information, see [Tab appearance](~/fundamentals/shell/tab.md#tab-appearance).
+- How the color of a tab is set in a Shell app has changed on some platforms. For more information, see [Tab appearance](~/fundamentals/shell/tabs.md#tab-appearance).
 
 <!-- ## Performance
 


### PR DESCRIPTION
Fixes #1689 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/shell/tabs.md](https://github.com/dotnet/docs-maui/blob/cfff813fe998a78bdb45d62b01a95e7ea5a243ca/docs/fundamentals/shell/tabs.md) | [.NET MAUI Shell tabs](https://review.learn.microsoft.com/en-us/dotnet/maui/fundamentals/shell/tabs?branch=pr-en-us-1818) |
| [docs/whats-new/dotnet-8.md](https://github.com/dotnet/docs-maui/blob/cfff813fe998a78bdb45d62b01a95e7ea5a243ca/docs/whats-new/dotnet-8.md) | [What's new in .NET MAUI for .NET 8](https://review.learn.microsoft.com/en-us/dotnet/maui/whats-new/dotnet-8?branch=pr-en-us-1818) |


<!-- PREVIEW-TABLE-END -->