### PR TITLE
Update secure-storage.md

### DIFF
--- a/docs/migration/secure-storage.md
+++ b/docs/migration/secure-storage.md
@@ -67,7 +67,7 @@ public class LegacySecureStorage
         bool result = false;
 
 #if ANDROID
-        Preferences.Clear(Alias);
+        Preferences.Remove(key, Alias);
         result = true;
 #elif IOS
         KeyChain keyChain = new KeyChain();


### PR DESCRIPTION
Fix incorrect logic when removing a key from legacy storage on Android. The old logic cleared all preferences instead of removing the singular key as intended. The new logic now only removes the desired key.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/migration/secure-storage.md](https://github.com/dotnet/docs-maui/blob/7f834d2c960cacff4d5b84994e2370f2ecf82465/docs/migration/secure-storage.md) | [Migrate from Xamarin.Essentials secure storage to .NET MAUI secure storage](https://review.learn.microsoft.com/en-us/dotnet/maui/migration/secure-storage?branch=pr-en-us-1859) |

<!-- PREVIEW-TABLE-END -->