### PR TITLE
Add missing argument for InstallAndroidDependencies

### DIFF
--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -171,7 +171,7 @@ No matter which way you install Android, you can develop .NET MAUI apps in Visua
 
 #### Using "InstallAndroidDependencies"
 
-* .NET 7 and above has a build target that helps set up your Android environment for you. You can add or remove the following properties to `dotnet build -t:InstallAndroidDependencies` to configure your machine:
+* .NET 7 and above has a build target that helps set up your Android environment for you. You can add or remove the following properties to `dotnet build -t:InstallAndroidDependencies -f:net7.0-android` to configure your machine:
   * `-p:AndroidSdkDirectory "<PATH>"` installs or updates Android dependencies to the specified path (Note: You must use an absolute path without a tilde "~").
   * `-p:JavaSdkDirectory "<PATH>"` installs Java to the specified path (Note: You must use an absolute path without a tilde "~").
   * `-p:AcceptAndroidSDKLicenses=True` accepts the necessary Android licenses for development.


### PR DESCRIPTION
The example command `dotnet build -t:InstallAndroidDependencies` was missing the required `-f:net7.0-android`. 
If a user tries to run the command as is, they will get an error about the `InstallAndroidDependencies` target not existing.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/get-started/installation.md](https://github.com/dotnet/docs-maui/blob/0d6eb8f071bd11abbc82e3bd04d064c8690a0dd7/docs/get-started/installation.md) | [Installation](https://review.learn.microsoft.com/en-us/dotnet/maui/get-started/installation?branch=pr-en-us-1863) |

<!-- PREVIEW-TABLE-END -->