### PR TITLE
[android] migration table for confusing item group names

### DIFF
--- a/docs/migration/android-binding-projects.md
+++ b/docs/migration/android-binding-projects.md
@@ -89,6 +89,38 @@ Alternatively, you could exclude all files within a folder:
 <AndroidLibrary Remove="AndroidStudio\**\*" />
 ```
 
+## New Item Group Names
+
+`<AndroidLibrary>` is now the recommended item group to use for all `.jar` and
+`.aar` files. In Xamarin.Android, the following items groups were used, which
+can instead use item metadata to achieve the same result:
+
+| Legacy Item Group      | New Item Group   | Item Metadata  | Legacy Project Type          |
+|------------------------|------------------|----------------| ---------------------------- |
+| `AndroidAarLibrary`    | `AndroidLibrary` | `Bind="false"` | Application                  |
+| `AndroidJavaLibrary`   | `AndroidLibrary` | `Bind="false"` | Application or class library |
+| `EmbeddedJar`          | `AndroidLibrary` | n/a            | Binding project              |
+| `EmbeddedReferenceJar` | `AndroidLibrary` | `Bind="false"` | Binding project              |
+| `InputJar`             | `AndroidLibrary` | `Pack="false"` | Binding project              |
+| `LibraryProjectZip`    | `AndroidLibrary` | n/a            | Binding project              |
+
+Consider a `.aar` or `.jar` file, in which you are *not* interested in including
+a C# binding. This is common for cases where you have Java or Kotlin
+dependencies that you do not need to call from C#. In this case, you can set the
+`Bind` metadata to `false`. By default, the file is picked up by the default
+wildcards, you can also use `Update` to set the `Bind` metadata:
+
+```xml
+<ItemGroup>
+  <AndroidLibrary Update="foo.jar" Bind="false">
+</ItemGroup>
+```
+
+In an Android class library project, this would redistribute the `.jar` file
+inside the resulting NuGet package as-is. In an Android application project,
+this would include the `.jar` file in the resulting `.apk` or `.aab` file.
+Neither would include a C# binding for this Java library.
+
 ## Embedded JAR/AAR files
 
 In Xamarin.Android, the Java `.jar` or `.aar` was often embedded into the binding `.dll` as an Embedded Resource. However, this led to slow builds, as each `.dll` must be opened and scanned for Java code. If found, it must be extracted to disk to be used.

--- a/docs/migration/android-binding-projects.md
+++ b/docs/migration/android-binding-projects.md
@@ -89,11 +89,9 @@ Alternatively, you could exclude all files within a folder:
 <AndroidLibrary Remove="AndroidStudio\**\*" />
 ```
 
-## New Item Group Names
+## New item group names
 
-`<AndroidLibrary>` is now the recommended item group to use for all `.jar` and
-`.aar` files. In Xamarin.Android, the following items groups were used, which
-can instead use item metadata to achieve the same result:
+`<AndroidLibrary>` is now the recommended item group to use for all `.jar` and `.aar` files. In Xamarin.Android, the following items groups were used, which can instead use item metadata to achieve the same result:
 
 | Legacy Item Group      | New Item Group   | Item Metadata  | Legacy Project Type          |
 |------------------------|------------------|----------------| ---------------------------- |
@@ -104,11 +102,7 @@ can instead use item metadata to achieve the same result:
 | `InputJar`             | `AndroidLibrary` | `Pack="false"` | Binding project              |
 | `LibraryProjectZip`    | `AndroidLibrary` | n/a            | Binding project              |
 
-Consider a `.aar` or `.jar` file, in which you are *not* interested in including
-a C# binding. This is common for cases where you have Java or Kotlin
-dependencies that you do not need to call from C#. In this case, you can set the
-`Bind` metadata to `false`. By default, the file is picked up by the default
-wildcards, you can also use `Update` to set the `Bind` metadata:
+Consider a `.aar` or `.jar` file, in which you aren't interested in including a C# binding. This is common for cases where you have Java or Kotlin dependencies that you don't need to call from C#. In this case, you can set the `Bind` metadata to `false`. By default, the file is picked up by the default wildcards. You can also use the `Update` attribute to set the `Bind` metadata:
 
 ```xml
 <ItemGroup>
@@ -116,10 +110,7 @@ wildcards, you can also use `Update` to set the `Bind` metadata:
 </ItemGroup>
 ```
 
-In an Android class library project, this would redistribute the `.jar` file
-inside the resulting NuGet package as-is. In an Android application project,
-this would include the `.jar` file in the resulting `.apk` or `.aab` file.
-Neither would include a C# binding for this Java library.
+In an Android class library project, this would redistribute the `.jar` file inside the resulting NuGet package as is. In an Android application project, this would include the `.jar` file in the resulting `.apk` or `.aab` file. Neither would include a C# binding for this Java library.
 
 ## Embedded JAR/AAR files
 


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/blob/main/Documentation/guides/OneDotNetEmbeddedResources.md
Context: https://github.com/xamarin/xamarin-android/issues/8411

I had some feedback from customers that it would be helpful to include a table of the old item group names and what to do going forward.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/migration/android-binding-projects.md](https://github.com/dotnet/docs-maui/blob/bfbcfd9525886a1c3883656d9c9dc56191c9eb42/docs/migration/android-binding-projects.md) | [Xamarin.Android binding project migration](https://review.learn.microsoft.com/en-us/dotnet/maui/migration/android-binding-projects?branch=pr-en-us-1916) |


<!-- PREVIEW-TABLE-END -->