### PR TITLE
Add .NET 8 VSMac enablement instructions to installation doc

### DIFF
--- a/docs/get-started/first-app.md
+++ b/docs/get-started/first-app.md
@@ -212,8 +212,7 @@ If your app fails to compile, review [Troubleshooting known issues](../troublesh
 
 - Visual Studio 2022 for Mac 17.6 with the .NET, .NET MAUI, Android, and iOS workloads installed. For more information, see [Installation](installation.md?tabs=vsmac).
 
-> [!IMPORTANT]
-> To use Visual Studio for Mac with .NET 8, enable the **Visual Studio > Preferences > Other > Preview Features > Use the .NET 8 SDK if installed (requires restart)** checkbox.
+[!INCLUDE [Enable .NET 8 support in Visual Studio Mac](includes/vsmac-net8.md)]
 
 ## Create an app
 

--- a/docs/get-started/includes/vsmac-net8.md
+++ b/docs/get-started/includes/vsmac-net8.md
@@ -1,0 +1,7 @@
+---
+ms.topic: include
+ms.date: 12/19/2023
+---
+
+> [!IMPORTANT]
+> To use Visual Studio for Mac with .NET 8, enable the **Visual Studio > Preferences > Other > Preview Features > Use the .NET 8 SDK if installed (requires restart)** checkbox.

--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -86,6 +86,8 @@ To build, sign, and deploy .NET MAUI apps for iOS or macOS, you'll also need:
 1. Install .NET 8 through the [standalone installer](https://dotnet.microsoft.com/en-us/download/dotnet/8.0).
 1. After .NET 8 has finished installing, run `dotnet workload install maui` in a terminal.
 
+[!INCLUDE [Enable .NET 8 support in Visual Studio Mac](includes/vsmac-net8.md)]
+
 If you have network trouble while installing in a corporate environment, review the [installing behind a firewall or proxy](#installation-behind-a-firewall-or-proxy-server) instructions.
 
 ## Installation behind a firewall or proxy server

--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -86,7 +86,7 @@ To build, sign, and deploy .NET MAUI apps for iOS or macOS, you'll also need:
 1. Install .NET 8 through the [standalone installer](https://dotnet.microsoft.com/en-us/download/dotnet/8.0).
 1. After .NET 8 has finished installing, run `dotnet workload install maui` in a terminal.
 
-[!INCLUDE [Enable .NET 8 support in Visual Studio Mac](includes/vsmac-net8.md)]
+    [!INCLUDE [Enable .NET 8 support in Visual Studio Mac](includes/vsmac-net8.md)]
 
 If you have network trouble while installing in a corporate environment, review the [installing behind a firewall or proxy](#installation-behind-a-firewall-or-proxy-server) instructions.
 


### PR DESCRIPTION
Fixes #1961 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/get-started/first-app.md](https://github.com/dotnet/docs-maui/blob/b64a9c91f020348a9ff955b090bf60c33b83e7f4/docs/get-started/first-app.md) | [Build your first app](https://review.learn.microsoft.com/en-us/dotnet/maui/get-started/first-app?branch=pr-en-us-1966) |
| [docs/get-started/installation.md](https://github.com/dotnet/docs-maui/blob/b64a9c91f020348a9ff955b090bf60c33b83e7f4/docs/get-started/installation.md) | [[Visual Studio](#tab/vswin)](https://review.learn.microsoft.com/en-us/dotnet/maui/get-started/installation?branch=pr-en-us-1966) |


<!-- PREVIEW-TABLE-END -->