### PR TITLE
Fix inverted 'IgnoreSafeArea' value

### DIFF
--- a/docs/ios/platform-specifics/page-safe-area-layout.md
+++ b/docs/ios/platform-specifics/page-safe-area-layout.md
@@ -32,4 +32,4 @@ On<iOS>().SetUseSafeArea(false);
 The `Page.On<iOS>` method specifies that this platform-specific will only run on iOS. The `Page.SetUseSafeArea` method, in the `Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific` namespace, controls whether the safe area layout guide is disabled.
 
 > [!NOTE]
-> The <xref:Microsoft.Maui.Controls.Layout> class defines a <xref:Microsoft.Maui.Controls.Layout.IgnoreSafeArea> property that ensures that content is positioned on an area of the screen that is safe for all iOS devices. This property can be set to `true` on any layout class, such as a <xref:Microsoft.Maui.Controls.Grid> or <Microsoft.Maui.Controls.StackLayout>, to perform the equivalent of this platform-specific.
+> The <xref:Microsoft.Maui.Controls.Layout> class defines a <xref:Microsoft.Maui.Controls.Layout.IgnoreSafeArea> property that ensures that content is positioned on an area of the screen that is safe for all iOS devices. This property can be set to `true` on any layout class, such as a <xref:Microsoft.Maui.Controls.Grid> or <xref:Microsoft.Maui.Controls.StackLayout>, to perform the equivalent of this platform-specific.

--- a/docs/ios/platform-specifics/page-safe-area-layout.md
+++ b/docs/ios/platform-specifics/page-safe-area-layout.md
@@ -32,4 +32,4 @@ On<iOS>().SetUseSafeArea(false);
 The `Page.On<iOS>` method specifies that this platform-specific will only run on iOS. The `Page.SetUseSafeArea` method, in the `Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific` namespace, controls whether the safe area layout guide is disabled.
 
 > [!NOTE]
-> The <xref:Microsoft.Maui.Controls.Layout> class defines a <xref:Microsoft.Maui.Controls.Layout.IgnoreSafeArea> property that ensures that content is positioned on an area of the screen that is safe for all iOS devices. This property can be set to `false` on any layout class, such as a <xref:Microsoft.Maui.Controls.Grid> or <Microsoft.Maui.Controls.StackLayout>, to perform the equivalent of this platform-specific.
+> The <xref:Microsoft.Maui.Controls.Layout> class defines a <xref:Microsoft.Maui.Controls.Layout.IgnoreSafeArea> property that ensures that content is positioned on an area of the screen that is safe for all iOS devices. This property can be set to `true` on any layout class, such as a <xref:Microsoft.Maui.Controls.Grid> or <Microsoft.Maui.Controls.StackLayout>, to perform the equivalent of this platform-specific.


### PR DESCRIPTION
The IgnoreSafeArea property needs to be set to 'true' to have any effect. The default is 'false', in which case the safe area is respected.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/ios/platform-specifics/page-safe-area-layout.md](https://github.com/dotnet/docs-maui/blob/f9d8abee9122803966b8050b9b3d5b3150d34252/docs/ios/platform-specifics/page-safe-area-layout.md) | [Disable the safe area layout guide on iOS](https://review.learn.microsoft.com/en-us/dotnet/maui/ios/platform-specifics/page-safe-area-layout?branch=pr-en-us-2065) |


<!-- PREVIEW-TABLE-END -->