### PR TITLE
Enhance DatePicker localization guidance for Windows platforms

### DIFF
--- a/docs/user-interface/controls/datepicker.md
+++ b/docs/user-interface/controls/datepicker.md
@@ -90,7 +90,7 @@ Localizing the date formats and strings in the `<xref:Microsoft.Maui.Controls.Da
 
 Follow these steps to configure your <xref:Microsoft.Maui.Controls.DatePicker> for localization on Windows:
 
-1. Locate the Resources aection.
+1. Locate the Resources section.
 
    Navigate to the `Platforms\Windows` folder of your project and open the *Package.appxmanifest* file in a code editor or Visual Studio. If using Visual Studio, ensure you're viewing the file's raw XML. Look for the `<Resources>` section, which may initially include:
 

--- a/docs/user-interface/controls/datepicker.md
+++ b/docs/user-interface/controls/datepicker.md
@@ -82,17 +82,17 @@ However, this is not recommended. Depending on the setting of the `Format` prope
 > [!TIP]
 > On Android, the <xref:Microsoft.Maui.Controls.DatePicker> dialog can be customized by overriding the `CreateDatePickerDialog` method in a custom renderer. This allows, for example, additional buttons to be added to the dialog. -->
 
-## Localizing the DatePicker on Windows
+## Localize a DatePicker on Windows
 
-For applications targeting Windows, ensuring that the <xref:Microsoft.Maui.Controls.DatePicker> displays dates in a format that's localized to the user's settings, including the names of months and days in the picker's dialog, requires specific configuration in your project's `Package.appxmanifest`. Localizing these elements improves the user experience by adhering to the cultural norms of the user's locale.
+For apps targeting Windows, ensuring that the <xref:Microsoft.Maui.Controls.DatePicker> displays dates in a format that's localized to the user's settings, including the names of months and days in the picker's dialog, requires specific configuration in your project's *Package.appxmanifest* file. Localizing the elements in the package manifest improves the user experience by adhering to the cultural norms of the user's locale.
 
-Localizing the date formats and strings in the `<xref:Microsoft.Maui.Controls.DatePicker>` requires declaring the supported languages within your `Package.appxmanifest` file.
+Localizing the date formats and strings in the `<xref:Microsoft.Maui.Controls.DatePicker>` requires declaring the supported languages within your *Package.appxmanifest* file.
 
-Follow these steps to configure your <xref:Microsoft.Maui.Controls.DatePicker> for localization:
+Follow these steps to configure your <xref:Microsoft.Maui.Controls.DatePicker> for localization on Windows:
 
-1. Locate the Resources Section
+1. Locate the Resources aection.
 
-   Navigate to the `Platforms\Windows` folder of your project and open the `Package.appxmanifest` file in a code editor or Visual Studio. If using Visual Studio, ensure you're viewing the file's raw XML. Look for the `<Resources>` section, which may initially include:
+   Navigate to the `Platforms\Windows` folder of your project and open the *Package.appxmanifest* file in a code editor or Visual Studio. If using Visual Studio, ensure you're viewing the file's raw XML. Look for the `<Resources>` section, which may initially include:
 
    ```xml
    <Resources>
@@ -100,11 +100,9 @@ Follow these steps to configure your <xref:Microsoft.Maui.Controls.DatePicker> f
    </Resources>
    ```
 
-2. Specify Supported Languages
+1. Specify the supported languages.
 
-   Replace the `<Resource Language="x-generate">` with `<Resource />` elements for each of your supported languages. The language code should be in the form of a BCP-47 language tag, such as `en-US` for English (United States), `es-ES` for Spanish (Spain), `fr-FR` for French (France) or `de-DE` for German (Germany).
-
-  For example, to add support for both English (United States) and Spanish (Spain), your `<Resources>` section should be modified to look like this:
+   Replace the `<Resource Language="x-generate">` with `<Resource />` elements for each of your supported languages. The language code should be in the form of a BCP-47 language tag, such as `en-US` for English (United States), `es-ES` for Spanish (Spain), `fr-FR` for French (France) or `de-DE` for German (Germany).  For example, to add support for both English (United States) and Spanish (Spain), your `<Resources>` section should be modified to look like this:
 
    ```xml
    <Resources>
@@ -114,3 +112,5 @@ Follow these steps to configure your <xref:Microsoft.Maui.Controls.DatePicker> f
    ```
 
 This configuration ensures that the <xref:Microsoft.Maui.Controls.DatePicker> will display date formats, months, and days according to the user's locale, significantly enhancing the app's usability and accessibility across different regions.
+
+For more information about localization in .NET MAUI apps, see [Localization](~/fundamentals/localization.md).

--- a/docs/user-interface/controls/datepicker.md
+++ b/docs/user-interface/controls/datepicker.md
@@ -81,3 +81,35 @@ However, this is not recommended. Depending on the setting of the `Format` prope
 <!--
 > [!TIP]
 > On Android, the <xref:Microsoft.Maui.Controls.DatePicker> dialog can be customized by overriding the `CreateDatePickerDialog` method in a custom renderer. This allows, for example, additional buttons to be added to the dialog. -->
+
+## Localizing the DatePicker on Windows
+
+For applications targeting Windows, ensuring that the <xref:Microsoft.Maui.Controls.DatePicker> displays dates in a format that's localized to the user's settings, including the names of months and days in the picker's dialog, requires specific configuration in your project's `Package.appxmanifest`. Localizing these elements improves the user experience by adhering to the cultural norms of the user's locale.
+
+Localizing the date formats and strings in the `<xref:Microsoft.Maui.Controls.DatePicker>` requires declaring the supported languages within your `Package.appxmanifest` file.
+
+Follow these steps to configure your <xref:Microsoft.Maui.Controls.DatePicker> for localization:
+
+1. Locate the Resources Section
+
+   Navigate to the `Platforms\Windows` folder of your project and open the `Package.appxmanifest` file in a code editor or Visual Studio. If using Visual Studio, ensure you're viewing the file's raw XML. Look for the `<Resources>` section, which may initially include:
+
+   ```xml
+   <Resources>
+       <Resource Language="x-generate" />
+   </Resources>
+   ```
+2. Specify Supported Languages
+
+   Replace the `<Resource Language="x-generate">` with `<Resource />` elements for each of your supported languages. The language code should be in the form of a BCP-47 language tag, such as `en-US` for English (United States), `es-ES` for Spanish (Spain), `fr-FR` for French (France) or `de-DE` for German (Germany).
+
+  For example, to add support for both English (United States) and Spanish (Spain), your <Resources> section should be modified to look like this:
+
+   ```xml
+   <Resources>
+       <Resource Language="en-US" />
+       <Resource Language="es-ES" />
+   </Resources>
+   ```
+
+This configuration ensures that the <xref:Microsoft.Maui.Controls.DatePicker> will display date formats, months, and days according to the user's locale, significantly enhancing the app's usability and accessibility across different regions.

--- a/docs/user-interface/controls/datepicker.md
+++ b/docs/user-interface/controls/datepicker.md
@@ -99,6 +99,7 @@ Follow these steps to configure your <xref:Microsoft.Maui.Controls.DatePicker> f
        <Resource Language="x-generate" />
    </Resources>
    ```
+
 2. Specify Supported Languages
 
    Replace the `<Resource Language="x-generate">` with `<Resource />` elements for each of your supported languages. The language code should be in the form of a BCP-47 language tag, such as `en-US` for English (United States), `es-ES` for Spanish (Spain), `fr-FR` for French (France) or `de-DE` for German (Germany).

--- a/docs/user-interface/controls/datepicker.md
+++ b/docs/user-interface/controls/datepicker.md
@@ -104,7 +104,7 @@ Follow these steps to configure your <xref:Microsoft.Maui.Controls.DatePicker> f
 
    Replace the `<Resource Language="x-generate">` with `<Resource />` elements for each of your supported languages. The language code should be in the form of a BCP-47 language tag, such as `en-US` for English (United States), `es-ES` for Spanish (Spain), `fr-FR` for French (France) or `de-DE` for German (Germany).
 
-  For example, to add support for both English (United States) and Spanish (Spain), your <Resources> section should be modified to look like this:
+  For example, to add support for both English (United States) and Spanish (Spain), your `<Resources>` section should be modified to look like this:
 
    ```xml
    <Resources>


### PR DESCRIPTION
This commit updates the documentation to provide a more detailed and clarified guidance on how to localize the `DatePicker` control for Windows applications within .NET MAUI. It includes an explanation on declaring supported languages in the `Package.appxmanifest` file, ensuring developers have clear instructions on configuring their apps for multiple locales.

The commit is related to https://github.com/dotnet/maui/issues/10805 because there seems to be a lot of confusion in the .NET MAUI windows space about whether or not the date picker is able to display localized dates and strings.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/user-interface/controls/datepicker.md](https://github.com/dotnet/docs-maui/blob/d80101d7bbe8e894528650a736e02b3c5678ec1c/docs/user-interface/controls/datepicker.md) | [DatePicker](https://review.learn.microsoft.com/en-us/dotnet/maui/user-interface/controls/datepicker?branch=pr-en-us-2079) |


<!-- PREVIEW-TABLE-END -->