### PR TITLE
Update QUEST config.

### DIFF
--- a/quest-config.json
+++ b/quest-config.json
@@ -17,7 +17,7 @@
       },
       {
           "Label": "okr-health",
-          "ParentNodeId": 237267
+          "ParentNodeId": 237266
       },
       {
           "Label": "user-feedback",


### PR DESCRIPTION
The okr-health label is more likely used for "freshness" than for "build validations".