### PR TITLE
Add missing quotes in a sdkmanager install command for macOS

### DIFF
--- a/docs/get-started/first-app.md
+++ b/docs/get-started/first-app.md
@@ -394,7 +394,7 @@ By default, you can deploy to your local macOS or Windows development machine. O
 If you want to use Android emulators, follow these steps:
 
 1. Navigate in your terminal to `<YOUR_ANDROID_SDK_DIRECTORY>/cmdline-tools/latest/bin/`.
-1. Run `sdkmanager --install emulator` and `sdkmanager --install system-images;android-33;google_apis;x86_64` on Windows, or `./sdkmanager --install emulator` and `./sdkmanager --install system-images;android-33;google_apis;x86_64` on macOS.
+1. Run `sdkmanager --install emulator` and `sdkmanager --install system-images;android-33;google_apis;x86_64` on Windows, or `./sdkmanager --install emulator` and `./sdkmanager --install "system-images;android-33;google_apis;x86_64"` on macOS.
 1. Then, you can create a new emulator on the command line with Android's [avdmanager](https://developer.android.com/tools/avdmanager). For example, you can run `avdmanager create avd -n MyAndroidVirtualDevice-API33 -k "system-images;android-33;google_apis;x86_64"` on Windows, or `./avdmanager create avd -n MyAndroidVirtualDevice-API33 -k "system-images;android-33;google_apis;x86_64"` on macOS.
 
 You can also debug on [physical Android devices](~/android/device/setup.md).


### PR DESCRIPTION
The lack of quote leads to an error and prevent the completion of the install :

./sdkmanager --install system-images;android-33;google_apis;x86_64 
Warning: Failed to find package 'system-images'                                 
zsh: command not found: android-33      ] 10% Computing updates...              
zsh: command not found: google_apis
zsh: command not found: x86_64


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/get-started/first-app.md](https://github.com/dotnet/docs-maui/blob/4f1a02c5896351470aec485074191b96b0654321/docs/get-started/first-app.md) | [Build your first app](https://review.learn.microsoft.com/en-us/dotnet/maui/get-started/first-app?branch=pr-en-us-2270) |

<!-- PREVIEW-TABLE-END -->