### PR TITLE
sdkmanager/etc. arguments must be quoted.

### DIFF
--- a/docs/get-started/first-app.md
+++ b/docs/get-started/first-app.md
@@ -394,8 +394,41 @@ By default, you can deploy to your local macOS or Windows development machine. O
 If you want to use Android emulators, follow these steps:
 
 1. Navigate in your terminal to `<YOUR_ANDROID_SDK_DIRECTORY>/cmdline-tools/latest/bin/`.
-1. Run `sdkmanager --install emulator` and `sdkmanager --install system-images;android-33;google_apis;x86_64` on Windows, or `./sdkmanager --install emulator` and `./sdkmanager --install system-images;android-33;google_apis;x86_64` on macOS.
-1. Then, you can create a new emulator on the command line with Android's [avdmanager](https://developer.android.com/tools/avdmanager). For example, you can run `avdmanager create avd -n MyAndroidVirtualDevice-API33 -k "system-images;android-33;google_apis;x86_64"` on Windows, or `./avdmanager create avd -n MyAndroidVirtualDevice-API33 -k "system-images;android-33;google_apis;x86_64"` on macOS.
+1. Use `sdkmanager` to install the emulator.
+
+    On Windows, run the following commands in the terminal:
+
+    ```console
+    sdkmanager --install emulator
+    sdkmanager --install "system-images;android-33;google_apis;x86_64"
+    ```
+
+    On macOS, run the following commands in the terminal:
+
+    ```console
+    ./sdkmanager --install emulator
+    ./sdkmanager --install "system-images;android-33;google_apis;x86_64"
+    ```
+
+    > [!NOTE]
+    > The quotes around the `sdkmanager` command-line arguments are important.
+
+1. Then, you can create a new emulator on the command line with Android's [avdmanager](https://developer.android.com/tools/avdmanager).
+
+    On Windows, run the following commands in the terminal:
+
+    ```console
+    avdmanager create avd -n MyAndroidVirtualDevice-API33 -k "system-images;android-33;google_apis;x86_64"
+    ```
+
+    On macOS, run the following commands in the terminal:
+
+    ```console
+    ./avdmanager create avd -n MyAndroidVirtualDevice-API33 -k "system-images;android-33;google_apis;x86_64"
+    ```
+
+    > [!NOTE]
+    > The quotes around the `avdmanager` command-line arguments are important.
 
 You can also debug on [physical Android devices](~/android/device/setup.md).
 


### PR DESCRIPTION
Context: https://github.com/dotnet/docs-maui/issues/2214
Context: https://github.com/xamarin/xamarin-android/issues/8960

Issue #2214 mentions that:

 1. `dotnet build -t:InstallAndroidDependencies` generates an XARAT7001 warning.

 2. `./sdkmanager --install system-images;android-33;google_apis;x86_64` fails.

 3. (1) and (2) may have left the Android SDK in a "bad state", breaking Rider and Rider's Device Manager.

(1) requires further investigation, on multiple fronts. See also xamarin/xamarin-android#8960.

(3) is Bad, but out of scope.

Which leaves (2): *how* did it fail?

    ./sdkmanager --install system-images;android-33;google_apis;x86_64
    Warning: Errors during XML parse:
    Warning: Additionally, the fallback loader failed to parse the XML.
    Warning: Failed to find package 'system-images'
    zsh: command not found: android-33      ] 10% Computing updates...
    zsh: command not found: google_apis
    zsh: command not found: x86_64

Note in particular the `zsh: command not found` messages at the end.

The problem is that the `sdkmanager` parameter value contains `;`, which the shell splits up into separate commands!

    ./sdkmanager --install system-images;android-33;google_apis;x86_64

is thus *actually* treated by zsh as:

    ./sdkmanager --install system-images
    android-33
    google_apis
    x86_64

What is required is that the parameter value be *quoted*:

    ./sdkmanager --install "system-images;android-33;google_apis;x86_64"

This ensures that `sdkmanager` gets the required parameter value.

Where did this `sdkmanager` command-line come from?  It came from `docs/get-started/first-app.md`!

Update `first-app.md` to:

 1. Use code blocks around for the commands, to make it easier for readers to copy the command.
 2. Explicitly call out that the parameter value requires quoting.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/get-started/first-app.md](https://github.com/dotnet/docs-maui/blob/00ffcaf3f240e0afe3a4a97715e1e8eb6fc19449/docs/get-started/first-app.md) | [Build your first app](https://review.learn.microsoft.com/en-us/dotnet/maui/get-started/first-app?branch=pr-en-us-2275) |

<!-- PREVIEW-TABLE-END -->