### PR TITLE
iOS 16.4+ requires a signed app to display the splash screen

### DIFF
--- a/docs/TOC.yml
+++ b/docs/TOC.yml
@@ -576,7 +576,7 @@
               - name: "ANDXXxxxx: Generic Android tooling"
                 items:
                 - name: Overview
-                  href: /dotnet/android/messages/andxxxxxx-generic-android-tooling?toc=/dotnet/maui/toc.json&bc=/dotnet/maui/breadcrumb/toc.json
+                  href: /dotnet/android/messages/#andxxxxxx-generic-android-tooling?toc=/dotnet/maui/toc.json&bc=/dotnet/maui/breadcrumb/toc.json
                 - name: ANDAS0000
                   href: /dotnet/android/messages/andas0000?toc=/dotnet/maui/toc.json&bc=/dotnet/maui/breadcrumb/toc.json
                 - name: ANDJS0000

--- a/docs/user-interface/images/splashscreen.md
+++ b/docs/user-interface/images/splashscreen.md
@@ -13,9 +13,9 @@ On Android and iOS, .NET Multi-platform App UI (.NET MAUI) apps can display a sp
 Once the app is ready for interaction, its splash screen is dismissed.
 
 > [!IMPORTANT]
-> In iOS 16.4+, simulators won't load a splash screen unless your app is signed. For information about a workaround, see [GitHub issue 18479](https://github.com/xamarin/xamarin-macios/issues/18469).
->
-> On Android 12+ (API 31+), the splash screen shows an icon that's centred on screen. For more information about splash screens on Android 12+, see [Splash screens](https://developer.android.com/develop/ui/views/launch/splash-screen) on developer.android.com.
+> On iOS 16.4+, simulators won't load a splash screen unless your app is signed. For more information, including a workaround, see [GitHub issue 18479](https://github.com/xamarin/xamarin-macios/issues/18469).
+
+On Android 12+ (API 31+), the splash screen shows an icon that's centred on screen. For more information about splash screens on Android 12+, see [Splash screens](https://developer.android.com/develop/ui/views/launch/splash-screen) on developer.android.com.
 
 In a .NET MAUI app project, a splash screen can be specified in a single location in your app project, and at build time it can be resized to the correct resolution for the target platform, and added to your app package. This avoids having to manually duplicate and name the splash screen on a per platform basis. By default, bitmap (non-vector) image formats are not automatically resized by .NET MAUI.
 

--- a/docs/user-interface/images/splashscreen.md
+++ b/docs/user-interface/images/splashscreen.md
@@ -12,7 +12,9 @@ On Android and iOS, .NET Multi-platform App UI (.NET MAUI) apps can display a sp
 
 Once the app is ready for interaction, its splash screen is dismissed.
 
-> [!NOTE]
+> [!IMPORTANT]
+> In iOS 16.4+, simulators won't load a splash screen unless your app is signed. For information about a workaround, see [GitHub issue 18479](https://github.com/xamarin/xamarin-macios/issues/18469).
+>
 > On Android 12+ (API 31+), the splash screen shows an icon that's centred on screen. For more information about splash screens on Android 12+, see [Splash screens](https://developer.android.com/develop/ui/views/launch/splash-screen) on developer.android.com.
 
 In a .NET MAUI app project, a splash screen can be specified in a single location in your app project, and at build time it can be resized to the correct resolution for the target platform, and added to your app package. This avoids having to manually duplicate and name the splash screen on a per platform basis. By default, bitmap (non-vector) image formats are not automatically resized by .NET MAUI.

--- a/docs/whats-new/dotnet-docs-maui-mod2.md
+++ b/docs/whats-new/dotnet-docs-maui-mod2.md
@@ -39,7 +39,7 @@ Welcome to what's new in the .NET Multi-platform App UI (.NET MAUI) docs for May
     - [ADB0040](/dotnet/android/messages/adb0040?toc=/dotnet/maui/toc.json&bc=/dotnet/maui/breadcrumb/toc.json)
     - [ADB0050](/dotnet/android/messages/adb0050?toc=/dotnet/maui/toc.json&bc=/dotnet/maui/breadcrumb/toc.json)
     - [ADB0060](/dotnet/android/messages/adb0060?toc=/dotnet/maui/toc.json&bc=/dotnet/maui/breadcrumb/toc.json)
-  - [ANDXXxxxx: Generic Android tooling](/dotnet/android/messages/andxxxxxx-generic-android-tooling?toc=/dotnet/maui/toc.json&bc=/dotnet/maui/breadcrumb/toc.json)
+  - [ANDXXxxxx: Generic Android tooling](/dotnet/android/messages/#andxxxxxx-generic-android-tooling?toc=/dotnet/maui/toc.json&bc=/dotnet/maui/breadcrumb/toc.json)
     - [ANDAS0000](/dotnet/android/messages/andas0000?toc=/dotnet/maui/toc.json&bc=/dotnet/maui/breadcrumb/toc.json)
     - [ANDJS0000](/dotnet/android/messages/andjs0000?toc=/dotnet/maui/toc.json&bc=/dotnet/maui/breadcrumb/toc.json)
     - [ANDKT0000](/dotnet/android/messages/andkt0000?toc=/dotnet/maui/toc.json&bc=/dotnet/maui/breadcrumb/toc.json)


### PR DESCRIPTION
Fixes #2268

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/user-interface/images/splashscreen.md](https://github.com/dotnet/docs-maui/blob/ff49c2075231aaeacec923bf58fe5986f7f5c38c/docs/user-interface/images/splashscreen.md) | [Add a splash screen to a .NET MAUI app project](https://review.learn.microsoft.com/en-us/dotnet/maui/user-interface/images/splashscreen?branch=pr-en-us-2292) |
| [docs/whats-new/dotnet-docs-maui-mod2.md](https://github.com/dotnet/docs-maui/blob/ff49c2075231aaeacec923bf58fe5986f7f5c38c/docs/whats-new/dotnet-docs-maui-mod2.md) | [".NET Multi-platform App UI (.NET MAUI) docs: What's new for May 2024"](https://review.learn.microsoft.com/en-us/dotnet/maui/whats-new/dotnet-docs-maui-mod2?branch=pr-en-us-2292) |


<!-- PREVIEW-TABLE-END -->