### PR TITLE
Fix simulator instead of device typo in cli.md

### DIFF
--- a/docs/ios/cli.md
+++ b/docs/ios/cli.md
@@ -80,7 +80,7 @@ A device must be provisioned before you can deploy an iOS app to it. For more in
     Alternatively, right-click on your device and select **Copy Identifier** to copy the UDID to the clipboard.
 
 <!-- markdownlint-disable MD029 -->
-5. In **Terminal**, build the app and run it on your chosen simulator by specifying the `_DeviceName` MSBuild property using the `-p` [MSBuild option](/dotnet/core/tools/dotnet-build#msbuild):
+5. In **Terminal**, build the app and run it on your chosen device by specifying the `_DeviceName` MSBuild property using the `-p` [MSBuild option](/dotnet/core/tools/dotnet-build#msbuild):
 
     ```zsh
     dotnet build -t:Run -f net8.0-ios -p:RuntimeIdentifier=ios-arm64 -p:_DeviceName=MY_SPECIFIC_UDID


### PR DESCRIPTION
This section talks about running on device, not simulator.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/ios/cli.md](https://github.com/dotnet/docs-maui/blob/5c051b140d3203cd5b89e50f5c45c40146f34916/docs/ios/cli.md) | [Build an iOS app with .NET CLI](https://review.learn.microsoft.com/en-us/dotnet/maui/ios/cli?branch=pr-en-us-2295) |

<!-- PREVIEW-TABLE-END -->