### PR TITLE
Use case for Editor auto-sizing

### DIFF
--- a/docs/user-interface/controls/editor.md
+++ b/docs/user-interface/controls/editor.md
@@ -18,7 +18,7 @@ These properties are backed by <xref:Microsoft.Maui.Controls.BindableProperty> o
 
 In addition, <xref:Microsoft.Maui.Controls.Editor> defines a `Completed` event, which is raised when the user finalizes text in the <xref:Microsoft.Maui.Controls.Editor> with the return key.
 
-<xref:Microsoft.Maui.Controls.Editor> derives from the `InputView` class, from which it inherits the following properties:
+<xref:Microsoft.Maui.Controls.Editor> derives from the <xref:Microsoft.Maui.Controls.InputView> class, from which it inherits the following properties:
 
 - `CharacterSpacing`, of type `double`, sets the spacing between characters in the entered text.
 - `CursorPosition`, of type `int`, defines the position of the cursor within the editor.
@@ -40,7 +40,7 @@ In addition, <xref:Microsoft.Maui.Controls.Editor> defines a `Completed` event, 
 
 These properties are backed by <xref:Microsoft.Maui.Controls.BindableProperty> objects, which means that they can be targets of data bindings, and styled.
 
-In addition, `InputView` defines a `TextChanged` event, which is raised when the text in the <xref:Microsoft.Maui.Controls.Editor> changes. The `TextChangedEventArgs` object that accompanies the `TextChanged` event has `NewTextValue` and `OldTextValue` properties, which specify the new and old text, respectively.
+In addition, <xref:Microsoft.Maui.Controls.InputView> defines a `TextChanged` event, which is raised when the text in the <xref:Microsoft.Maui.Controls.Editor> changes. The `TextChangedEventArgs` object that accompanies the `TextChanged` event has `NewTextValue` and `OldTextValue` properties, which specify the new and old text, respectively.
 
 For information about specifying fonts on an <xref:Microsoft.Maui.Controls.Editor>, see [Fonts](~/user-interface/fonts.md).
 
@@ -130,9 +130,9 @@ This can be accomplished as follows:
         AutoSize="TextChanges" />
 ```
 
-When auto-resizing is enabled, the height of the <xref:Microsoft.Maui.Controls.Editor> will increase when the user fills it with text, and the height will decrease as the user deletes text.
+When auto-resizing is enabled, the height of the <xref:Microsoft.Maui.Controls.Editor> will increase when the user fills it with text, and the height will decrease as the user deletes text. This can be used to ensure that <xref:Microsoft.Maui.Controls.Editor> objects in a <xref:Microsoft.Maui.Controls.DataTemplate> in a <xref:Microsoft.Maui.Controls.CollectionView> size correctly.
 
-> [!NOTE]
+> [!IMPORTANT]
 > An <xref:Microsoft.Maui.Controls.Editor> will not auto-size if the <xref:Microsoft.Maui.Controls.VisualElement.HeightRequest> property has been set.
 
 ## Transform text

--- a/docs/user-interface/controls/entry.md
+++ b/docs/user-interface/controls/entry.md
@@ -22,7 +22,7 @@ These properties are backed by <xref:Microsoft.Maui.Controls.BindableProperty> o
 
 In addition, <xref:Microsoft.Maui.Controls.Entry> defines a `Completed` event, which is raised when the user finalizes text in the <xref:Microsoft.Maui.Controls.Entry> with the return key.
 
-<xref:Microsoft.Maui.Controls.Entry> derives from the `InputView` class, from which it inherits the following properties:
+<xref:Microsoft.Maui.Controls.Entry> derives from the <xref:Microsoft.Maui.Controls.InputView> class, from which it inherits the following properties:
 
 - `CharacterSpacing`, of type `double`, sets the spacing between characters in the entered text.
 - `CursorPosition`, of type `int`, defines the position of the cursor within the editor.
@@ -44,7 +44,7 @@ In addition, <xref:Microsoft.Maui.Controls.Entry> defines a `Completed` event, w
 
 These properties are backed by <xref:Microsoft.Maui.Controls.BindableProperty> objects, which means that they can be targets of data bindings, and styled.
 
-In addition, `InputView` defines a `TextChanged` event, which is raised when the text in the <xref:Microsoft.Maui.Controls.Entry> changes. The `TextChangedEventArgs` object that accompanies the `TextChanged` event has `NewTextValue` and `OldTextValue` properties, which specify the new and old text, respectively.
+In addition, <xref:Microsoft.Maui.Controls.InputView> defines a `TextChanged` event, which is raised when the text in the <xref:Microsoft.Maui.Controls.Entry> changes. The `TextChangedEventArgs` object that accompanies the `TextChanged` event has `NewTextValue` and `OldTextValue` properties, which specify the new and old text, respectively.
 
 For information about specifying fonts on an <xref:Microsoft.Maui.Controls.Entry>, see [Fonts](~/user-interface/fonts.md).
 

--- a/docs/user-interface/controls/searchbar.md
+++ b/docs/user-interface/controls/searchbar.md
@@ -22,7 +22,7 @@ These properties are backed by <xref:Microsoft.Maui.Controls.BindableProperty> o
 
 In addition, <xref:Microsoft.Maui.Controls.SearchBar> defines a `SearchButtonPressed` event, which is raised when the search button is clicked, or the enter key is pressed.
 
-<xref:Microsoft.Maui.Controls.SearchBar> derives from the `InputView` class, from which it inherits the following properties:
+<xref:Microsoft.Maui.Controls.SearchBar> derives from the <xref:Microsoft.Maui.Controls.InputView> class, from which it inherits the following properties:
 
 - `CharacterSpacing`, of type `double`, sets the spacing between characters in the entered text.
 - `CursorPosition`, of type `int`, defines the position of the cursor within the editor.
@@ -44,7 +44,7 @@ In addition, <xref:Microsoft.Maui.Controls.SearchBar> defines a `SearchButtonPre
 
 These properties are backed by <xref:Microsoft.Maui.Controls.BindableProperty> objects, which means that they can be targets of data bindings, and styled.
 
-In addition, `InputView` defines a `TextChanged` event, which is raised when the text in the <xref:Microsoft.Maui.Controls.Entry> changes. The `TextChangedEventArgs` object that accompanies the `TextChanged` event has `NewTextValue` and `OldTextValue` properties, which specify the new and old text, respectively.
+In addition, <xref:Microsoft.Maui.Controls.InputView> defines a `TextChanged` event, which is raised when the text in the <xref:Microsoft.Maui.Controls.Entry> changes. The `TextChangedEventArgs` object that accompanies the `TextChanged` event has `NewTextValue` and `OldTextValue` properties, which specify the new and old text, respectively.
 
 ## Create a SearchBar
 
@@ -69,7 +69,7 @@ SearchBar searchBar = new SearchBar { Placeholder = "Search items..." };
 A search can be executed using the <xref:Microsoft.Maui.Controls.SearchBar> control by attaching an event handler to one of the following events:
 
 - `SearchButtonPressed`, which is called when the user either clicks the search button or presses the enter key.
-- `TextChanged`, which is called anytime the text in the query box is changed. This event is inherited from the `InputView` class.
+- `TextChanged`, which is called anytime the text in the query box is changed. This event is inherited from the <xref:Microsoft.Maui.Controls.InputView> class.
 
 The following XAML example shows an event handler attached to the `TextChanged` event and uses a <xref:Microsoft.Maui.Controls.ListView> to display search results:
 

--- a/docs/windows/platform-specifics/inputview-reading-order.md
+++ b/docs/windows/platform-specifics/inputview-reading-order.md
@@ -27,7 +27,7 @@ using Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific;
 editor.On<Microsoft.Maui.Controls.PlatformConfiguration.Windows>().SetDetectReadingOrderFromContent(true);
 ```
 
-The `Editor.On<Microsoft.Maui.Controls.PlatformConfiguration.Windows>` method specifies that this platform-specific will only run on Windows. The `InputView.SetDetectReadingOrderFromContent` method, in the `Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific` namespace, is used to control whether the reading order is detected from the content in the `InputView`. In addition, the `InputView.SetDetectReadingOrderFromContent` method can be used to toggle whether the reading order is detected from the content by calling the `InputView.GetDetectReadingOrderFromContent` method to return the current value:
+The `Editor.On<Microsoft.Maui.Controls.PlatformConfiguration.Windows>` method specifies that this platform-specific will only run on Windows. The `InputView.SetDetectReadingOrderFromContent` method, in the `Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific` namespace, is used to control whether the reading order is detected from the content in the <xref:Microsoft.Maui.Controls.InputView>. In addition, the `InputView.SetDetectReadingOrderFromContent` method can be used to toggle whether the reading order is detected from the content by calling the `InputView.GetDetectReadingOrderFromContent` method to return the current value:
 
 ```csharp
 editor.On<Microsoft.Maui.Controls.PlatformConfiguration.Windows>().SetDetectReadingOrderFromContent(!editor.On<Microsoft.Maui.Controls.PlatformConfiguration.Windows>().GetDetectReadingOrderFromContent());


### PR DESCRIPTION
Fixes #2279 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/user-interface/controls/editor.md](https://github.com/dotnet/docs-maui/blob/0308b3f69d4d3b2a760c65df2a27c241995ae67a/docs/user-interface/controls/editor.md) | [Editor](https://review.learn.microsoft.com/en-us/dotnet/maui/user-interface/controls/editor?branch=pr-en-us-2296) |
| [docs/user-interface/controls/entry.md](https://github.com/dotnet/docs-maui/blob/0308b3f69d4d3b2a760c65df2a27c241995ae67a/docs/user-interface/controls/entry.md) | ["Entry"](https://review.learn.microsoft.com/en-us/dotnet/maui/user-interface/controls/entry?branch=pr-en-us-2296) |
| [docs/user-interface/controls/searchbar.md](https://github.com/dotnet/docs-maui/blob/0308b3f69d4d3b2a760c65df2a27c241995ae67a/docs/user-interface/controls/searchbar.md) | [SearchBar](https://review.learn.microsoft.com/en-us/dotnet/maui/user-interface/controls/searchbar?branch=pr-en-us-2296) |
| [docs/windows/platform-specifics/inputview-reading-order.md](https://github.com/dotnet/docs-maui/blob/0308b3f69d4d3b2a760c65df2a27c241995ae67a/docs/windows/platform-specifics/inputview-reading-order.md) | [docs/windows/platform-specifics/inputview-reading-order](https://review.learn.microsoft.com/en-us/dotnet/maui/windows/platform-specifics/inputview-reading-order?branch=pr-en-us-2296) |

<!-- PREVIEW-TABLE-END -->