### PR TITLE
Added note recommending a GroupName for RadioButtonGroup

### DIFF
--- a/docs/user-interface/controls/radiobutton.md
+++ b/docs/user-interface/controls/radiobutton.md
@@ -39,7 +39,9 @@ These properties are backed by <xref:Microsoft.Maui.Controls.BindableProperty> o
 
 <xref:Microsoft.Maui.Controls.RadioButton> grouping can be managed by the `RadioButtonGroup` class, which defines the following attached properties:
 
-- `GroupName`, of type `string`, which defines the group name for <xref:Microsoft.Maui.Controls.RadioButton> objects in an `ILayout`.
+- `GroupName`, of type `string`, which defines the group name for <xref:Microsoft.Maui.Controls.RadioButton> objects in an `ILayout`. 
+> [!NOTE]
+> Although not required, it is strongly recommended that you provide a `GroupName` to ensure `SelectedValue` works correctly across all platforms.
 - `SelectedValue`, of type `object`, which represents the value of the checked <xref:Microsoft.Maui.Controls.RadioButton> object within an `ILayout` group. This attached property uses a `TwoWay` binding by default.
 
 For more information about the `GroupName` attached property, see [Group RadioButtons](#group-radiobuttons). For more information about the `SelectedValue` attached property, see [Respond to RadioButton state changes](#respond-to-radiobutton-state-changes).

--- a/docs/user-interface/controls/radiobutton.md
+++ b/docs/user-interface/controls/radiobutton.md
@@ -39,10 +39,11 @@ These properties are backed by <xref:Microsoft.Maui.Controls.BindableProperty> o
 
 <xref:Microsoft.Maui.Controls.RadioButton> grouping can be managed by the `RadioButtonGroup` class, which defines the following attached properties:
 
-- `GroupName`, of type `string`, which defines the group name for <xref:Microsoft.Maui.Controls.RadioButton> objects in an `ILayout`. 
-> [!NOTE]
-> Although not required, it is strongly recommended that you provide a `GroupName` to ensure `SelectedValue` works correctly across all platforms.
+- `GroupName`, of type `string`, which defines the group name for <xref:Microsoft.Maui.Controls.RadioButton> objects in an `ILayout`.
 - `SelectedValue`, of type `object`, which represents the value of the checked <xref:Microsoft.Maui.Controls.RadioButton> object within an `ILayout` group. This attached property uses a `TwoWay` binding by default.
+
+> [!TIP]
+> Although not mandatory, it's strongly recommended that you set the `GroupName` property to ensure that the `SelectedValue` property works correctly across all platforms.
 
 For more information about the `GroupName` attached property, see [Group RadioButtons](#group-radiobuttons). For more information about the `SelectedValue` attached property, see [Respond to RadioButton state changes](#respond-to-radiobutton-state-changes).
 


### PR DESCRIPTION
Inspired by Bug turned into Proposal here: https://github.com/dotnet/maui/issues/21335

Warning developers to assign GroupName to ensure SelectedValue works across all platforms. The bug was turned into a proposal to allow for null or empty strings for GroupName, but documentation can be updated to reflect its current state.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/user-interface/controls/radiobutton.md](https://github.com/dotnet/docs-maui/blob/8d55ac4f570c77ba2d20d9a9fa52d2432a62201c/docs/user-interface/controls/radiobutton.md) | [RadioButton](https://review.learn.microsoft.com/en-us/dotnet/maui/user-interface/controls/radiobutton?branch=pr-en-us-2301) |


<!-- PREVIEW-TABLE-END -->