### PR TITLE
Fix for troubleshooting command.

### DIFF
--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -132,7 +132,7 @@ To debug to an Android target in Visual Studio Code:
 
 ## Troubleshooting
 
-You might face issues when setting up the .NET MAUI extension for Visual Studio Code. To see details on errors related to the extension, navigate to the **Output** window (<kbd>CTRL/CMD + Shift + u</kdb>) and select **.NET MAUI** in the dropdown. See the below sections to help address your issue. If you're still facing issues after following the troubleshooting steps, please [report an issue](#provide-feedback).
+You might face issues when setting up the .NET MAUI extension for Visual Studio Code. To see details on errors related to the extension, navigate to the **Output** window (<kbd>CTRL/CMD + Shift + u </kbd>) and select **.NET MAUI** in the dropdown. See the below sections to help address your issue. If you're still facing issues after following the troubleshooting steps, please [report an issue](#provide-feedback).
 
 ### Project creation
 


### PR DESCRIPTION
Troubleshooting section was displayed as codeblock from shortcut onwards.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/get-started/installation.md](https://github.com/dotnet/docs-maui/blob/90b701999c5ae2f4dd8e9e589dd069ea65176777/docs/get-started/installation.md) | [Installation](https://review.learn.microsoft.com/en-us/dotnet/maui/get-started/installation?branch=pr-en-us-2343) |

<!-- PREVIEW-TABLE-END -->