### PR TITLE
Update app-lifecycle.md for Mac Catalyst

### DIFF
--- a/docs/fundamentals/app-lifecycle.md
+++ b/docs/fundamentals/app-lifecycle.md
@@ -188,7 +188,7 @@ namespace PlatformLifecycleDemo
 
 For more information about the Android app lifecycle, see [Understand the Activity Lifecycle](https://developer.android.com/guide/components/activities/activity-lifecycle) on developer.android.com.
 
-### iOS
+### iOS & Mac Catalyst
 
 The following table lists the .NET MAUI delegates that are invoked in response to iOS lifecycle events being raised:
 

--- a/docs/fundamentals/app-lifecycle.md
+++ b/docs/fundamentals/app-lifecycle.md
@@ -188,9 +188,9 @@ namespace PlatformLifecycleDemo
 
 For more information about the Android app lifecycle, see [Understand the Activity Lifecycle](https://developer.android.com/guide/components/activities/activity-lifecycle) on developer.android.com.
 
-### iOS & Mac Catalyst
+### iOS and Mac Catalyst
 
-The following table lists the .NET MAUI delegates that are invoked in response to iOS lifecycle events being raised:
+The following table lists the .NET MAUI delegates that are invoked in response to iOS and Mac Catalyst lifecycle events being raised:
 
 | Delegate | Arguments | Description |
 | -- | -- | -- |
@@ -223,7 +223,7 @@ The following table lists the .NET MAUI delegates that are invoked in response t
 > [!IMPORTANT]
 > Each delegate, with the exception of `PerformFetch`, has a corresponding identically named extension method that can be called to register a handler for the delegate.
 
-To respond to an iOS lifecycle delegate being invoked, call the `ConfigureLifecycleEvents` method on the `MauiAppBuilder` object in the `CreateMauiapp` method of your `MauiProgram` class. Then, on the `ILifecycleBuilder` object, call the `AddiOS` method and specify the `Action` that registers handlers for the required delegates:
+To respond to an iOS and Mac Catalyst lifecycle delegate being invoked, call the `ConfigureLifecycleEvents` method on the `MauiAppBuilder` object in the `CreateMauiapp` method of your `MauiProgram` class. Then, on the `ILifecycleBuilder` object, call the `AddiOS` method and specify the `Action` that registers handlers for the required delegates:
 
 ```csharp
 using Microsoft.Maui.LifecycleEvents;
@@ -239,7 +239,7 @@ namespace PlatformLifecycleDemo
                 .UseMauiApp<App>()
                 .ConfigureLifecycleEvents(events =>
                 {
-#if IOS
+#if IOS || MACCATALYST
                     events.AddiOS(ios => ios
                         .OnActivated((app) => LogEvent(nameof(iOSLifecycle.OnActivated)))
                         .OnResignActivation((app) => LogEvent(nameof(iOSLifecycle.OnResignActivation)))

--- a/docs/whats-new/dotnet-8.md
+++ b/docs/whats-new/dotnet-8.md
@@ -72,7 +72,7 @@ While the focus of this release of .NET MAUI is quality, there's also some new f
 
 - Window management can be decoupled from the `App` class. For more information, see [Decouple window management from the App class](~/fundamentals/windows.md#decouple-window-management-from-the-app-class).
 - Several system fonts can be easily consumed in Android apps. For more information, see [Consume fonts](~/user-interface/fonts.md#consume-fonts).
-- On iOS, `MauiUIApplicationDelegate` gains a `PerformFetch` method that can be overridden or consumed via the `iOSLifecycle.PerformFetch` delegate. For more information, see [iOS platform lifecycle events](~/fundamentals/app-lifecycle.md#ios).
+- On iOS, `MauiUIApplicationDelegate` gains a `PerformFetch` method that can be overridden or consumed via the `iOSLifecycle.PerformFetch` delegate. For more information, see [iOS and Mac Catalyst platform lifecycle events](~/fundamentals/app-lifecycle.md#ios-and-maccatalyst).
 
 ## Type deprecation and removal
 

--- a/docs/whats-new/dotnet-8.md
+++ b/docs/whats-new/dotnet-8.md
@@ -72,7 +72,7 @@ While the focus of this release of .NET MAUI is quality, there's also some new f
 
 - Window management can be decoupled from the `App` class. For more information, see [Decouple window management from the App class](~/fundamentals/windows.md#decouple-window-management-from-the-app-class).
 - Several system fonts can be easily consumed in Android apps. For more information, see [Consume fonts](~/user-interface/fonts.md#consume-fonts).
-- On iOS, `MauiUIApplicationDelegate` gains a `PerformFetch` method that can be overridden or consumed via the `iOSLifecycle.PerformFetch` delegate. For more information, see [iOS and Mac Catalyst platform lifecycle events](~/fundamentals/app-lifecycle.md#ios-and-maccatalyst).
+- On iOS, `MauiUIApplicationDelegate` gains a `PerformFetch` method that can be overridden or consumed via the `iOSLifecycle.PerformFetch` delegate. For more information, see [iOS and Mac Catalyst platform lifecycle events](~/fundamentals/app-lifecycle.md#ios-and-mac-catalyst).
 
 ## Type deprecation and removal
 


### PR DESCRIPTION
Today, I wanted to use platform-specific lifecycle events and I noticed that the page mentions only iOS and not Mac Catalyst. 

I have tried `FinishedLaunching` on a Mac Catalyst machine and it worked. So I assume it's the same on iOS and Mac Catalyst. But I'm not 100 per cent sure. Is it?

Still I find it worthy to improve the documentation page because it can save some time to people.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/app-lifecycle.md](https://github.com/dotnet/docs-maui/blob/dbac4a5e4b6d1cbb6adf771bc77f068587626d01/docs/fundamentals/app-lifecycle.md) | [App lifecycle](https://review.learn.microsoft.com/en-us/dotnet/maui/fundamentals/app-lifecycle?branch=pr-en-us-2359) |
| [docs/whats-new/dotnet-8.md](https://github.com/dotnet/docs-maui/blob/dbac4a5e4b6d1cbb6adf771bc77f068587626d01/docs/whats-new/dotnet-8.md) | [What's new in .NET MAUI for .NET 8](https://review.learn.microsoft.com/en-us/dotnet/maui/whats-new/dotnet-8?branch=pr-en-us-2359) |


<!-- PREVIEW-TABLE-END -->