### PR TITLE
Paragraph on Label linebreaks in a Grid

### DIFF
--- a/docs/migration/layouts.md
+++ b/docs/migration/layouts.md
@@ -1,7 +1,7 @@
 ---
 title: "Layout behavior changes from Xamarin.Forms"
 description: "Learn about the layout behavior changes between Xamarin.Forms and .NET MAUI."
-ms.date: 02/15/2023
+ms.date: 07/18/2024
 ---
 
 # Layout behavior changes from Xamarin.Forms
@@ -73,6 +73,8 @@ In Xamarin.Forms, despite not declaring that the <xref:Microsoft.Maui.Controls.G
 
 > [!IMPORTANT]
 > By default, .NET MAUI creates a <xref:Microsoft.Maui.Controls.Grid> with one column and one row. Therefore, it's not necessary to set the `ColumnDefinitions` and `RowDefinitions` properties if this is your intention.
+
+In Xamarin.Forms, when a `Label` is a column where the width of its `ColumnDefinition` is set to `Auto`, line breaks such as word wrap and tail truncation implicitly occur. In .NET MAUI, in this scenario line breaks don't implicitly occur because the column expands past the width of the screen to accommodate the child's content. If you want the <xref:Microsoft.Maui.Controls.Label> to wrap at the edge of the <xref:Microsoft.Maui.Controls.Grid> you should set the appropriate `ColumnDefinition` to either `*` or a value.
 
 ## StackLayout
 

--- a/docs/migration/layouts.md
+++ b/docs/migration/layouts.md
@@ -74,7 +74,7 @@ In Xamarin.Forms, despite not declaring that the <xref:Microsoft.Maui.Controls.G
 > [!IMPORTANT]
 > By default, .NET MAUI creates a <xref:Microsoft.Maui.Controls.Grid> with one column and one row. Therefore, it's not necessary to set the `ColumnDefinitions` and `RowDefinitions` properties if this is your intention.
 
-In Xamarin.Forms, when a `Label` is a column where the width of its `ColumnDefinition` is set to `Auto`, line breaks such as word wrap and tail truncation implicitly occur. In .NET MAUI, in this scenario line breaks don't implicitly occur because the column expands past the width of the screen to accommodate the child's content. If you want the <xref:Microsoft.Maui.Controls.Label> to wrap at the edge of the <xref:Microsoft.Maui.Controls.Grid> you should set the appropriate `ColumnDefinition` to either `*` or a value.
+In Xamarin.Forms, when a `Label` is in a column where the width of its `ColumnDefinition` is set to `Auto`, line breaks such as word wrap and tail truncation implicitly occur. In .NET MAUI, in this scenario line breaks don't implicitly occur because the column expands past the width of the screen to accommodate the child's content. If you want the <xref:Microsoft.Maui.Controls.Label> to wrap at the edge of the <xref:Microsoft.Maui.Controls.Grid> you should set the appropriate `ColumnDefinition` to either `*` or a value.
 
 ## StackLayout
 


### PR DESCRIPTION
Fixes #2164 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/migration/layouts.md](https://github.com/dotnet/docs-maui/blob/4a783dca1a7c06aa9e8f42b40aa107d653d409cc/docs/migration/layouts.md) | [Layout behavior changes from Xamarin.Forms](https://review.learn.microsoft.com/en-us/dotnet/maui/migration/layouts?branch=pr-en-us-2370) |


<!-- PREVIEW-TABLE-END -->