### PR TITLE
Update button.md

### DIFF
--- a/docs/user-interface/controls/button.md
+++ b/docs/user-interface/controls/button.md
@@ -282,7 +282,6 @@ The following XAML example shows how to define a visual state for the `Pressed` 
     <VisualStateManager.VisualStateGroups>
         <VisualStateGroup x:Name="CommonStates">
             <VisualState x:Name="PointerOver" />
-            <VisualState x:Name="Focused" />
             <VisualState x:Name="Normal">
                 <VisualState.Setters>
                     <Setter Property="Scale"
@@ -299,11 +298,11 @@ The following XAML example shows how to define a visual state for the `Pressed` 
     </VisualStateManager.VisualStateGroups>
 </Button>
 ```
-> [!IMPORTANT]
-> For a Button to return to its Normal state, the user has to define blank `Focused` and `PointerOver` state
-<xref:Microsoft.Maui.Controls.Button>must have its `IsEnabled` property set to `true` for it to respond to taps.
 
 In this example, the `Pressed` <xref:Microsoft.Maui.Controls.VisualState> specifies that when the <xref:Microsoft.Maui.Controls.Button> is pressed, its `Scale` property will be changed from its default value of 1 to 0.8. The `Normal` <xref:Microsoft.Maui.Controls.VisualState> specifies that when the <xref:Microsoft.Maui.Controls.Button> is in a normal state, its `Scale` property will be set to 1. Therefore, the overall effect is that when the <xref:Microsoft.Maui.Controls.Button> is pressed, it's rescaled to be slightly smaller, and when the <xref:Microsoft.Maui.Controls.Button> is released, it's rescaled to its default size.
+
+> [!IMPORTANT]
+> For a Button to return to its `Normal` state the `VisualStateGroup` must also define a `PointerOver` state. If you use the styles `ResourceDictionary` created by the .NET MAUI app project template, you'll already have an implicit `Button` style that defines the `PointerOver` state.
 
 For more information about visual states, see [Visual states](~/user-interface/visual-states.md).
 

--- a/docs/user-interface/controls/button.md
+++ b/docs/user-interface/controls/button.md
@@ -281,6 +281,8 @@ The following XAML example shows how to define a visual state for the `Pressed` 
         ...>
     <VisualStateManager.VisualStateGroups>
         <VisualStateGroup x:Name="CommonStates">
+            <VisualState x:Name="PointerOver" />
+            <VisualState x:Name="Focused" />
             <VisualState x:Name="Normal">
                 <VisualState.Setters>
                     <Setter Property="Scale"
@@ -297,6 +299,9 @@ The following XAML example shows how to define a visual state for the `Pressed` 
     </VisualStateManager.VisualStateGroups>
 </Button>
 ```
+> [!IMPORTANT]
+> For a Button to return to its Normal state, the user has to define blank `Focused` and `PointerOver` state
+<xref:Microsoft.Maui.Controls.Button>must have its `IsEnabled` property set to `true` for it to respond to taps.
 
 In this example, the `Pressed` <xref:Microsoft.Maui.Controls.VisualState> specifies that when the <xref:Microsoft.Maui.Controls.Button> is pressed, its `Scale` property will be changed from its default value of 1 to 0.8. The `Normal` <xref:Microsoft.Maui.Controls.VisualState> specifies that when the <xref:Microsoft.Maui.Controls.Button> is in a normal state, its `Scale` property will be set to 1. Therefore, the overall effect is that when the <xref:Microsoft.Maui.Controls.Button> is pressed, it's rescaled to be slightly smaller, and when the <xref:Microsoft.Maui.Controls.Button> is released, it's rescaled to its default size.
 

--- a/docs/user-interface/controls/button.md
+++ b/docs/user-interface/controls/button.md
@@ -281,7 +281,6 @@ The following XAML example shows how to define a visual state for the `Pressed` 
         ...>
     <VisualStateManager.VisualStateGroups>
         <VisualStateGroup x:Name="CommonStates">
-            <VisualState x:Name="PointerOver" />
             <VisualState x:Name="Normal">
                 <VisualState.Setters>
                     <Setter Property="Scale"
@@ -294,6 +293,7 @@ The following XAML example shows how to define a visual state for the `Pressed` 
                             Value="0.8" />
                 </VisualState.Setters>
             </VisualState>
+            <VisualState x:Name="PointerOver" />            
         </VisualStateGroup>
     </VisualStateManager.VisualStateGroups>
 </Button>
@@ -302,7 +302,7 @@ The following XAML example shows how to define a visual state for the `Pressed` 
 In this example, the `Pressed` <xref:Microsoft.Maui.Controls.VisualState> specifies that when the <xref:Microsoft.Maui.Controls.Button> is pressed, its `Scale` property will be changed from its default value of 1 to 0.8. The `Normal` <xref:Microsoft.Maui.Controls.VisualState> specifies that when the <xref:Microsoft.Maui.Controls.Button> is in a normal state, its `Scale` property will be set to 1. Therefore, the overall effect is that when the <xref:Microsoft.Maui.Controls.Button> is pressed, it's rescaled to be slightly smaller, and when the <xref:Microsoft.Maui.Controls.Button> is released, it's rescaled to its default size.
 
 > [!IMPORTANT]
-> For a Button to return to its `Normal` state the `VisualStateGroup` must also define a `PointerOver` state. If you use the styles `ResourceDictionary` created by the .NET MAUI app project template, you'll already have an implicit `Button` style that defines the `PointerOver` state.
+> For a <xref:Microsoft.Maui.Controls.Button> to return to its `Normal` state the `VisualStateGroup` must also define a `PointerOver` state. If you use the styles `ResourceDictionary` created by the .NET MAUI app project template, you'll already have an implicit `Button` style that defines the `PointerOver` state.
 
 For more information about visual states, see [Visual states](~/user-interface/visual-states.md).
 

--- a/docs/user-interface/controls/imagebutton.md
+++ b/docs/user-interface/controls/imagebutton.md
@@ -141,12 +141,16 @@ The following XAML example shows how to define a visual state for the `Pressed` 
                             Value="0.8" />
                 </VisualState.Setters>
             </VisualState>
+            <VisualState x:Name="PointerOver" />            
         </VisualStateGroup>
     </VisualStateManager.VisualStateGroups>
 </ImageButton>
 ```
 
 In this example, the `Pressed` <xref:Microsoft.Maui.Controls.VisualState> specifies that when the <xref:Microsoft.Maui.Controls.ImageButton> is pressed, its `Scale` property will be changed from its default value of 1 to 0.8. The `Normal` <xref:Microsoft.Maui.Controls.VisualState> specifies that when the <xref:Microsoft.Maui.Controls.ImageButton> is in a normal state, its `Scale` property will be set to 1. Therefore, the overall effect is that when the <xref:Microsoft.Maui.Controls.ImageButton> is pressed, it's rescaled to be slightly smaller, and when the <xref:Microsoft.Maui.Controls.ImageButton> is released, it's rescaled to its default size.
+
+> [!IMPORTANT]
+> For an <xref:Microsoft.Maui.Controls.ImageButton> to return to its `Normal` state the `VisualStateGroup` must also define a `PointerOver` state. If you use the styles `ResourceDictionary` created by the .NET MAUI app project template, you'll already have an implicit `ImageButton` style that defines the `PointerOver` state.
 
 For more information about visual states, see [Visual states](~/user-interface/visual-states.md).
 


### PR DESCRIPTION
For a button to return to its Normal state a user has to define a PointOver and/or Focused VisualState. This information is taken from https://github.com/dotnet/maui/pull/11842.

This not-fully-explained fragment of documentation could misguide new users like me

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/user-interface/controls/button.md](https://github.com/dotnet/docs-maui/blob/a87bd3b15f3b8af9269ae20e605f64108e519b7e/docs/user-interface/controls/button.md) | [Button](https://review.learn.microsoft.com/en-us/dotnet/maui/user-interface/controls/button?branch=pr-en-us-2387) |
| [docs/user-interface/controls/imagebutton.md](https://github.com/dotnet/docs-maui/blob/a87bd3b15f3b8af9269ae20e605f64108e519b7e/docs/user-interface/controls/imagebutton.md) | ["ImageButton"](https://review.learn.microsoft.com/en-us/dotnet/maui/user-interface/controls/imagebutton?branch=pr-en-us-2387) |


<!-- PREVIEW-TABLE-END -->

---
[Associated WorkItem - 293942](https://dev.azure.com/msft-skilling/Content/_workitems/edit/293942)