### PR TITLE
Update repoman config to latest version

### DIFF
--- a/.repoman.yml
+++ b/.repoman.yml
@@ -1,5 +1,5 @@
-revision: 1
-schema-version: 1
+revision: 2
+schema-version: 5
 owner-ms-alias: adegeo
 
 config:
@@ -9,29 +9,81 @@ config:
 
     ParserRegex: "^\\* (.*): (.*)$"
 
+    ContentUrlRegex:
+     - "### Page URL\n\n(.*)"
+
 issues:
 
   unlabeled: "labeled"
   
   labeled:
 
-    # Handle issues with /prod /tech labels from label bot
-    # Manages the Not Triaged label for issues missing/having an org category issue
+    # Temporary label to mark issues as updated for Quest. The label is instantly removed
     - check:
         - type: query
-          value: "length(Issue.labels[?contains(name, '/svc') || contains(name, '/subsvc')]) != `0`"
+          value: "length(Issue.Labels[?Name == ':world_map: mapQUEST']) != `0`"
+      pass:
+        - labels-remove: [":world_map: mapQUEST"]
+
+    # Handle issues with /svc /subsvc labels from label bot
+    - check:
+        - type: query
+          value: "length(Issue.Labels[?contains(Name, '/svc') || contains(Name, '/subsvc')]) != `0`"
+
+      # If the issue has a /svc or /subsvc label, it must be categorized otherwise it's considered untriaged
       pass:
         - check:
           - type: query
-            value: "length(Issue.labels[?name == 'doc-enhancement' || name == 'product-question' || name == 'in-progress' || name == 'test-issue' || name == 'kudos' || name == 'loc' || name == 'doc-bug' || name == 'product-feedback' || name == 'code-of-conduct' || name == 'support-request' || name == 'duplicate' || name == 'resolved-by-customer' || name == 'docs-experience' || name == 'doc-provided' || name == 'doc-idea' || name == 'needs-more-info']) != `0`"
+            value: "length(Issue.Labels[?Name == ':pushpin: seQUESTered' || Name == ':world_map: reQUEST' || Name == 'training-module' || Name == 'doc-enhancement' || Name == 'product-question' || Name == 'in-progress' || Name == 'test-issue' || Name == 'kudos' || Name == 'loc' || Name == 'doc-bug' || Name == 'product-feedback' || Name == 'code-of-conduct' || Name == 'support-request' || Name == 'duplicate' || Name == 'resolved-by-customer' || Name == 'docs-experience' || Name == 'doc-provided' || Name == 'doc-idea' || Name == 'needs-more-info']) != `0`"
           pass:
             - labels-remove: [":watch: Not Triaged"]
           fail:
             - labels-add: [":watch: Not Triaged"]
 
+      # Not an doc issue specifically
+      fail:
+
+        # If the issue is open, then we'll allow some further processing on it. If it's closed, ignore it and let the user do what they want.
+        - check:
+          - type: query
+            value: "Issue.State.StringValue == 'open'"
+
+          pass:
+            - check:
+              - type: query
+                value: "length(Issue.Labels[?Name == ':pushpin: seQUESTered' || Name == ':world_map: reQUEST' || Name == 'training-module' || Name == 'video-content'] || Name == 'test-issue') != `0`"
+              pass:
+                - labels-remove: [":watch: Not Triaged"]
+              fail:
+                - labels-add: [":watch: Not Triaged"]
+
   opened:
     # New issue opened, add Not Triaged  
     - labels-add: [":watch: Not Triaged"]
+
+    # Dependabot opened issue, label it
+    - check:
+        - type: query
+          value: "Issue.User.Login == 'dependabot'"
+      pass:
+        - labels-add: ["dependencies"]
+
+    # Try to detect an empty issue
+    - check:
+        - type: comment-body
+          value: "### Description[\\n\\r]+\\[Enter feedback here\\][\\n\\r]+###"
+      pass:
+        - labels-add: ["needs-more-info"]
+        - labels-remove: [":watch: Not Triaged"]
+        - close
+
+    # Add links to related issues if it's a doc issue
+    - check:
+        - type: metadata-exists
+        - type: variable-exists
+          name: "document_version_independent_id"
+      pass:
+        - link-related-issues
 
   reopened:
 
@@ -43,14 +95,19 @@ issues:
     # Issue closed, remove in-progress and not triaged labels
     - labels-remove: ["in-progress", ":watch: Not Triaged"]
 
-pull_request:
+    # Check if the issue was closed by the user who opened it
+    - check:
+        - type: query
+          value: "Issue.User.Id == EventPayload.sender.id"
+      pass:
+        - labels-add: ["resolved-by-customer"]
+        - labels-remove: [":watch: Not Triaged"]
 
-  reopened: opened
+projects_v2_item:
 
-  opened:
+  reordered:
 
-    # Set default sprint for new PRs
-    #- milestone-set: "![sprint]"
+    - labels-add: [":world_map: mapQUEST"]
 
 issue_comment:
 
@@ -59,7 +116,7 @@ issue_comment:
     # someone creates a comment with #please-review in it, add changes-addressed label
     - check:
         - type: query
-          value: "Issue.state == 'open' && Issue.user.id == Comment.user.id"
+          value: "Issue.State.StringValue == 'open' && Issue.User.Id == Comment.User.Id"
         - type: comment-body
           value: ^#please-review$
       pass:


### PR DESCRIPTION
**Can't merge until the old repoman webhook is turned off.**

This new config adds the following changes:

- Use regex to see if the details of the issue is still the default.

  This config setting is good at detecting spam. If someone comes in and only fills out a subject with no extra text, it will get closed. Let me know if you want me to remove this setting.

  This config takes the following actions when it detects the issue just has the default description text:

  - Add `needs-more-info` label.
  - Remove `not triaged` label.
  - Close the issue
 
- Turns on a new feature which adds a link to the bottom of the issue that is a search for issues related to the article.
- Support for moving issues related to project items around, and not having to manually add a label to the issue to get quest to pick up changed details.