### PR TITLE
Stand-alone RDs are XAML compiled in .NET 9

### DIFF
--- a/docs/fundamentals/resource-dictionaries.md
+++ b/docs/fundamentals/resource-dictionaries.md
@@ -1,7 +1,7 @@
 ---
 title: "Resource dictionaries"
 description: "Learn how .NET MAUI XAML resources dictionaries enable resources to be shared and reused throughout an app."
-ms.date: 04/21/2023
+ms.date: 09/25/2024
 ---
 
 # Resource dictionaries
@@ -126,7 +126,17 @@ When resources share keys, resources defined lower in the visual tree will take 
 
 ## Stand-alone resource dictionaries
 
+::: moniker range="=net-maui-8.0"
+
 A <xref:Microsoft.Maui.Controls.ResourceDictionary> can also be created as a stand-alone XAML file that isn't backed by a code-behind file. To create a stand-alone <xref:Microsoft.Maui.Controls.ResourceDictionary>, add a new <xref:Microsoft.Maui.Controls.ResourceDictionary> file to the project with the **.NET MAUI ResourceDictionary (XAML)** item template and delete its code-behind file. Then, in the XAML file remove the `x:Class` attribute from the <xref:Microsoft.Maui.Controls.ResourceDictionary> tag near the start of the file. In addition, add `<?xaml-comp compile="true" ?>` after the XML header to ensure that the XAML will be compiled.
+
+::: moniker-end
+
+::: moniker range=">=net-maui-9.0"
+
+A <xref:Microsoft.Maui.Controls.ResourceDictionary> can also be created as a stand-alone XAML file that isn't backed by a code-behind file. To create a stand-alone <xref:Microsoft.Maui.Controls.ResourceDictionary>, add a new <xref:Microsoft.Maui.Controls.ResourceDictionary> file to the project with the **.NET MAUI ResourceDictionary (XAML)** item template and delete its code-behind file. Then, in the XAML file remove the `x:Class` attribute from the <xref:Microsoft.Maui.Controls.ResourceDictionary> tag near the start of the file. By default, a stand-alone <xref:Microsoft.Maui.Controls.ResourceDictionary> has its XAML compiled, unless `<?xaml-comp compile="false" ?>` is specified after the XML header.
+
+::: moniker-end
 
 > [!NOTE]
 > A stand-alone <xref:Microsoft.Maui.Controls.ResourceDictionary> must have a build action of **MauiXaml**.
@@ -135,7 +145,6 @@ The following XAML example shows a stand-alone <xref:Microsoft.Maui.Controls.Res
 
 ```xaml
 <?xml version="1.0" encoding="UTF-8" ?>
-<?xaml-comp compile="true" ?>
 <ResourceDictionary xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
     <DataTemplate x:Key="PersonDataTemplate">

--- a/docs/whats-new/dotnet-9.md
+++ b/docs/whats-new/dotnet-9.md
@@ -330,6 +330,10 @@ The template can also be used from `dotnew new`:
 dotnet new maui-blazor-web -n AllTheTargets
 ```
 
+## Resource dictionaries
+
+In .NET MAUI 9, a stand-alone XAML <xref:Microsoft.Maui.Controls.ResourceDictionary> (which isn't backed by a code-behind file) defaults to having its XAML compiled. To opt out of this behavior, specify `<?xaml-comp compile="false" ?>` after the XML header.
+
 ## Xcode sync
 
 .NET MAUI 9 includes Xcode sync (`xcsync`), which is a tool that enables you to use Xcode for managing Apple specific files with .NET projects, including asset catalogs, plist files, storyboards, and xib files. The tool has two main commands to generate a temporary Xcode project from a .NET project, and to synchronize changes from the Xcode files back to your .NET project.

--- a/docs/whats-new/dotnet-9.md
+++ b/docs/whats-new/dotnet-9.md
@@ -133,7 +133,7 @@ The binding mode for `IsVisible` and `IsEnabled` on a `BackButtonBehavior` in a 
 
 ### BlazorWebView
 
-On iOS and Mac Catalyst 18, .NET MAUI 9 changes the default behavior for hosting content in a `BlazorWebView` to `localhost`. The internal `0.0.0.0` address used to host content no longer works and results in the `BlazorWebView` not loading any content and rendering as an empty rectangle.
+On iOS and Mac Catalyst 18, .NET MAUI 9 changes the default behavior for hosting content in a <xref:Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView> to `localhost`. The internal `0.0.0.0` address used to host content no longer works and results in the <xref:Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView> not loading any content and rendering as an empty rectangle.
 
 To opt into using the `0.0.0.0` address, add the following code to your `MauiProgram` class:
 
@@ -141,6 +141,14 @@ To opt into using the `0.0.0.0` address, add the following code to your `MauiPro
 // Set this switch to use the LEGACY behavior of always using 0.0.0.0 to host BlazorWebView
 AppContext.SetSwitch("BlazorWebView.AppHostAddressAlways0000", true);
 ```
+
+If you encounter hangs on Android with <xref:Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView> you should enable an <xref:System.AppContext> switch in the `CreateMauiApp` method in your `MauiProgram` class:
+
+```csharp
+AppContext.SetSwitch("BlazorWebView.AndroidFireAndForgetAsync", true);
+```
+
+This switch enables <xref:Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView> to fire and forget the async disposal that occurs, and as a result fixes the majority of the disposal deadlocks that occur on Android. For more information, see [Fix disposal deadlocks on Android](~/user-interface/controls/blazorwebview.md#fix-disposal-deadlocks-on-android).
 
 ### CollectionView and CarouselView
 


### PR DESCRIPTION
Fixes #2062 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/resource-dictionaries.md](https://github.com/dotnet/docs-maui/blob/4d124558805e7fabba623c05d9fdd419c9c5136d/docs/fundamentals/resource-dictionaries.md) | [docs/fundamentals/resource-dictionaries](https://review.learn.microsoft.com/en-us/dotnet/maui/fundamentals/resource-dictionaries?branch=pr-en-us-2520) |
| [docs/whats-new/dotnet-9.md](https://github.com/dotnet/docs-maui/blob/4d124558805e7fabba623c05d9fdd419c9c5136d/docs/whats-new/dotnet-9.md) | [docs/whats-new/dotnet-9](https://review.learn.microsoft.com/en-us/dotnet/maui/whats-new/dotnet-9?branch=pr-en-us-2520) |


<!-- PREVIEW-TABLE-END -->