### PR TITLE
Visual states examples need VisualStateGroupList for them to work properly

### DIFF
--- a/docs/user-interface/controls/button.md
+++ b/docs/user-interface/controls/button.md
@@ -294,7 +294,7 @@ The following XAML example shows how to define a visual state for the `Pressed` 
                                 Value="0.8" />
                     </VisualState.Setters>
                 </VisualState>
-            <VisualState x:Name="PointerOver" />            
+                <VisualState x:Name="PointerOver" />            
             </VisualStateGroup>
         </VisualStateGroupList>
     </VisualStateManager.VisualStateGroups>

--- a/docs/user-interface/controls/button.md
+++ b/docs/user-interface/controls/button.md
@@ -280,21 +280,23 @@ The following XAML example shows how to define a visual state for the `Pressed` 
 <Button Text="Click me!"
         ...>
     <VisualStateManager.VisualStateGroups>
-        <VisualStateGroup x:Name="CommonStates">
-            <VisualState x:Name="Normal">
-                <VisualState.Setters>
-                    <Setter Property="Scale"
-                            Value="1" />
-                </VisualState.Setters>
-            </VisualState>
-            <VisualState x:Name="Pressed">
-                <VisualState.Setters>
-                    <Setter Property="Scale"
-                            Value="0.8" />
-                </VisualState.Setters>
-            </VisualState>
+        <VisualStateGroupList>
+            <VisualStateGroup x:Name="CommonStates">
+                <VisualState x:Name="Normal">
+                    <VisualState.Setters>
+                        <Setter Property="Scale"
+                                Value="1" />
+                    </VisualState.Setters>
+                </VisualState>
+                <VisualState x:Name="Pressed">
+                    <VisualState.Setters>
+                        <Setter Property="Scale"
+                                Value="0.8" />
+                    </VisualState.Setters>
+                </VisualState>
             <VisualState x:Name="PointerOver" />            
-        </VisualStateGroup>
+            </VisualStateGroup>
+        </VisualStateGroupList>
     </VisualStateManager.VisualStateGroups>
 </Button>
 ```

--- a/docs/user-interface/visual-states.md
+++ b/docs/user-interface/visual-states.md
@@ -54,31 +54,33 @@ The following example shows visual states defined on an <xref:Microsoft.Maui.Con
 ```xaml
 <Entry FontSize="18">
     <VisualStateManager.VisualStateGroups>
-        <VisualStateGroup Name="CommonStates">
-            <VisualState Name="Normal">
-                <VisualState.Setters>
-                    <Setter Property="BackgroundColor" Value="Lime" />
-                </VisualState.Setters>
-            </VisualState>
+        <VisualStateGroupList>
+            <VisualStateGroup Name="CommonStates">
+                <VisualState Name="Normal">
+                    <VisualState.Setters>
+                        <Setter Property="BackgroundColor" Value="Lime" />
+                    </VisualState.Setters>
+                </VisualState>
 
-            <VisualState Name="Focused">
-                <VisualState.Setters>
-                    <Setter Property="FontSize" Value="36" />
-                </VisualState.Setters>
-            </VisualState>
+                <VisualState Name="Focused">
+                    <VisualState.Setters>
+                        <Setter Property="FontSize" Value="36" />
+                    </VisualState.Setters>
+                </VisualState>
 
-            <VisualState Name="Disabled">
-                <VisualState.Setters>
-                    <Setter Property="BackgroundColor" Value="Pink" />
-                </VisualState.Setters>
-            </VisualState>
+                <VisualState Name="Disabled">
+                    <VisualState.Setters>
+                        <Setter Property="BackgroundColor" Value="Pink" />
+                    </VisualState.Setters>
+                </VisualState>
 
-            <VisualState Name="PointerOver">
-                <VisualState.Setters>
-                    <Setter Property="BackgroundColor" Value="LightBlue" />
-                </VisualState.Setters>
-            </VisualState>
-        </VisualStateGroup>
+                <VisualState Name="PointerOver">
+                    <VisualState.Setters>
+                        <Setter Property="BackgroundColor" Value="LightBlue" />
+                    </VisualState.Setters>
+                </VisualState>
+            </VisualStateGroup>
+        </VisualStateGroupList>
     </VisualStateManager.VisualStateGroups>
 </Entry>
 ```


### PR DESCRIPTION
When trying the visual states documented examples for Button and Entry they threw an exception.
Details of the crash is described in this issue https://github.com/dotnet/maui/issues/25069

A simple solution would be to update the visual states' documented examples for Button and Entry to include VisualStateGroupList.

---
[Associated WorkItem - 320968](https://dev.azure.com/msft-skilling/Content/_workitems/edit/320968)