### PR TITLE
HideSoftInputOnTappedChanged is lit up on MacCat

### DIFF
--- a/docs/user-interface/pages/contentpage.md
+++ b/docs/user-interface/pages/contentpage.md
@@ -19,7 +19,7 @@ The .NET Multi-platform App UI (.NET MAUI) <xref:Microsoft.Maui.Controls.Content
 
 ::: moniker-end
 
-::: moniker range=">=net-maui-8.0"
+::: moniker range=">=net-maui-9.0"
 
 - <xref:Microsoft.Maui.Controls.ContentPage.Content> property, of type <xref:Microsoft.Maui.Controls.View>, which defines the view that represents the page's content.
 - <xref:Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped>, of type `bool`, which indicates whether tapping anywhere on the page will cause the soft input keyboard to hide if it's visible on Android, iOS, and Mac Catalyst.

--- a/docs/user-interface/pages/contentpage.md
+++ b/docs/user-interface/pages/contentpage.md
@@ -12,8 +12,19 @@ The .NET Multi-platform App UI (.NET MAUI) <xref:Microsoft.Maui.Controls.Content
 
 <xref:Microsoft.Maui.Controls.ContentPage> defines the following properties:
 
+::: moniker range="=net-maui-8.0"
+
 - <xref:Microsoft.Maui.Controls.ContentPage.Content> property, of type <xref:Microsoft.Maui.Controls.View>, which defines the view that represents the page's content.
-- <xref:Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped>, of type `bool`, which indicates whether tapping anywhere on the page will cause the soft input keyboard to hide if it's visible.
+- <xref:Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped>, of type `bool`, which indicates whether tapping anywhere on the page will cause the soft input keyboard to hide if it's visible on Android and iOS.
+
+::: moniker-end
+
+::: moniker range=">=net-maui-8.0"
+
+- <xref:Microsoft.Maui.Controls.ContentPage.Content> property, of type <xref:Microsoft.Maui.Controls.View>, which defines the view that represents the page's content.
+- <xref:Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped>, of type `bool`, which indicates whether tapping anywhere on the page will cause the soft input keyboard to hide if it's visible on Android, iOS, and Mac Catalyst.
+
+::: moniker-end
 
 These properties are backed by <xref:Microsoft.Maui.Controls.BindableProperty> objects, which means that they can be the target of data bindings, and styled.
 

--- a/docs/whats-new/dotnet-9.md
+++ b/docs/whats-new/dotnet-9.md
@@ -166,6 +166,10 @@ builder.ConfigureMauiHandlers(handlers =>
 #endif
 ```
 
+### ContentPage
+
+In .NET MAUI 9, the <xref:Microsoft.Maui.Controls.ContentPage.HideSoftInputOnTapped> property is also supported on Mac Catalyst, as well and Android and iOS.
+
 ### Label text alignment
 
 You can now horizontally align text in <xref:Microsoft.Maui.Controls.Label> objects with `HorizontalTextAlignment.Justify`:


### PR DESCRIPTION
Fixes #2265 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/user-interface/pages/contentpage.md](https://github.com/dotnet/docs-maui/blob/a9773910145c82ef4b5d872be5b7ab789c315d51/docs/user-interface/pages/contentpage.md) | [docs/user-interface/pages/contentpage](https://review.learn.microsoft.com/en-us/dotnet/maui/user-interface/pages/contentpage?branch=pr-en-us-2539) |
| [docs/whats-new/dotnet-9.md](https://github.com/dotnet/docs-maui/blob/a9773910145c82ef4b5d872be5b7ab789c315d51/docs/whats-new/dotnet-9.md) | [docs/whats-new/dotnet-9](https://review.learn.microsoft.com/en-us/dotnet/maui/whats-new/dotnet-9?branch=pr-en-us-2539) |


<!-- PREVIEW-TABLE-END -->