### PR TITLE
Loading XAML at runtime isn't trim safe

### DIFF
--- a/docs/whats-new/dotnet-9.md
+++ b/docs/whats-new/dotnet-9.md
@@ -361,7 +361,7 @@ When disconnecting, the `DisconnectHandlers` method will propagate down the cont
 
 ## Load XAML at runtime
 
-Loading XAML at runtime isn't trim safe and shouldn't be used with full trimming or NativeAOT. It can be made trim safe by annotating all types that could be loaded with the [`DynamicallyAccessedMembers`](xref:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute) attribute or the [`DynamicDependency`](xref:System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute) attribute. However, this is very error prone and isn't recommended.
+Loading XAML at runtime isn't trim safe and shouldn't be used with full trimming or NativeAOT. It can be made trim safe by annotating all types that could be loaded at runtime with the [`DynamicallyAccessedMembers`](xref:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute) attribute or the [`DynamicDependency`](xref:System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute) attribute. However, this is very error prone and isn't recommended.
 
 ## Multi-window support
 

--- a/docs/whats-new/dotnet-9.md
+++ b/docs/whats-new/dotnet-9.md
@@ -359,6 +359,10 @@ video.DisconnectHandlers();
 
 When disconnecting, the `DisconnectHandlers` method will propagate down the control tree until it completes or arrives at a control that has set a manual policy.
 
+## Load XAML at runtime
+
+Loading XAML at runtime isn't trim safe, and requires annotating all types that could be loaded using the [`DynamicallyAccessedMembers`](xref:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute) attribute or the [`DynamicDependency`](xref:System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute) attribute. This is very error prone, and so it isn't recommended to use runtime XAML parsing with full trimming or NativeAOT.
+
 ## Multi-window support
 
 .NET MAUI 9 adds the ability to bring a specific window to the front on Mac Catalyst and Windows with the `Application.Current.ActivateWindow` method:
@@ -439,7 +443,7 @@ Several areas of .NET MAUI come with trimmer directives, known as feature switch
 
 To consume a feature switch you should put the corresponding MSBuild property into your app's project file (*.csproj), which causes the related code to be trimmed from the .NET MAUI assemblies. Disabling features an app doesn't require can help reduce the app size when combined with the `Full` trimming mode.
 
-## XAML
+## XAML markup extensions
 
 All classes that implement <xref:Microsoft.Maui.Controls.Xaml.IMarkupExtension>, <xref:Microsoft.Maui.Controls.Xaml.IMarkupExtension`1>, <xref:Microsoft.Maui.Controls.Xaml.IValueProvider>, and <xref:Microsoft.Maui.Controls.IExtendedTypeConverter> need to be annotated with either the <xref:Microsoft.Maui.Controls.Xaml.RequireServiceAttribute> or <xref:Microsoft.Maui.Controls.Xaml.AcceptEmptyServiceProviderAttribute>. This is required due to a XAML compiler optimization introduced in .NET MAUI 9 that enables the generation of more efficient code, which helps reduce the app size and improve runtime performance.
 

--- a/docs/whats-new/dotnet-9.md
+++ b/docs/whats-new/dotnet-9.md
@@ -361,7 +361,7 @@ When disconnecting, the `DisconnectHandlers` method will propagate down the cont
 
 ## Load XAML at runtime
 
-Loading XAML at runtime isn't trim safe, and requires annotating all types that could be loaded using the [`DynamicallyAccessedMembers`](xref:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute) attribute or the [`DynamicDependency`](xref:System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute) attribute. This is very error prone, and so it isn't recommended to use runtime XAML parsing with full trimming or NativeAOT.
+Loading XAML at runtime isn't trim safe and shouldn't be used with full trimming or NativeAOT. It can be made trim safe by annotating all types that could be loaded with the [`DynamicallyAccessedMembers`](xref:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute) attribute or the [`DynamicDependency`](xref:System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute) attribute. However, this is very error prone and isn't recommended.
 
 ## Multi-window support
 

--- a/docs/xaml/runtime-load.md
+++ b/docs/xaml/runtime-load.md
@@ -35,7 +35,7 @@ The `InitializeComponent` method calls the <xref:Microsoft.Maui.Controls.Xaml.Ex
 The `Extensions` class, in the `Microsoft.Maui.Controls.Xaml` namespace, includes <xref:Microsoft.Maui.Controls.Xaml.Extensions.LoadFromXaml%2A> extension methods that can be used to load and parse XAML at runtime. The <xref:Microsoft.Maui.Controls.Xaml.Extensions.LoadFromXaml%2A> methods are `public`, and therefore can be called from .NET MAUI applications to load, and parse XAML at runtime. This enables scenarios such as an app downloading XAML from a web service, creating the required view from the XAML, and displaying it in the app.
 
 > [!WARNING]
-> Loading XAML at runtime isn't trim safe, and requires annotating all types that could be loaded using the [`DynamicallyAccessedMembers`](xref:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute) attribute or the [`DynamicDependency`](xref:System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute) attribute. This is very error prone, and so it isn't recommended to use runtime XAML parsing with full trimming or NativeAOT. In addition, loading XAML at runtime has a significant performance cost.
+> Loading XAML at runtime isn't trim safe and shouldn't be used with full trimming or NativeAOT. It can be made trim safe by annotating all types that could be loaded with the [`DynamicallyAccessedMembers`](xref:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute) attribute or the [`DynamicDependency`](xref:System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute) attribute. However, this is very error prone and isn't recommended. In addition, loading XAML at runtime has a significant performance cost.
 
 The following code example shows a simple usage:
 

--- a/docs/xaml/runtime-load.md
+++ b/docs/xaml/runtime-load.md
@@ -34,8 +34,19 @@ The `InitializeComponent` method calls the <xref:Microsoft.Maui.Controls.Xaml.Ex
 
 The `Extensions` class, in the `Microsoft.Maui.Controls.Xaml` namespace, includes <xref:Microsoft.Maui.Controls.Xaml.Extensions.LoadFromXaml%2A> extension methods that can be used to load and parse XAML at runtime. The <xref:Microsoft.Maui.Controls.Xaml.Extensions.LoadFromXaml%2A> methods are `public`, and therefore can be called from .NET MAUI applications to load, and parse XAML at runtime. This enables scenarios such as an app downloading XAML from a web service, creating the required view from the XAML, and displaying it in the app.
 
+::: moniker range="=net-maui-8.0"
+
+> [!WARNING]
+> Loading XAML at runtime has a significant performance cost, and generally should be avoided.
+
+::: moniker-end
+
+::: moniker range=">=net-maui-9.0"
+
 > [!WARNING]
 > Loading XAML at runtime isn't trim safe and shouldn't be used with full trimming or NativeAOT. It can be made trim safe by annotating all types that could be loaded with the [`DynamicallyAccessedMembers`](xref:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute) attribute or the [`DynamicDependency`](xref:System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute) attribute. However, this is very error prone and isn't recommended. In addition, loading XAML at runtime has a significant performance cost.
+
+::: moniker-end
 
 The following code example shows a simple usage:
 

--- a/docs/xaml/runtime-load.md
+++ b/docs/xaml/runtime-load.md
@@ -1,7 +1,7 @@
 ---
 title: "Load XAML at runtime"
 description: "In .NET MAUI, XAML can be loaded and parsed at runtime with the LoadFromXaml extension methods."
-ms.date: 01/26/2022
+ms.date: 10/08/2024
 ---
 
 # Load XAML at runtime
@@ -18,7 +18,7 @@ public partial class MainPage : ContentPage
 }
 ```
 
-When Visual Studio builds a project containing a XAML file, a source generator generates new C# source that contains the definition of the `InitializeComponent` method and adds it to the compilation object. The following example shows the generated `InitializeComponent` method for the `MainPage` class:
+When a project containing a XAML file is built, a source generator generates new C# source that contains the definition of the `InitializeComponent` method and adds it to the compilation object. The following example shows the generated `InitializeComponent` method for the `MainPage` class:
 
 ```csharp
 private void InitializeComponent()
@@ -35,7 +35,7 @@ The `InitializeComponent` method calls the <xref:Microsoft.Maui.Controls.Xaml.Ex
 The `Extensions` class, in the `Microsoft.Maui.Controls.Xaml` namespace, includes <xref:Microsoft.Maui.Controls.Xaml.Extensions.LoadFromXaml%2A> extension methods that can be used to load and parse XAML at runtime. The <xref:Microsoft.Maui.Controls.Xaml.Extensions.LoadFromXaml%2A> methods are `public`, and therefore can be called from .NET MAUI applications to load, and parse XAML at runtime. This enables scenarios such as an app downloading XAML from a web service, creating the required view from the XAML, and displaying it in the app.
 
 > [!WARNING]
-> Loading XAML at runtime has a significant performance cost, and generally should be avoided.
+> Loading XAML at runtime isn't trim safe, and requires annotating all types that could be loaded using the [`DynamicallyAccessedMembers`](xref:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute) attribute or the [`DynamicDependency`](xref:System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute) attribute. This is very error prone, and so it isn't recommended to use runtime XAML parsing with full trimming or NativeAOT. In addition, loading XAML at runtime has a significant performance cost.
 
 The following code example shows a simple usage:
 

--- a/docs/xaml/runtime-load.md
+++ b/docs/xaml/runtime-load.md
@@ -44,7 +44,7 @@ The `Extensions` class, in the `Microsoft.Maui.Controls.Xaml` namespace, include
 ::: moniker range=">=net-maui-9.0"
 
 > [!WARNING]
-> Loading XAML at runtime isn't trim safe and shouldn't be used with full trimming or NativeAOT. It can be made trim safe by annotating all types that could be loaded with the [`DynamicallyAccessedMembers`](xref:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute) attribute or the [`DynamicDependency`](xref:System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute) attribute. However, this is very error prone and isn't recommended. In addition, loading XAML at runtime has a significant performance cost.
+> Loading XAML at runtime isn't trim safe and shouldn't be used with full trimming or NativeAOT. It can be made trim safe by annotating all types that could be loaded at runtime with the [`DynamicallyAccessedMembers`](xref:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute) attribute or the [`DynamicDependency`](xref:System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute) attribute. However, this is very error prone and isn't recommended. In addition, loading XAML at runtime has a significant performance cost.
 
 ::: moniker-end
 


### PR DESCRIPTION
Fixes #2547 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/whats-new/dotnet-9.md](https://github.com/dotnet/docs-maui/blob/68b959ed3f0cefedca22d479d96f95a81bb12f7d/docs/whats-new/dotnet-9.md) | [docs/whats-new/dotnet-9](https://review.learn.microsoft.com/en-us/dotnet/maui/whats-new/dotnet-9?branch=pr-en-us-2552) |
| [docs/xaml/runtime-load.md](https://github.com/dotnet/docs-maui/blob/68b959ed3f0cefedca22d479d96f95a81bb12f7d/docs/xaml/runtime-load.md) | [docs/xaml/runtime-load](https://review.learn.microsoft.com/en-us/dotnet/maui/xaml/runtime-load?branch=pr-en-us-2552) |


<!-- PREVIEW-TABLE-END -->