### PR TITLE
Fix docs about "LLVM Marshal Methods"

### DIFF
--- a/docs/whats-new/dotnet-9.md
+++ b/docs/whats-new/dotnet-9.md
@@ -545,18 +545,19 @@ For more information about Android asset packs, see [Android asset packs](~/andr
 <TargetFramework>net9.0-android35</TargetFramework>
 ```
 
-### LLVM marshalled methods
+### LLVM Marshal Methods
 
-Low-level Virtual Machine (LLVM) marshalled methods are now enabled by default in .NET for Android 9 in non-Blazor apps. This has resulted in a [~10% improvement in performance in a test app](https://github.com/xamarin/xamarin-android/pull/8925).
+Improvements to Low-level Virtual Machine (LLVM) Marshal Methods in .NET 9, has made the feature work more reliably in applications but is not yet the default. Enabling this feature has resulted in a [~10% improvement in performance in a test app](https://github.com/dotnet/android/commit/a9706b6ef0429250ecaf1e500d77cd19e94e2eb5).
 
-LLVM marshalled methods can be disabled in your project file (*.csproj*):
+LLVM Marshal Methods can be enabled in your project file (*.csproj*) via the `$(AndroidEnableMarshalMethods)` property:
 
 ```xml
-<PropertyGroup Condition="'$(TargetFramework)' == 'net9.0-android'">
-    <AndroidEnableLLVM>false</AndroidEnableLLVM>
-    <AndroidEnableLLVMOptimizations>false</AndroidEnableLLVMOptimizations>
+<PropertyGroup>
+    <AndroidEnableMarshalMethods>true</AndroidEnableMarshalMethods>
 </PropertyGroup>
 ```
+
+For specific details about the feature, see the [implementation on GitHub](https://github.com/dotnet/android/commit/8bc7a3e84f95e70fe12790ac31ecd97957771cb2).
 
 ### Trimming enhancements
 


### PR DESCRIPTION
It appears this section might have been AI generated, as it appeared to contain "hallucinated" MSBuild property names. It also didn't make sense that the example set things to `false`. I updated the section as appropriate.

We also have made the feature non-default in:

* https://github.com/dotnet/android/pull/9336

I also linked to GitHub commits, as we have more detailed text inside, generally, than pull requests.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/whats-new/dotnet-9.md](https://github.com/dotnet/docs-maui/blob/05fffb8560d7eaf5f0bd8ddb56cc83b3c99b9512/docs/whats-new/dotnet-9.md) | [docs/whats-new/dotnet-9](https://review.learn.microsoft.com/en-us/dotnet/maui/whats-new/dotnet-9?branch=pr-en-us-2566) |

<!-- PREVIEW-TABLE-END -->