### PR TITLE
[android] what's new in .NET 9 revamp

### DIFF
--- a/docs/whats-new/dotnet-9.md
+++ b/docs/whats-new/dotnet-9.md
@@ -572,11 +572,11 @@ Or in a multi-targeted project:
 <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">android-arm;android-arm64;android-x86;android-x64</RuntimeIdentifiers>
 ```
 
-### LLVM Marshal Methods
+### Android Marshal Methods
 
-Improvements to Low-level Virtual Machine (LLVM) Marshal Methods in .NET 9, has made the feature work more reliably in applications but is not yet the default. Enabling this feature has resulted in a [~10% improvement in performance in a test app](https://github.com/dotnet/android/commit/a9706b6ef0429250ecaf1e500d77cd19e94e2eb5).
+Improvements to Android Marshal Methods in .NET 9, has made the feature work more reliably in applications but is not yet the default. Enabling this feature has resulted in a [~10% improvement in performance in a test app](https://github.com/dotnet/android/commit/a9706b6ef0429250ecaf1e500d77cd19e94e2eb5).
 
-LLVM Marshal Methods can be enabled in your project file (*.csproj*) via the `$(AndroidEnableMarshalMethods)` property:
+Android Marshal Methods can be enabled in your project file (*.csproj*) via the `$(AndroidEnableMarshalMethods)` property:
 
 ```xml
 <PropertyGroup>
@@ -584,7 +584,7 @@ LLVM Marshal Methods can be enabled in your project file (*.csproj*) via the `$(
 </PropertyGroup>
 ```
 
-For specific details about the feature, see the [implementation on GitHub](https://github.com/dotnet/android/commit/8bc7a3e84f95e70fe12790ac31ecd97957771cb2).
+For specific details about the feature, see the [feature documentation](https://github.com/dotnet/android/blob/main/Documentation/guides/internals/JavaJNI_Interop.md#marshal-methods) or [implementation](https://github.com/dotnet/android/commit/8bc7a3e84f95e70fe12790ac31ecd97957771cb2) on GitHub.
 
 ### Trimming enhancements
 

--- a/docs/whats-new/dotnet-9.md
+++ b/docs/whats-new/dotnet-9.md
@@ -490,7 +490,7 @@ In addition, the `Microsoft.Maui.SizeRequest` struct is obsoleted. Instead, `Mic
 
 ## .NET for Android
 
-.NET for Android 9, which adds support for API 35, includes work to reduce build times, and to improve the trimability of apps to reduce size and improve performance. For more information about .NET for Android 9, see the following release notes:
+.NET for Android in .NET 9, which adds support for API 35, includes work to reduce build times, and to improve the trimability of apps to reduce size and improve performance. For more information about .NET for Android in .NET 9, see the following release notes:
 
 - [.NET for Android 9 RC2](https://github.com/dotnet/android/releases/tag/35.0.0-rc.2.152)
 - [.NET for Android 9 RC1](https://github.com/dotnet/android/releases/tag/35.0.0-rc.1.80)
@@ -504,7 +504,7 @@ In addition, the `Microsoft.Maui.SizeRequest` struct is obsoleted. Instead, `Mic
 
 ### Asset packs
 
-.NET for Android 9 introduces the ability to place assets into a separate package, known as an *asset pack*. This enables you to upload games and apps that would normally be larger than the basic package size allowed by Google Play. By putting these assets into a separate package you gain the ability to upload a package which is up to 2Gb in size, rather than the basic package size of 200Mb.
+.NET for Android in .NET 9 introduces the ability to place assets into a separate package, known as an *asset pack*. This enables you to upload games and apps that would normally be larger than the basic package size allowed by Google Play. By putting these assets into a separate package you gain the ability to upload a package which is up to 2Gb in size, rather than the basic package size of 200Mb.
 
 > [!IMPORTANT]
 > Asset packs can only contain assets. In the case of .NET for Android this means items that have the `AndroidAsset` build action.
@@ -543,10 +543,33 @@ For more information about Android asset packs, see [Android asset packs](~/andr
 
 ### Android 15 support
 
-.NET for Android 9 adds .NET bindings for Android 15 (API 35). To build for these APIs, update the target framework of your project:
+.NET for Android in .NET 9 adds .NET bindings for Android 15 (API 35). To build for these APIs, update the target framework of your project to `net9.0`:
 
 ```xml
-<TargetFramework>net9.0-android35</TargetFramework>
+<TargetFramework>net9.0-android</TargetFramework>
+```
+
+You can also specify `net9.0-android35` as a target framework, but the number `35` will likely change in future .NET releases to match newer Android OS releases.
+
+### 64-bit Architectures by Default
+
+.NET for Android in .NET 9 no longer builds the following runtime identifiers (RIDs) by default:
+
+* `android-arm`
+* `android-x86`
+
+This should improve build times and reduce the size of Android `.apk` files. Note that Google Play supports splitting up app bundles per architecture.
+
+If you need to build for these architectures, you can add them to your project file (*.csproj*):
+
+```xml
+<RuntimeIdentifiers>android-arm;android-arm64;android-x86;android-x64</RuntimeIdentifiers>
+```
+
+Or in a multi-targeted project:
+
+```xml
+<RuntimeIdentifiers Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">android-arm;android-arm64;android-x86;android-x64</RuntimeIdentifiers>
 ```
 
 ### LLVM Marshal Methods
@@ -565,13 +588,17 @@ For specific details about the feature, see the [implementation on GitHub](https
 
 ### Trimming enhancements
 
-.NET for Android 9 includes fixes for when using full trimming to reduce app size. Full trimming is usually only enabled for release builds of your app, and can be configured in your project file (*.csproj*):
+In .NET 9, the Android API assemblies (`Mono.Android.dll`, `Java.Interop.dll`) are now fully trim-compatible. To opt into full trimming, set the `TrimMode` property in your project file (*.csproj*):
 
 ```xml
-<PropertyGroup Condition="'$(Configuration)' == 'Release' And '$(TargetFramework)' == 'net9.0-android'">
+<PropertyGroup>
     <TrimMode>Full</TrimMode>
 </PropertyGroup>
 ```
+
+This also enables trimming analyzers, so that warnings are introduced for any problematic C# code.
+
+See the [documentation on trimming granularity](https://learn.microsoft.com/dotnet/core/deploying/trimming/trimming-options#trimming-granularity) for more information.
 
 ## .NET for iOS
 
@@ -607,12 +634,28 @@ This will produce two libraries, one using iOS 17.0 bindings, and one using iOS 
 > [!IMPORTANT]
 > An app project should always target the latest iOS SDK.
 
+### Trimming enhancements
+
+In .NET 9, the `Microsoft.iOS.dll`, `Microsoft.MacCatalyst.dll`, etc. assemblies are now fully trim-compatible. To opt into full trimming, set the `TrimMode` property in your project file (*.csproj*):
+
+```xml
+<PropertyGroup>
+    <TrimMode>Full</TrimMode>
+</PropertyGroup>
+```
+
+This also enables trimming analyzers, so that warnings are introduced for any problematic C# code.
+
+See the [documentation on trimming granularity](https://learn.microsoft.com/dotnet/core/deploying/trimming/trimming-options#trimming-granularity) for more information.
+
 ### Native AOT for iOS & Mac Catalyst
 
-In .NET for iOS 9, native Ahead of Time (AOT) compilation for iOS and Mac Catalyst takes advantage of full trimming to reduce your app's package size and startup performance. This is a publishing feature that you can use when you're ready to ship your app.
+In .NET for iOS 9, native Ahead of Time (AOT) compilation for iOS and Mac Catalyst takes advantage of full trimming to reduce your app's package size and startup performance. NativeAOT builds upon full trimming, by also opting into a new runtime.
 
 > [!IMPORTANT]
 > Your app and it's dependencies must be fully trimmable in order to utilize this feature.
+
+NativeAOT requires applications to be built with zero trimmer warnings, in order to prove the application will work correctly at runtime.
 
 ## See also
 

--- a/docs/whats-new/dotnet-9.md
+++ b/docs/whats-new/dotnet-9.md
@@ -543,15 +543,16 @@ For more information about Android asset packs, see [Android asset packs](~/andr
 
 ### Android 15 support
 
-.NET for Android in .NET 9 adds .NET bindings for Android 15 (API 35). To build for these APIs, update the target framework of your project to `net9.0`:
+.NET for Android in .NET 9 adds .NET bindings for Android 15 (API 35). To build for these APIs, update the target framework of your project to `net9.0-android`:
 
 ```xml
 <TargetFramework>net9.0-android</TargetFramework>
 ```
 
-You can also specify `net9.0-android35` as a target framework, but the number `35` will likely change in future .NET releases to match newer Android OS releases.
+> [!NOTE]
+> You can also specify `net9.0-android35` as a target framework, but the number 35 will probably change in future .NET releases to match newer Android OS releases.
 
-### 64-bit Architectures by Default
+### 64-bit architectures by default
 
 .NET for Android in .NET 9 no longer builds the following runtime identifiers (RIDs) by default:
 
@@ -572,11 +573,11 @@ Or in a multi-targeted project:
 <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">android-arm;android-arm64;android-x86;android-x64</RuntimeIdentifiers>
 ```
 
-### Android Marshal Methods
+### Android marshal methods
 
-Improvements to Android Marshal Methods in .NET 9, has made the feature work more reliably in applications but is not yet the default. Enabling this feature has resulted in a [~10% improvement in performance in a test app](https://github.com/dotnet/android/commit/a9706b6ef0429250ecaf1e500d77cd19e94e2eb5).
+Improvements to Android marshal methods in .NET 9 has made the feature work more reliably in applications but is not yet the default. Enabling this feature has resulted in a [~10% improvement in performance in a test app](https://github.com/dotnet/android/commit/a9706b6ef0429250ecaf1e500d77cd19e94e2eb5).
 
-Android Marshal Methods can be enabled in your project file (*.csproj*) via the `$(AndroidEnableMarshalMethods)` property:
+Android marshal methods can be enabled in your project file (*.csproj*) via the `$(AndroidEnableMarshalMethods)` property:
 
 ```xml
 <PropertyGroup>
@@ -588,7 +589,7 @@ For specific details about the feature, see the [feature documentation](https://
 
 ### Trimming enhancements
 
-In .NET 9, the Android API assemblies (`Mono.Android.dll`, `Java.Interop.dll`) are now fully trim-compatible. To opt into full trimming, set the `TrimMode` property in your project file (*.csproj*):
+In .NET 9, the Android API assemblies (*Mono.Android.dll*, *Java.Interop.dll*) are now fully trim-compatible. To opt into full trimming, set the `$(TrimMode)` property in your project file (*.csproj*):
 
 ```xml
 <PropertyGroup>
@@ -598,7 +599,7 @@ In .NET 9, the Android API assemblies (`Mono.Android.dll`, `Java.Interop.dll`) a
 
 This also enables trimming analyzers, so that warnings are introduced for any problematic C# code.
 
-See the [documentation on trimming granularity](https://learn.microsoft.com/dotnet/core/deploying/trimming/trimming-options#trimming-granularity) for more information.
+For more information, see [Trimming granularity](/dotnet/core/deploying/trimming/trimming-options#trimming-granularity).
 
 ## .NET for iOS
 
@@ -636,7 +637,7 @@ This will produce two libraries, one using iOS 17.0 bindings, and one using iOS 
 
 ### Trimming enhancements
 
-In .NET 9, the `Microsoft.iOS.dll`, `Microsoft.MacCatalyst.dll`, etc. assemblies are now fully trim-compatible. To opt into full trimming, set the `TrimMode` property in your project file (*.csproj*):
+In .NET 9, the iOS and Mac Catalyst assemblies (*Microsoft.iOS.dll*, *Microsoft.MacCatalyst.dll* etc.) are now fully trim-compatible. To opt into full trimming, set the `$(TrimMode)` property in your project file (*.csproj*):
 
 ```xml
 <PropertyGroup>
@@ -646,7 +647,7 @@ In .NET 9, the `Microsoft.iOS.dll`, `Microsoft.MacCatalyst.dll`, etc. assemblies
 
 This also enables trimming analyzers, so that warnings are introduced for any problematic C# code.
 
-See the [documentation on trimming granularity](https://learn.microsoft.com/dotnet/core/deploying/trimming/trimming-options#trimming-granularity) for more information.
+For more information, see [Trimming granularity](/dotnet/core/deploying/trimming/trimming-options#trimming-granularity).
 
 ### Native AOT for iOS & Mac Catalyst
 


### PR DESCRIPTION
I went through and cleaned up this doc a bit, to make sure we have the latest information.

* Rename `.NET for Android 9` to `.NET for Android in .NET 9`, as suggested by @davidortinau. There is a bulleted list of releases that I left alone, that seemed OK.

* Don't suggest `net9.0-android35` for API 35, just use `net9.0-android`.

* Mention the removal of 32-bit architectures. This is just important to be in here.

* Mention `TrimMode=full` for both iOS and Android. We solved all the trimming warnings for `Mono.Android.dll`, `Java.Interop.dll`, `Microsoft.iOS.dll`, etc.

* Mention NativeAOT expands upon trimming, and you need 0 trimming warnings.

* Remove any mention of LLVM, it is simply "Android Marshal Methods", link to additional doc.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/whats-new/dotnet-9.md](https://github.com/dotnet/docs-maui/blob/fa940e95ce3447331966a9dad42c4b9c93200977/docs/whats-new/dotnet-9.md) | [docs/whats-new/dotnet-9](https://review.learn.microsoft.com/en-us/dotnet/maui/whats-new/dotnet-9?branch=pr-en-us-2570) |


<!-- PREVIEW-TABLE-END -->