### PR TITLE
Storage permissions on API33+ always return granted

### DIFF
--- a/docs/platform-integration/appmodel/permissions.md
+++ b/docs/platform-integration/appmodel/permissions.md
@@ -45,10 +45,10 @@ The following table uses ✔️ to indicate that the permission is supported and
 | [StorageWrite](xref:Microsoft.Maui.ApplicationModel.Permissions.StorageWrite)           | ✔️     | ❌   | ❌      | ❌    |
 | [Vibrate](xref:Microsoft.Maui.ApplicationModel.Permissions.Vibrate)                     | ✔️     | ❌   | ❌      | ❌    |
 
-If a permission is marked as ❌, it will always return <xref:Microsoft.Maui.ApplicationModel.PermissionStatus.Granted> when checked or requested.
-
 > [!IMPORTANT]
 > The [StorageRead](xref:Microsoft.Maui.ApplicationModel.Permissions.StorageRead) and [StorageWrite](xref:Microsoft.Maui.ApplicationModel.Permissions.StorageWrite) permissions will always return <xref:Microsoft.Maui.ApplicationModel.PermissionStatus.Granted> on Android API 33+. This is because the underlying Android `READ_EXTERNAL_STORAGE` and `WRITE_EXTERNAL_STORAGE` permissions are no longer available from API 33.
+
+If a permission is marked as ❌, it will always return <xref:Microsoft.Maui.ApplicationModel.PermissionStatus.Granted> when checked or requested.
 
 ## Checking permissions
 

--- a/docs/platform-integration/appmodel/permissions.md
+++ b/docs/platform-integration/appmodel/permissions.md
@@ -1,7 +1,7 @@
 ---
 title: "Permissions"
 description: "Learn how to use the .NET MAUI Permissions class, to check and request permissions. This class is in the Microsoft.Maui.ApplicationModel namespace."
-ms.date: 08/07/2024
+ms.date: 10/28/2024
 no-loc: ["Microsoft.Maui", "Microsoft.Maui.ApplicationModel"]
 ---
 
@@ -46,6 +46,9 @@ The following table uses ✔️ to indicate that the permission is supported and
 | [Vibrate](xref:Microsoft.Maui.ApplicationModel.Permissions.Vibrate)                     | ✔️     | ❌   | ❌      | ❌    |
 
 If a permission is marked as ❌, it will always return <xref:Microsoft.Maui.ApplicationModel.PermissionStatus.Granted> when checked or requested.
+
+> [!IMPORTANT]
+> The <xref:Microsoft.Maui.ApplicationModel.Permissions.StorageRead> and <xref:Microsoft.Maui.ApplicationModel.Permissions.StorageWrite> permissions will always return <xref:Microsoft.Maui.ApplicationModel.PermissionStatus.Granted> on Android API 33+. This is because the underlying Android `READ_EXTERNAL_STORAGE` and `.WRITE_EXTERNAL_STORAGE` permissions are no longer available from API 33.
 
 ## Checking permissions
 

--- a/docs/platform-integration/appmodel/permissions.md
+++ b/docs/platform-integration/appmodel/permissions.md
@@ -48,7 +48,7 @@ The following table uses ✔️ to indicate that the permission is supported and
 If a permission is marked as ❌, it will always return <xref:Microsoft.Maui.ApplicationModel.PermissionStatus.Granted> when checked or requested.
 
 > [!IMPORTANT]
-> The <xref:Microsoft.Maui.ApplicationModel.Permissions.StorageRead> and <xref:Microsoft.Maui.ApplicationModel.Permissions.StorageWrite> permissions will always return <xref:Microsoft.Maui.ApplicationModel.PermissionStatus.Granted> on Android API 33+. This is because the underlying Android `READ_EXTERNAL_STORAGE` and `.WRITE_EXTERNAL_STORAGE` permissions are no longer available from API 33.
+> The [StorageRead](xref:Microsoft.Maui.ApplicationModel.Permissions.StorageRead) and [StorageWrite](xref:Microsoft.Maui.ApplicationModel.Permissions.StorageWrite) permissions will always return <xref:Microsoft.Maui.ApplicationModel.PermissionStatus.Granted> on Android API 33+. This is because the underlying Android `READ_EXTERNAL_STORAGE` and `WRITE_EXTERNAL_STORAGE` permissions are no longer available from API 33.
 
 ## Checking permissions
 


### PR DESCRIPTION
Fixes #2562 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/platform-integration/appmodel/permissions.md](https://github.com/dotnet/docs-maui/blob/99afda3c51a99f87faabaac7da11c4f58b7c21d4/docs/platform-integration/appmodel/permissions.md) | [docs/platform-integration/appmodel/permissions](https://review.learn.microsoft.com/en-us/dotnet/maui/platform-integration/appmodel/permissions?branch=pr-en-us-2582) |


<!-- PREVIEW-TABLE-END -->