### PR TITLE
Fire and forget enabled by default

### DIFF
--- a/docs/user-interface/controls/blazorwebview.md
+++ b/docs/user-interface/controls/blazorwebview.md
@@ -1,7 +1,7 @@
 ---
 title: "Host a Blazor web app in a .NET MAUI app using BlazorWebView"
 description: "The .NET MAUI BlazorWebView control enables you to host a Blazor web app in your .NET MAUI app, and integrate the app with device features."
-ms.date: 10/01/2024
+ms.date: 11/13/2024
 ---
 
 # Host a Blazor web app in a .NET MAUI app using BlazorWebView
@@ -220,18 +220,18 @@ To play inline video in a Blazor hybrid app on iOS, in a <xref:Microsoft.AspNetC
 
 ## Fix disposal deadlocks on Android
 
-By default, <xref:Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView> performs async-over-sync disposal, which means that it blocks the thread until the async disposal is complete. However, this can cause deadlocks if the disposal needs to run code on the same thread (because the thread is blocked while waiting).
-
-If you encounter hangs on Android with <xref:Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView> you should enable an <xref:System.AppContext> switch in the `CreateMauiApp` method in *MauiProgram.cs*:
-
-```csharp
-AppContext.SetSwitch("BlazorWebView.AndroidFireAndForgetAsync", true);
-```
-
-This switch enables <xref:Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView> to fire and forget the async disposal that occurs, and as a result fixes the majority of the disposal deadlocks that occur on Android.
+By default, <xref:Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView> fires and forgets the async disposal of the underlying `WebViewManager`. This reduces the number of disposal deadlocks that can occur on Android, resulting in less application hangs occurring.
 
 > [!WARNING]
-> Enabling this switch means that disposal can return before all objects are disposed, which can cause behavioral changes in your app. The items that are disposed are partially Blazor's own internal types, but also app-defined types such as scoped services used within the <xref:Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView> portion of your app.
+> This fire-and-forget default behavior means that disposal can return before all objects are disposed, which can cause behavioral changes in your app. The items that are disposed are partially Blazor's own internal types, but also app-defined types such as scoped services used within the <xref:Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView> portion of your app.
+
+To opt out of this behavior, you should configure your app to block on dispose via an <xref:System.AppContext> switch in the `CreateMauiApp` method in your `MauiProgram` class:
+
+```csharp
+AppContext.SetSwitch("BlazorWebView.AndroidFireAndForgetAsync", false);
+```
+
+If your app is configured to block on dispose via this switch, <xref:Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView> performs async-over-sync disposal, which means that it blocks the thread until the async disposal is complete. However, this can cause deadlocks if the disposal needs to run code on the same thread (because the thread is blocked while waiting).
 
 ## Host content using the legacy behavior on iOS and Mac Catalyst
 

--- a/docs/user-interface/controls/blazorwebview.md
+++ b/docs/user-interface/controls/blazorwebview.md
@@ -218,9 +218,9 @@ To play inline video in a Blazor hybrid app on iOS, in a <xref:Microsoft.AspNetC
 
 ::: moniker range=">=net-maui-9.0"
 
-## Fix disposal deadlocks on Android
+## Disposal deadlocks on Android
 
-By default, <xref:Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView> fires and forgets the async disposal of the underlying `WebViewManager`. This reduces the number of disposal deadlocks that can occur on Android, resulting in less application hangs occurring.
+By default, <xref:Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView> fires and forgets the async disposal of the underlying `WebViewManager`. This reduces the potential for disposal deadlocks to occur on Android.
 
 > [!WARNING]
 > This fire-and-forget default behavior means that disposal can return before all objects are disposed, which can cause behavioral changes in your app. The items that are disposed are partially Blazor's own internal types, but also app-defined types such as scoped services used within the <xref:Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView> portion of your app.

--- a/docs/whats-new/dotnet-9.md
+++ b/docs/whats-new/dotnet-9.md
@@ -153,13 +153,18 @@ To opt into using the `0.0.0.1` address, add the following code to the `CreateMa
 AppContext.SetSwitch("BlazorWebView.AppHostAddressAlways0000", true);
 ```
 
-If you encounter hangs on Android with <xref:Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView> you should enable an <xref:System.AppContext> switch in the `CreateMauiApp` method in your `MauiProgram` class:
+<xref:Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView> now fires and forgets the async disposal of the underlying `WebViewManager` by default. This reduces the number of disposal deadlocks that can occur on Android, resulting in less application hangs occurring.
+
+> [!WARNING]
+> This fire-and-forget default behavior means that disposal can return before all objects are disposed, which can cause behavioral changes in your app. The items that are disposed are partially Blazor's own internal types, but also app-defined types such as scoped services used within the <xref:Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView> portion of your app.
+
+To opt out of this behavior, you should configure your app to block on dispose via an <xref:System.AppContext> switch in the `CreateMauiApp` method in your `MauiProgram` class:
 
 ```csharp
-AppContext.SetSwitch("BlazorWebView.AndroidFireAndForgetAsync", true);
+AppContext.SetSwitch("BlazorWebView.AndroidFireAndForgetAsync", false);
 ```
 
-This switch enables <xref:Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView> to fire and forget the async disposal that occurs, and as a result fixes the majority of the disposal deadlocks that occur on Android. For more information, see [Fix disposal deadlocks on Android](~/user-interface/controls/blazorwebview.md#fix-disposal-deadlocks-on-android).
+If your app is configured to block on dispose via this switch, <xref:Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView> performs async-over-sync disposal, which means that it blocks the thread until the async disposal is complete. However, this can cause deadlocks if the disposal needs to run code on the same thread (because the thread is blocked while waiting).
 
 ### Buttons on iOS
 

--- a/docs/whats-new/dotnet-9.md
+++ b/docs/whats-new/dotnet-9.md
@@ -153,7 +153,7 @@ To opt into using the `0.0.0.1` address, add the following code to the `CreateMa
 AppContext.SetSwitch("BlazorWebView.AppHostAddressAlways0000", true);
 ```
 
-<xref:Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView> now fires and forgets the async disposal of the underlying `WebViewManager` by default. This reduces the number of disposal deadlocks that can occur on Android, resulting in less application hangs occurring.
+By default, <xref:Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView> now fires and forgets the async disposal of the underlying `WebViewManager`. This reduces the potential for disposal deadlocks to occur on Android.
 
 > [!WARNING]
 > This fire-and-forget default behavior means that disposal can return before all objects are disposed, which can cause behavioral changes in your app. The items that are disposed are partially Blazor's own internal types, but also app-defined types such as scoped services used within the <xref:Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView> portion of your app.


### PR DESCRIPTION
Fixes #2625 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/user-interface/controls/blazorwebview.md](https://github.com/dotnet/docs-maui/blob/75e419f8dd52a9d11af4fbb3a27f9d69327e3f67/docs/user-interface/controls/blazorwebview.md) | [docs/user-interface/controls/blazorwebview](https://review.learn.microsoft.com/en-us/dotnet/maui/user-interface/controls/blazorwebview?branch=pr-en-us-2628) |
| [docs/whats-new/dotnet-9.md](https://github.com/dotnet/docs-maui/blob/75e419f8dd52a9d11af4fbb3a27f9d69327e3f67/docs/whats-new/dotnet-9.md) | [docs/whats-new/dotnet-9](https://review.learn.microsoft.com/en-us/dotnet/maui/whats-new/dotnet-9?branch=pr-en-us-2628) |


<!-- PREVIEW-TABLE-END -->