### PR TITLE
Update remote-simulator.md with workaround steps for boot loops

### DIFF
--- a/docs/ios/remote-simulator.md
+++ b/docs/ios/remote-simulator.md
@@ -81,6 +81,18 @@ In some circumstances, an Xcode configuration problem can result in the remote i
 - Run `killall -9 com.apple.CoreSimulator.CoreSimulatorService`.
 - Run `xcrun simctl list devices`.
 
+In some cases, Xcode may have generated simulator devices that can also cause the remote iOS Simulator for Windows to be unable to read its properties correctly as it attempts to verify which ones can be deployed to, causing a boot loop.
+
+You can work around this by removing and creating new simulators which you can deploy to.
+
+- Ensure that Xamarin Mac Agent (XMA) and Xcode aren't running.
+- Run `xcrun simctl list | grep -w "Shutdown"  | grep -o "([-A-Z0-9]*)" | sed 's/[\(\)]//g' | xargs -I uuid xcrun simctl delete  uuid`
+- Run `xcrun simctl list devices`. You should see no devices listed.
+- Open Xcode on your connected Mac
+- Open **Windows > Devices & Simulators**
+- Select **Simulators**
+- Create a new simulator you wish to deploy to.
+
 ### Logs
 
 If you experience issues with the remote iOS Simulator, you can view the logs in the following locations:

--- a/docs/ios/remote-simulator.md
+++ b/docs/ios/remote-simulator.md
@@ -86,11 +86,11 @@ In some cases, Xcode may have generated simulator devices that can also cause th
 You can work around this by removing and creating new simulators which you can deploy to:
 
 - Ensure that Xamarin Mac Agent (XMA) and Xcode aren't running.
-- Run `xcrun simctl list | grep -w "Shutdown"  | grep -o "([-A-Z0-9]*)" | sed 's/[\(\)]//g' | xargs -I uuid xcrun simctl delete  uuid`
+- Run `xcrun simctl list | grep -w "Shutdown"  | grep -o "([-A-Z0-9]*)" | sed 's/[\(\)]//g' | xargs -I uuid xcrun simctl delete  uuid`.
 - Run `xcrun simctl list devices`. You should see no devices listed.
-- Open Xcode on your connected Mac
-- Open **Windows > Devices & Simulators**
-- Select **Simulators**
+- Open Xcode on your connected Mac.
+- Open **Windows > Devices & Simulators**.
+- Select **Simulators**.
 - Create a new simulator you wish to deploy to.
 
 ### Logs

--- a/docs/ios/remote-simulator.md
+++ b/docs/ios/remote-simulator.md
@@ -83,7 +83,7 @@ In some circumstances, an Xcode configuration problem can result in the remote i
 
 In some cases, Xcode may have generated simulator devices that can also cause the remote iOS Simulator for Windows to be unable to read its properties correctly as it attempts to verify which ones can be deployed to, causing a boot loop.
 
-You can work around this by removing and creating new simulators which you can deploy to.
+You can work around this by removing and creating new simulators which you can deploy to:
 
 - Ensure that Xamarin Mac Agent (XMA) and Xcode aren't running.
 - Run `xcrun simctl list | grep -w "Shutdown"  | grep -o "([-A-Z0-9]*)" | sed 's/[\(\)]//g' | xargs -I uuid xcrun simctl delete  uuid`


### PR DESCRIPTION
Xcode can generate simulators with null data that causes the iOS Remote Simulator to trip up with an NRE. This has been addressed internally and can also be worked around by removing and recreating the simulators.