### PR TITLE
Update single-project.md | using correct extension method ToPlatform() instead of ToNative()

### DIFF
--- a/docs/fundamentals/single-project.md
+++ b/docs/fundamentals/single-project.md
@@ -186,12 +186,12 @@ Multi-targeting can also be combined with conditional compilation so that code i
 
 ```csharp
 #if ANDROID
-                  handler.NativeView.SetBackgroundColor(Colors.Red.ToNative());
+                  handler.NativeView.SetBackgroundColor(Colors.Red.ToPlatform());
 #elif IOS
-                  handler.NativeView.BackgroundColor = Colors.Red.ToNative();
+                  handler.NativeView.BackgroundColor = Colors.Red.ToPlatform();
                   handler.NativeView.BorderStyle = UIKit.UITextBorderStyle.Line;
 #elif WINDOWS
-                  handler.NativeView.Background = Colors.Red.ToNative();
+                  handler.NativeView.Background = Colors.Red.ToPlatform();
 #endif
 ```
 

--- a/docs/fundamentals/single-project.md
+++ b/docs/fundamentals/single-project.md
@@ -186,12 +186,12 @@ Multi-targeting can also be combined with conditional compilation so that code i
 
 ```csharp
 #if ANDROID
-                  handler.NativeView.SetBackgroundColor(Colors.Red.ToPlatform());
+                  handler.PlatformView.SetBackgroundColor(Colors.Red.ToPlatform());
 #elif IOS
-                  handler.NativeView.BackgroundColor = Colors.Red.ToPlatform();
-                  handler.NativeView.BorderStyle = UIKit.UITextBorderStyle.Line;
+                  handler.PlatformView.BackgroundColor = Colors.Red.ToPlatform();
+                  handler.PlatformView.BorderStyle = UIKit.UITextBorderStyle.Line;
 #elif WINDOWS
-                  handler.NativeView.Background = Colors.Red.ToPlatform();
+                  handler.PlatformView.Background = Colors.Red.ToPlatform();
 #endif
 ```
 


### PR DESCRIPTION

In the example of Platform-specific code section `ToNative()` extension method is being used on a Color. 

But In reality, There is no such extension method of Color exists.

It need's to replaced with `ToPlatform()` extension method which exists.