### PR TITLE
Update local-notifications.md | Fix incorrect link to the Resolution section in Dependency Injection documentation

### DIFF
--- a/docs/platform-integration/local-notifications.md
+++ b/docs/platform-integration/local-notifications.md
@@ -483,7 +483,7 @@ INotificationManagerService notificationManager =
     Application.Current?.Windows[0].Page?.Handler?.MauiContext?.Services.GetService<INotificationManagerService>();
 ```
 
-For more information about resolving registered types, see [Resolution](~/fundamentals/dependency-injection.md).
+For more information about resolving registered types, see [Resolution](~/fundamentals/dependency-injection.md#resolution).
 
 Once the `INotificationManagerService` implementation is resolved, its operations can be invoked:
 


### PR DESCRIPTION
Updated the link to the "Resolution" section in the Dependency Injection documentation from ` [Resolution](~/fundamentals/dependency-injection.md)`  to `[Resolution](~/fundamentals/dependency-injection.md#resolution)` to ensure it navigates directly to the correct section.