### PR TITLE
Increase the minimum apple versions

### DIFF
--- a/docs/supported-platforms.md
+++ b/docs/supported-platforms.md
@@ -26,8 +26,8 @@ ms.date: 10/04/2024
 ::: moniker range=">=net-maui-9.0"
 
 - Android 5.0 (API 21) or higher is required.
-- iOS 12.2 or higher is required.
-- macOS 12 or higher, using Mac Catalyst.
+- iOS 15.0 or higher is required.
+- macOS 12.0 or higher, using Mac Catalyst (15.0).
 - Windows 11 and Windows 10 version 1809 or higher, using [Windows UI Library (WinUI) 3](/windows/apps/winui/winui3/).
 
 .NET MAUI Blazor apps have the following additional platform requirements:

--- a/docs/whats-new/dotnet-9.md
+++ b/docs/whats-new/dotnet-9.md
@@ -28,7 +28,7 @@ In .NET 9, .NET MAUI ships as a .NET workload and multiple NuGet packages. The a
 
 ## Minimum deployment targets
 
-.NET MAUI 9 requires minimum deployment targets of iOS 12.2, and Mac Catalyst 15.0 (macOS 12.0). Android and Windows minimum deployment targets remain the same. For more information, see [Supported platforms for .NET MAUI apps](../supported-platforms.md).
+.NET MAUI 9 requires minimum deployment targets of iOS 15.0, and Mac Catalyst 15.0 (macOS 12.0). Android and Windows minimum deployment targets remain the same. For more information, see [Supported platforms for .NET MAUI apps](../supported-platforms.md).
 
 ## New controls
 


### PR DESCRIPTION
This increases the minimum versions provided by the .NET MAUI template at: https://github.com/dotnet/maui/blob/main/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj

We discovered this in an issue for the toolkit and wanted to help bring this up to date.
https://github.com/CommunityToolkit/Maui/issues/2528