### PR TITLE
CSS specificity is supported in .NET 9 SR4

### DIFF
--- a/docs/user-interface/styles/css.md
+++ b/docs/user-interface/styles/css.md
@@ -342,8 +342,18 @@ The following selectors are unsupported:
 - `@media` and `@supports`
 - `:` and `::`
 
+::: moniker range="=net-maui-8.0"
+
 > [!NOTE]
 > Specificity, and specificity overrides are unsupported.
+
+::: moniker-end
+
+::: moniker range=">=net-maui-9.0"
+
+If two or more CSS rules point to the same element, the selector with the highest specificity will take precedence and its style declaration will be applied to the element. The [specificity algorithm](https://github.com/dotnet/maui/blob/main/src/Controls/src/Core/StyleSheets/Selector.cs#L319) calculates the weight of a CSS selector to determine which rule from competing CSS declarations gets applied to the element.
+
+::: moniker-end
 
 ## Property reference
 


### PR DESCRIPTION
Fixes #2776 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/user-interface/styles/css.md](https://github.com/dotnet/docs-maui/blob/92cdea776112dadd12dd6ccf125e166003d1b2f1/docs/user-interface/styles/css.md) | [docs/user-interface/styles/css](https://review.learn.microsoft.com/en-us/dotnet/maui/user-interface/styles/css?branch=pr-en-us-2794) |

<!-- PREVIEW-TABLE-END -->