### PR TITLE
Ensure this only runs once per night

### DIFF
--- a/.github/workflows/quest-bulk.yml
+++ b/.github/workflows/quest-bulk.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Azure OpenID Connect
         id: azure-oidc-auth
-        uses: dotnet/docs-tools/.github/actions/oidc-auth-flow@5e8bcc78465d45a7544bba56509a1a69922b6a5a # main
+        uses: dotnet/docs-tools/.github/actions/oidc-auth-flow@main
         with:
           client-id: ${{ secrets.CLIENT_ID }}
           tenant-id: ${{ secrets.TENANT_ID }}
@@ -45,7 +45,7 @@ jobs:
 
       - name: bulk-sequester
         id: bulk-sequester
-        uses: dotnet/docs-tools/actions/sequester@5e8bcc78465d45a7544bba56509a1a69922b6a5a # main
+        uses: dotnet/docs-tools/actions/sequester@main
         env:
           ImportOptions__ApiKeys__GitHubToken: ${{ secrets.GITHUB_TOKEN }}
           ImportOptions__ApiKeys__QuestKey: ${{ secrets.QUEST_KEY }}
@@ -56,4 +56,4 @@ jobs:
           org: ${{ github.repository_owner }}
           repo: ${{ github.repository }}
           issue: '-1'
-          duration: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.duration || github.event.schedule == '0 1 6 * *' && -1 || 5 }}
+          duration: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.duration || github.event.schedule == '0 2 6 * *' && -1 || 5 }}

--- a/.github/workflows/quest-bulk.yml
+++ b/.github/workflows/quest-bulk.yml
@@ -1,8 +1,8 @@
 name: "bulk quest import"
 on:
   schedule:
-    - cron: '0 2 * * *' # UTC time, that's 9:00 pm EST, 6:00 pm PST.
-    - cron: '0 1 6 * *'  # This is the morning of the 6th.
+    - cron: '0 2 1-5,7-31 * *' # UTC time, that's 9:00 pm EST, 6:00 pm PST.
+    - cron: '0 2 6 * *'  # This is the morning of the 6th.
   workflow_dispatch:
     inputs:
       reason:

--- a/.github/workflows/quest.yml
+++ b/.github/workflows/quest.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Azure OpenID Connect
         id: azure-oidc-auth
-        uses: dotnet/docs-tools/.github/actions/oidc-auth-flow@5e8bcc78465d45a7544bba56509a1a69922b6a5a # main
+        uses: dotnet/docs-tools/.github/actions/oidc-auth-flow@main
         with:
           client-id: ${{ secrets.CLIENT_ID }}
           tenant-id: ${{ secrets.TENANT_ID }}
@@ -51,7 +51,7 @@ jobs:
       - name: manual-sequester
         if: ${{ github.event_name == 'workflow_dispatch' }}
         id: manual-sequester
-        uses: dotnet/docs-tools/actions/sequester@5e8bcc78465d45a7544bba56509a1a69922b6a5a # main
+        uses: dotnet/docs-tools/actions/sequester@main
         env:
           ImportOptions__ApiKeys__GitHubToken: ${{ secrets.GITHUB_TOKEN }}
           ImportOptions__ApiKeys__AzureAccessToken: ${{ env.AZURE_ACCESS_TOKEN }}
@@ -67,7 +67,7 @@ jobs:
       - name: auto-sequester
         if: ${{ github.event_name != 'workflow_dispatch' }}
         id: auto-sequester
-        uses: dotnet/docs-tools/actions/sequester@5e8bcc78465d45a7544bba56509a1a69922b6a5a # main
+        uses: dotnet/docs-tools/actions/sequester@main
         env:
           ImportOptions__ApiKeys__GitHubToken: ${{ secrets.GITHUB_TOKEN }}
           ImportOptions__ApiKeys__AzureAccessToken: $AZURE_ACCESS_TOKEN


### PR DESCRIPTION
The monthly run hammered the REST APIs too aggressively when this was run twice in every repo.

Times are now staggered based on [this table](https://github.com/dotnet/docs-tools/tree/main/actions/sequester#staggering-times)

While fixing this, I found another error: This repo was running the old code, because dependabot doesn't update the commit hash for us in our own tools. (those in our docs-tools repo). For those, we should just use `main`.