### PR TITLE
Add missing entitlement detail for Location Services

### DIFF
--- a/docs/platform-integration/device/geolocation.md
+++ b/docs/platform-integration/device/geolocation.md
@@ -84,6 +84,13 @@ The `<string>` element is the reason the app is requesting access to location in
 
 An alternative to editing the _Platforms/iOS/Info.plist_ and _Platforms/MacCatalyst/Info.plist_ files directly is opening the plist editor. In the editor you can add the **Privacy - Location When In Use Usage Description** property, and fill in a value to display to the user.
 
+In the _Platforms/MacCatalyst/Entitlements.plist_ file, add the following key and value to allow the app to access Location Services on macOS:
+
+```xml
+<key>com.apple.security.personal-information.location</key>
+<true/>
+```
+
 ### Full accuracy location permission
 
 If you're going to request full accuracy with the <xref:Microsoft.Maui.Devices.Sensors.GeolocationRequest.RequestFullAccuracy?displayProperty=nameWithType> property, add the following dictionary to the _Platforms/iOS/Info.plist_ and _Platforms/MacCatalyst/Info.plist_ files:


### PR DESCRIPTION
Without this, macOS doesn't recognize the app requesting for location.


https://developer.apple.com/documentation/bundleresources/entitlements/com.apple.security.personal-information.location

https://github.com/dotnet/maui/issues/9506#issuecomment-2332960497

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/platform-integration/device/geolocation.md](https://github.com/dotnet/docs-maui/blob/4f399a1fc7ea6a50b792dda9d4c26698c0a37e7c/docs/platform-integration/device/geolocation.md) | [docs/platform-integration/device/geolocation](https://review.learn.microsoft.com/en-us/dotnet/maui/platform-integration/device/geolocation?branch=pr-en-us-2880) |

<!-- PREVIEW-TABLE-END -->