### PR TITLE
Adding 10 Preview 4 url

### DIFF
--- a/docs/whats-new/dotnet-10.md
+++ b/docs/whats-new/dotnet-10.md
@@ -1,19 +1,14 @@
 ---
 title: What's new in .NET MAUI for .NET 10
 description: Learn about the new features introduced in .NET MAUI for .NET 10.
-ms.date: 04/08/2025
+ms.date: 05/13/2025
 ---
 
 # What's new in .NET MAUI for .NET 10
 
-The focus of .NET Multi-platform App UI (.NET MAUI) in .NET 10 is to improve product quality. For information about the product fixes in .NET MAUI in .NET 10, see the following release notes:
+The focus of .NET Multi-platform App UI (.NET MAUI) in .NET 10 is to improve product quality. For information about what's new in each .NET MAUI in .NET 10 release, see the following release notes:
 
-- [.NET MAUI in .NET 10 Preview 3](https://github.com/dotnet/maui/releases/tag/10.0.0-preview.3.25203.16)
-- [.NET MAUI in .NET 10 Preview 2](https://github.com/dotnet/maui/releases/tag/10.0.0-preview.2.25165.1)
-- [.NET MAUI in .NET 10 Preview 1](https://github.com/dotnet/maui/releases/tag/10.0.0-preview.1.25122.6)
-
-For information about what's new in each .NET MAUI in .NET 10 release, see the following release notes:
-
+- [.NET MAUI in .NET 10 Preview 4](https://github.com/dotnet/core/blob/main/release-notes/10.0/preview/preview4/dotnetmaui.md)
 - [.NET MAUI in .NET 10 Preview 3](https://github.com/dotnet/core/blob/main/release-notes/10.0/preview/preview3/dotnetmaui.md)
 - [.NET MAUI in .NET 10 Preview 2](https://github.com/dotnet/core/blob/main/release-notes/10.0/preview/preview2/dotnetmaui.md)
 - [.NET MAUI in .NET 10 Preview 1](https://github.com/dotnet/core/blob/main/release-notes/10.0/preview/preview1/dotnetmaui.md)


### PR DESCRIPTION
Also removing the release notes direct links. They are available via the links that remain.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/whats-new/dotnet-10.md](https://github.com/dotnet/docs-maui/blob/db1b187a2791427b622ade5f64b8a699e26bdf72/docs/whats-new/dotnet-10.md) | [docs/whats-new/dotnet-10](https://review.learn.microsoft.com/en-us/dotnet/maui/whats-new/dotnet-10?branch=pr-en-us-2905) |

<!-- PREVIEW-TABLE-END -->