### PR TITLE
Clarify CharacterSpacing behavior for InputView's

### DIFF
--- a/docs/user-interface/controls/editor.md
+++ b/docs/user-interface/controls/editor.md
@@ -20,7 +20,7 @@ In addition, <xref:Microsoft.Maui.Controls.Editor> defines a `Completed` event, 
 
 <xref:Microsoft.Maui.Controls.Editor> derives from the <xref:Microsoft.Maui.Controls.InputView> class, from which it inherits the following properties:
 
-- `CharacterSpacing`, of type `double`,sets the spacing between characters in the text content, including both the user-entered or displayed text and the placeholder text.
+- `CharacterSpacing`, of type `double`, sets the spacing between characters in the text content, including both the user-entered or displayed text and the placeholder text.
 - `CursorPosition`, of type `int`, defines the position of the cursor within the editor.
 - `FontAttributes`, of type `FontAttributes`, determines text style.
 - `FontAutoScalingEnabled`, of type `bool`, defines whether the text will reflect scaling preferences set in the operating system. The default value of this property is `true`.

--- a/docs/user-interface/controls/editor.md
+++ b/docs/user-interface/controls/editor.md
@@ -20,7 +20,7 @@ In addition, <xref:Microsoft.Maui.Controls.Editor> defines a `Completed` event, 
 
 <xref:Microsoft.Maui.Controls.Editor> derives from the <xref:Microsoft.Maui.Controls.InputView> class, from which it inherits the following properties:
 
-- `CharacterSpacing`, of type `double`, sets the spacing between characters in the entered text.
+- `CharacterSpacing`, of type `double`,sets the spacing between characters in the text content, including both the user-entered or displayed text and the placeholder text.
 - `CursorPosition`, of type `int`, defines the position of the cursor within the editor.
 - `FontAttributes`, of type `FontAttributes`, determines text style.
 - `FontAutoScalingEnabled`, of type `bool`, defines whether the text will reflect scaling preferences set in the operating system. The default value of this property is `true`.

--- a/docs/user-interface/controls/entry.md
+++ b/docs/user-interface/controls/entry.md
@@ -24,7 +24,7 @@ In addition, <xref:Microsoft.Maui.Controls.Entry> defines a `Completed` event, w
 
 <xref:Microsoft.Maui.Controls.Entry> derives from the <xref:Microsoft.Maui.Controls.InputView> class, from which it inherits the following properties:
 
-- `CharacterSpacing`, of type `double`, sets the spacing between characters in the entered text.
+- `CharacterSpacing`, of type `double`, sets the spacing between characters in the text content, including both the user-entered or displayed text and the placeholder text.
 - `CursorPosition`, of type `int`, defines the position of the cursor within the editor.
 - `FontAttributes`, of type `FontAttributes`, determines text style.
 - `FontAutoScalingEnabled`, of type `bool`, defines whether the text will reflect scaling preferences set in the operating system. The default value of this property is `true`.

--- a/docs/user-interface/controls/searchbar.md
+++ b/docs/user-interface/controls/searchbar.md
@@ -40,7 +40,7 @@ In addition, <xref:Microsoft.Maui.Controls.SearchBar> defines a `SearchButtonPre
 
 <xref:Microsoft.Maui.Controls.SearchBar> derives from the <xref:Microsoft.Maui.Controls.InputView> class, from which it inherits the following properties:
 
-- `CharacterSpacing`, of type `double`, sets the spacing between characters in the entered text.
+- `CharacterSpacing`, of type `double`, sets the spacing between characters in the text content, including both the user-entered or displayed text and the placeholder text.
 - `CursorPosition`, of type `int`, defines the position of the cursor within the editor.
 - `FontAttributes`, of type `FontAttributes`, determines text style.
 - `FontAutoScalingEnabled`, of type `bool`, defines whether the text will reflect scaling preferences set in the operating system. The default value of this property is `true`.


### PR DESCRIPTION
This PR updates the `CharacterSpacing` property descriptions of InputView's to clarify that the spacing applies to both the entered/displayed text and the placeholder text.

API reference:
https://learn.microsoft.com/en-us/dotnet/api/microsoft.maui.controls.inputview.characterspacing?view=net-maui-9.0#microsoft-maui-controls-inputview-characterspacing