### PR TITLE
[NET10] Deprecate ClickGestureRecognizer

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,65 @@
+# Working notes for .NET MAUI .NET 10 docs updates
+
+These notes capture our lightweight process and guardrails while submitting focused pull requests against `main` for .NET 10 changes.
+
+Last updated: 2025-08-18
+
+## Branching and PRs
+
+- Create small, topic-focused branches directly off `main` (for example: `pr01-pop-ups-async-from-main`, `pr02-mediapicker-multiselect-from-main`, `pr03-gestures-tap-click-deprecation`).
+- Open PRs directly to `main` with clear scope and migration context. Avoid staging branches.
+- Keep changes minimal: only the pages/includes required for the topic.
+
+## Monikers and versioning
+
+- Preserve existing content for <= .NET 9 and add >= .NET 10 content using DocFX monikers:
+
+  ```md
+  ::: moniker range="<=net-maui-9.0"
+  ... existing <= 9 content ...
+  ::: moniker-end
+
+  ::: moniker range=">=net-maui-10.0"
+  ... new .NET 10 content ...
+  ::: moniker-end
+  ```
+
+- Use includes when appropriate to keep duplication low, but don’t over-abstract if a single page change is small and clear.
+
+## Preview drift and verification
+
+Changes must be verified against the .NET MAUI source for .NET 10 to avoid preview drift:
+
+1. Check APIs on the `dotnet/maui` `net10.0` branch.
+   - Repository: https://github.com/dotnet/maui
+   - Browse `src/Controls/src/Core` and handlers/platform folders as needed.
+2. Cross-check against API docs/xrefs where available.
+3. Confirm platform notes (Android/iOS/Mac Catalyst/Windows) reflect real behavior.
+
+Examples already verified:
+
+- Pop-ups (.NET 10): `DisplayAlertAsync`, `DisplayActionSheetAsync` replace non-`Async` APIs.
+- Media picker (.NET 10): `PickPhotosAsync` / `PickVideosAsync` returning `List<FileResult>`; options like `SelectionLimit`, `MaximumWidth/Height`, `CompressionQuality`, etc.
+
+## Quality gates before submitting a PR
+
+- Lint the markdown visually in the diff for:
+  - Valid xrefs and relative links.
+  - Correct admonitions and moniker blocks are balanced.
+  - Code fences have a language hint and compile logically.
+- Keep `ms.date` current on pages you materially change.
+- Make sure headings form a sensible outline and anchors aren’t unintentionally renamed.
+
+## PR description checklist
+
+- Summarize the .NET 10 change and motivation.
+- Call out migration guidance and any breaking changes.
+- List files changed and a quick test of samples where relevant.
+- Note platform-specific behaviors/limitations.
+- Link to upstream MAUI PRs or source lines used for verification when helpful.
+
+## Known .NET 10 changes we’ve documented
+
+- Pop-ups: `DisplayAlertAsync` / `DisplayActionSheetAsync` (PR01).
+- Media picker: multi-select `PickPhotosAsync` / `PickVideosAsync` (PR02).
+- Gestures: deprecate `ClickGestureRecognizer`; promote `TapGestureRecognizer` and `PointerGestureRecognizer` (PR03).

--- a/docs/fundamentals/gestures/tap.md
+++ b/docs/fundamentals/gestures/tap.md
@@ -1,12 +1,19 @@
 ---
 title: "Recognize a tap gesture"
 description: "This article explains how to recognize a tap gesture in a .NET MAUI app."
-ms.date: 10/03/2022
+ms.date: 08/18/2025
 ---
 
 # Recognize a tap gesture
 
-A .NET Multi-platform App UI (.NET MAUI) tap gesture recognizer is used for tap detection and is implemented with the <xref:Microsoft.Maui.Controls.TapGestureRecognizer> class. This class defines the following properties:
+A .NET Multi-platform App UI (.NET MAUI) tap gesture recognizer is used for tap detection and is implemented with the <xref:Microsoft.Maui.Controls.TapGestureRecognizer> class.
+
+::: moniker range=">=net-maui-10.0"
+> [!IMPORTANT]
+> In .NET 10, <xref:Microsoft.Maui.Controls.ClickGestureRecognizer> is deprecated. Use <xref:Microsoft.Maui.Controls.TapGestureRecognizer> for tap/click interactions, and <xref:Microsoft.Maui.Controls.PointerGestureRecognizer> for pointer hover/move/press scenarios. The <xref:Microsoft.Maui.Controls.TapGestureRecognizer> supports primary and secondary buttons via the <xref:Microsoft.Maui.Controls.TapGestureRecognizer.Buttons> property and can be used to handle single and double tap gestures.
+:::
+
+This class defines the following properties:
 
 - <xref:Microsoft.Maui.Controls.TapGestureRecognizer.Buttons>, of type <xref:Microsoft.Maui.Controls.ButtonsMask>, which defines whether the primary or secondary mouse button, or both, triggers the gesture on Android, Mac Catalyst, and Windows. For more information, see [Define the button masks](#define-the-button-mask).
 - <xref:Microsoft.Maui.Controls.TapGestureRecognizer.Command>, of type <xref:System.Windows.Input.ICommand>, which is executed when a tap is recognized.
@@ -55,6 +62,53 @@ image.GestureRecognizers.Add(tapGestureRecognizer);
 ```
 
 By default the <xref:Microsoft.Maui.Controls.Image> will respond to single taps. When the <xref:Microsoft.Maui.Controls.TapGestureRecognizer.NumberOfTapsRequired> property is set to greater than one, the event handler will only be executed if the taps occur within a set period of time. If the second (or subsequent) taps don't occur within that period, they're effectively ignored.
+
+::: moniker range=">=net-maui-10.0"
+
+## Migrate from ClickGestureRecognizer (>= .NET 10)
+
+In previous versions, mouse click interactions could be handled with <xref:Microsoft.Maui.Controls.ClickGestureRecognizer>. In .NET 10, this recognizer is deprecated. Migrate to <xref:Microsoft.Maui.Controls.TapGestureRecognizer> for click/tap interactions, and use <xref:Microsoft.Maui.Controls.PointerGestureRecognizer> for pointer enter/exit/move/press/release scenarios.
+
+The following example shows how to migrate from `ClickGestureRecognizer` to `TapGestureRecognizer` while maintaining support for primary/secondary buttons:
+
+```xaml
+<!-- Before (.NET 9 and earlier) -->
+<Image Source="dotnet_bot.png">
+    <Image.GestureRecognizers>
+        <ClickGestureRecognizer Clicked="OnClicked"
+                                                        NumberOfClicksRequired="1"
+                                                        Buttons="Primary,Secondary" />
+    </Image.GestureRecognizers>
+</Image>
+
+<!-- After (.NET 10) -->
+<Image Source="dotnet_bot.png">
+    <Image.GestureRecognizers>
+        <TapGestureRecognizer Tapped="OnTapped"
+                                                    NumberOfTapsRequired="1"
+                                                    Buttons="Primary,Secondary" />
+    </Image.GestureRecognizers>
+</Image>
+```
+
+In code-behind, handle the <xref:Microsoft.Maui.Controls.TapGestureRecognizer.Tapped> event and inspect <xref:Microsoft.Maui.Controls.TappedEventArgs.Buttons> to distinguish the mouse button:
+
+```csharp
+void OnTapped(object sender, TappedEventArgs e)
+{
+        if (e.Buttons == ButtonsMask.Secondary)
+        {
+                // Handle secondary/right click
+        }
+        else
+        {
+                // Handle primary/left click
+        }
+}
+```
+
+If you need pointer hover or press/release details (without a completed tap), use <xref:Microsoft.Maui.Controls.PointerGestureRecognizer> and its events such as `PointerEntered`, `PointerMoved`, `PointerPressed`, and `PointerReleased`. For more information, see [Recognize a pointer gesture](pointer.md).
+:::
 
 ## Define the button mask
 

--- a/docs/fundamentals/gestures/tap.md
+++ b/docs/fundamentals/gestures/tap.md
@@ -11,7 +11,7 @@ A .NET Multi-platform App UI (.NET MAUI) tap gesture recognizer is used for tap 
 ::: moniker range=">=net-maui-10.0"
 > [!IMPORTANT]
 > In .NET 10, <xref:Microsoft.Maui.Controls.ClickGestureRecognizer> is deprecated. Use <xref:Microsoft.Maui.Controls.TapGestureRecognizer> for tap/click interactions, and <xref:Microsoft.Maui.Controls.PointerGestureRecognizer> for pointer hover/move/press scenarios. The <xref:Microsoft.Maui.Controls.TapGestureRecognizer> supports primary and secondary buttons via the <xref:Microsoft.Maui.Controls.TapGestureRecognizer.Buttons> property and can be used to handle single and double tap gestures.
-:::
+::: moniker-end
 
 This class defines the following properties:
 
@@ -108,7 +108,7 @@ void OnTapped(object sender, TappedEventArgs e)
 ```
 
 If you need pointer hover or press/release details (without a completed tap), use <xref:Microsoft.Maui.Controls.PointerGestureRecognizer> and its events such as `PointerEntered`, `PointerMoved`, `PointerPressed`, and `PointerReleased`. For more information, see [Recognize a pointer gesture](pointer.md).
-:::
+::: moniker-end
 
 ## Define the button mask
 


### PR DESCRIPTION

- Summary: ClickGestureRecognizer is deprecated in .NET 10. Add migration guidance to use TapGestureRecognizer for tap/click interactions and PointerGestureRecognizer for pointer hover/move/press/release.
- Files changed:
  - docs/fundamentals/gestures/tap.md (adds .NET 10 Important note + “Migrate from ClickGestureRecognizer” section; ms.date updated)
  - .github/copilot-instructions.md (working notes for .NET 10 docs PRs)
- Monikers: <= .NET 9 content remains; >= .NET 10 adds deprecation note and migration steps.
- Examples:
  - Before/After XAML (Click → Tap) and code-behind using TappedEventArgs.Buttons to distinguish primary vs secondary.
  - Pointer link-out for non-tap pointer interactions.
- Verification: Obsolete attribute and guidance present in MAUI source; doc scan shows no other ClickGestureRecognizer references requiring updates.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [.github/copilot-instructions.md](https://github.com/dotnet/docs-maui/blob/a301a983b44931cadeebf3cf10e608323c6c6224/.github/copilot-instructions.md) | [.github/copilot-instructions](https://review.learn.microsoft.com/en-us/dotnet/maui/.github/copilot-instructions?branch=pr-en-us-2985) |
| [docs/fundamentals/gestures/tap.md](https://github.com/dotnet/docs-maui/blob/a301a983b44931cadeebf3cf10e608323c6c6224/docs/fundamentals/gestures/tap.md) | [docs/fundamentals/gestures/tap](https://review.learn.microsoft.com/en-us/dotnet/maui/fundamentals/gestures/tap?branch=pr-en-us-2985) |


<!-- PREVIEW-TABLE-END -->