### PR TITLE
[NET10] Messaging: Migrate from MessagingCenter to modern alternatives (Toolkit WeakReferenceMessenger)

### DIFF
--- a/docs/fundamentals/messagingcenter.md
+++ b/docs/fundamentals/messagingcenter.md
@@ -21,7 +21,6 @@ MessagingCenter was a convenience API to implement the publish-subscribe pattern
 The Toolkit messenger uses strongly typed messages and weak references to recipients. A minimal migration looks like this:
 
 1. Add the CommunityToolkit.Mvvm package to your project.
-   
    In your project file (`.csproj`):
    ```xml
    <ItemGroup>

--- a/docs/fundamentals/messagingcenter.md
+++ b/docs/fundamentals/messagingcenter.md
@@ -22,6 +22,7 @@ The Toolkit messenger uses strongly typed messages and weak references to recipi
 
 1. Add the CommunityToolkit.Mvvm package to your project.
    In your project file (`.csproj`):
+
    ```xml
    <ItemGroup>
      <PackageReference Include="CommunityToolkit.Mvvm" Version="8.*" />

--- a/docs/fundamentals/messagingcenter.md
+++ b/docs/fundamentals/messagingcenter.md
@@ -23,7 +23,6 @@ The Toolkit messenger uses strongly typed messages and weak references to recipi
 1. Add the CommunityToolkit.Mvvm package to your project.
    
    In your project file (`.csproj`):
-   
    ```xml
    <ItemGroup>
      <PackageReference Include="CommunityToolkit.Mvvm" Version="8.*" />

--- a/docs/fundamentals/messagingcenter.md
+++ b/docs/fundamentals/messagingcenter.md
@@ -1,11 +1,123 @@
 ---
 title: "Publish and subscribe to messages"
-description: "The .NET MAUI MessagingCenter class implements the publish-subscribe pattern, allowing message-based communication between components that are inconvenient to link by object and type references."
-ms.date: 02/18/2022
-monikerRange: "<=net-maui-9.0"
+description: "The .NET MAUI MessagingCenter class implements the publish-subscribe pattern and how to migrate to modern alternatives in .NET 10 and later."
+ms.date: 08/18/2025
 ---
 
 # Publish and subscribe to messages
+
+::: moniker range=">=net-maui-10.0"
+
+> [!IMPORTANT]
+> <xref:Microsoft.Maui.Controls.MessagingCenter> is deprecated in .NET 10. We recommend migrating to `WeakReferenceMessenger` from the [CommunityToolkit.Mvvm](https://www.nuget.org/packages/CommunityToolkit.Mvvm) package, or using events with weak references for simple scenarios. For more information, see [Messenger](/windows/communitytoolkit/mvvm/messenger).
+
+MessagingCenter was a convenience API to implement the publish-subscribe pattern without direct references between publishers and subscribers. In .NET 10 and later you should prefer one of the following:
+
+- CommunityToolkit.Mvvm `WeakReferenceMessenger` for decoupled, testable message-based communication.
+- Regular .NET events for local communication, ideally with <xref:Microsoft.Maui.WeakEventManager> to avoid memory leaks.
+
+## Migrate to WeakReferenceMessenger
+
+The Toolkit messenger uses strongly typed messages and weak references to recipients. A minimal migration looks like this:
+
+1. Add the CommunityToolkit.Mvvm package to your project.
+   
+   In your project file (`.csproj`):
+   
+   ```xml
+   <ItemGroup>
+     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.*" />
+   </ItemGroup>
+   ```
+
+2. Define a message type (optionally using `ValueChangedMessage<T>` when sending a single payload value):
+
+   ```csharp
+   using CommunityToolkit.Mvvm.Messaging.Messages;
+
+   public sealed class HiMessage : ValueChangedMessage<string>
+   {
+       public HiMessage(string name) : base(name) { }
+   }
+   ```
+
+3. Send a message from the publisher:
+
+   ```csharp
+   using CommunityToolkit.Mvvm.Messaging;
+
+   // Send without a direct reference to any recipients
+   WeakReferenceMessenger.Default.Send(new HiMessage("John"));
+   ```
+
+4. Receive the message in a recipient:
+
+   - Implement `IRecipient<TMessage>` and register with the messenger, or
+   - Inherit from `ObservableRecipient` and enable reception.
+
+   ```csharp
+   using CommunityToolkit.Mvvm.Messaging;
+   using CommunityToolkit.Mvvm.Messaging.Messages;
+
+   public sealed class GreetingViewModel : IRecipient<HiMessage>
+   {
+       public GreetingViewModel()
+       {
+           // Register this instance to receive HiMessage notifications
+           WeakReferenceMessenger.Default.Register(this);
+       }
+
+       public void Receive(HiMessage message)
+       {
+           var name = message.Value; // "John"
+           // Handle the message (e.g., update state)
+       }
+
+       // Call this when the recipient is disposed/no longer needed
+       public void Unregister()
+       {
+           WeakReferenceMessenger.Default.Unregister<HiMessage>(this);
+       }
+   }
+   ```
+
+### Mapping common MessagingCenter patterns
+
+- Send without payload: `MessagingCenter.Send<TSender>(sender, message)` → define an empty message type (no payload) and `Send(new MyMessage())`.
+- Send with payload: `MessagingCenter.Send<TSender, TArgs>(sender, message, args)` → use `ValueChangedMessage<TArgs>` or a custom message with properties.
+- Subscribe callback: `MessagingCenter.Subscribe<TSender>(subscriber, message, callback)` → implement `IRecipient<TMessage>` and register; the `Receive` method is the callback.
+- Unsubscribe: `MessagingCenter.Unsubscribe` → `WeakReferenceMessenger.Default.Unregister<TMessage>(recipient)`.
+
+### When to use events instead
+
+For simple, local communication (for example, between a control and its parent), standard .NET events are often sufficient. To reduce the risk of memory leaks with long-lived publishers, use <xref:Microsoft.Maui.WeakEventManager>:
+
+```csharp
+public class Counter
+{
+    readonly Microsoft.Maui.WeakEventManager _weakEventManager = new();
+
+    public event EventHandler<int> CountChanged
+    {
+        add => _weakEventManager.AddEventHandler(value);
+        remove => _weakEventManager.RemoveEventHandler(value);
+    }
+
+    int _count;
+    public void Increment()
+    {
+        _count++;
+        _weakEventManager.HandleEvent(this, _count, nameof(CountChanged));
+    }
+}
+```
+
+> [!TIP]
+> If you’re already using MVVM with the CommunityToolkit, `ObservableRecipient` can auto-manage registration lifetimes when `IsActive` is set.
+
+::: moniker-end
+
+::: moniker range="<=net-maui-9.0"
 
 The publish-subscribe pattern is a messaging pattern in which publishers send messages without having knowledge of any receivers, known as subscribers. Similarly, subscribers listen for specific messages, without having knowledge of any publishers.
 
@@ -95,3 +207,5 @@ MessagingCenter.Unsubscribe<MainPage, string>(this, "Hi");
 ```
 
 In this example, the `Unsubscribe` method unsubscribes the `this` object from the `Hi` message sent by the `MainPage` type, whose payload data is a `string`.
+
+::: moniker-end


### PR DESCRIPTION
Update Messaging guidance for .NET 10: migrate from MessagingCenter to modern alternatives

What changed
- docs/fundamentals/messagingcenter.md:
  - Added a >= net-maui-10.0 migration-first section recommending CommunityToolkit.Mvvm WeakReferenceMessenger, with minimal send/receive examples (typed message via ValueChangedMessage<T>, registration/unregistration, and an ObservableRecipient tip).
  - Added a short “When to use events instead” section showing .NET events with Microsoft.Maui.WeakEventManager for simple local scenarios.
  - Preserved legacy MessagingCenter usage under <= net-maui-9.0.
  - Switched from page-level monikerRange to inline moniker blocks and updated ms.date/description.

Why
- Microsoft.Maui.Controls.MessagingCenter is obsolete in .NET 10 (source has [Obsolete] attribute recommending CommunityToolkit.Mvvm.Messaging.WeakReferenceMessenger). This aligns the docs with platform guidance and promotes modern, testable patterns.

References
- Toolkit Messenger: https://learn.microsoft.com/windows/communitytoolkit/mvvm/messenger
- NuGet: https://www.nuget.org/packages/CommunityToolkit.Mvvm
- Weak events: `Microsoft.Maui.WeakEventManager`

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/messagingcenter.md](https://github.com/dotnet/docs-maui/blob/f1c295b7b2afebb898e809ae30ae7e4fe821994e/docs/fundamentals/messagingcenter.md) | [docs/fundamentals/messagingcenter](https://review.learn.microsoft.com/en-us/dotnet/maui/fundamentals/messagingcenter?branch=pr-en-us-2986) |


<!-- PREVIEW-TABLE-END -->