### PR TITLE
[NET10] iOS SafeAreaEdges

### DIFF
--- a/docs/ios/platform-specifics/page-safe-area-layout.md
+++ b/docs/ios/platform-specifics/page-safe-area-layout.md
@@ -1,12 +1,43 @@
 ---
 title: "Enable the safe area layout guide on iOS"
-description: "This article explains how to consume the .NET MAUI iOS platform-specific that enables the safe area layout guide."
-ms.date: 02/16/2023
+description: "How to control the iOS safe area layout guide in .NET MAUI, and .NET 10 guidance for modern safe area behavior."
+ms.date: 08/18/2025
 ---
 
 # Enable the safe area layout guide on iOS
 
 By default, .NET Multi-platform App UI (.NET MAUI) apps automatically position page content on an area of the screen that is safe for all devices. This is known as the safe area layout guide, and ensures that content isn't clipped by rounded device corners, the home indicator, or the sensor housing on some iPhone models.
+
+::: moniker range=">=net-maui-10.0"
+
+> [!IMPORTANT]
+> In .NET 10, MAUI continues to honor the iOS safe area by default. Prefer the `ISafeAreaView` pattern to opt a layout into drawing behind obstructions, and use page safe area insets when you need to react to device changes. The `iOS Page.UseSafeArea` platform-specific remains available for existing code, but for new apps we recommend the approach below.
+
+## Modern safe area guidance (.NET 10+)
+
+- To allow content to extend into the unsafe regions, set `IgnoreSafeArea` on any layout that implements <xref:Microsoft.Maui.ISafeAreaView>:
+
+    ```xaml
+    <Grid IgnoreSafeArea="True">
+            <!-- content can extend into areas behind toolbars, cutouts, etc. -->
+    </Grid>
+    ```
+
+- To read the current safe area insets on a Page at runtime, use the iOS-specific attached property via the platform configuration APIs:
+
+    ```csharp
+    using Microsoft.Maui.Controls.PlatformConfiguration;
+    using Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific;
+
+    var insets = On<iOS>().SafeAreaInsets(); // returns Microsoft.Maui.Thickness
+    ```
+
+> [!TIP]
+> Safe area insets can change at runtime (rotation, status bar changes). Handle layout updates accordingly.
+
+::: moniker-end
+
+::: moniker range="<=net-maui-9.0"
 
 This iOS platform-specific enables the safe area layout guide, if it's previously been disabled, and is consumed in XAML by setting the `Page.UseSafeArea` attached property to `true`:
 
@@ -33,3 +64,5 @@ The `Page.On<iOS>` method specifies that this platform-specific will only run on
 
 > [!NOTE]
 > The <xref:Microsoft.Maui.Controls.Layout> class defines a <xref:Microsoft.Maui.Controls.Layout.IgnoreSafeArea> property that ensures that content is positioned on an area of the screen that is safe for all iOS devices. This property can be set to `true` on any layout class, such as a <xref:Microsoft.Maui.Controls.Grid> or <xref:Microsoft.Maui.Controls.StackLayout>, to perform the equivalent of this platform-specific.
+
+::: moniker-end

--- a/docs/ios/platform-specifics/page-safe-area-layout.md
+++ b/docs/ios/platform-specifics/page-safe-area-layout.md
@@ -84,7 +84,7 @@ var insets = On<iOS>().SafeAreaInsets(); // Microsoft.Maui.Thickness
 > Safe area insets can change at runtime (for example, rotation or status bar changes). Update layout when insets change.
 
 > [!SEEALSO]
-> [Safe area enhancements in .NET 10](/dotnet/maui/whats-new/dotnet-10?view=net-maui-9.0#safearea-enhancements)
+> [Safe area enhancements in .NET 10](/dotnet/maui/whats-new/dotnet-10#safearea-enhancements)
 
 ::: moniker-end
 

--- a/docs/ios/platform-specifics/page-safe-area-layout.md
+++ b/docs/ios/platform-specifics/page-safe-area-layout.md
@@ -11,29 +11,80 @@ By default, .NET Multi-platform App UI (.NET MAUI) apps automatically position p
 ::: moniker range=">=net-maui-10.0"
 
 > [!IMPORTANT]
-> In .NET 10, MAUI continues to honor the iOS safe area by default. Prefer the `ISafeAreaView` pattern to opt a layout into drawing behind obstructions, and use page safe area insets when you need to react to device changes. The `iOS Page.UseSafeArea` platform-specific remains available for existing code, but for new apps we recommend the approach below.
+> In .NET 10, use the <xref:Microsoft.Maui.Controls.ContentPage.SafeAreaEdges> property (also available on <xref:Microsoft.Maui.Controls.Layout>, <xref:Microsoft.Maui.Controls.ScrollView>, <xref:Microsoft.Maui.Controls.ContentView>, and <xref:Microsoft.Maui.Controls.Border>) to precisely control safe area behavior. The iOS-specific `Page.UseSafeArea` remains for existing apps, but new code should prefer `SafeAreaEdges`.
 
 ## Modern safe area guidance (.NET 10+)
 
-- To allow content to extend into the unsafe regions, set `IgnoreSafeArea` on any layout that implements <xref:Microsoft.Maui.ISafeAreaView>:
+### Choose the safe area behavior with SafeAreaEdges
+
+`SafeAreaEdges` accepts the following values from <xref:Microsoft.Maui.SafeAreaRegions>: `Default`, `None`, `Container`, `SoftInput`, and `All`.
+
+- Keep content within all safe areas (avoid bars, notch, and keyboard):
 
     ```xaml
-    <Grid IgnoreSafeArea="True">
-            <!-- content can extend into areas behind toolbars, cutouts, etc. -->
+    <ContentPage SafeAreaEdges="All">
+            <!-- content stays within safe area -->
+    </ContentPage>
+    ```
+
+- Draw edge-to-edge (no safe area padding):
+
+    ```xaml
+    <ContentPage SafeAreaEdges="None">
+            <!-- content can extend behind bars and notch -->
+    </ContentPage>
+    ```
+
+- Keep out of the keyboard (soft input), but allow under top/bottom bars/notch:
+
+    ```xaml
+    <ScrollView SafeAreaEdges="SoftInput">
+            <!-- content can go under bars/notch but avoids keyboard overlap -->
+    </ScrollView>
+    ```
+
+- Keep out of top/bottom bars and notch, but allow under the keyboard:
+
+    ```xaml
+    <Grid SafeAreaEdges="Container">
+            <!-- content avoids bars/notch; may extend under keyboard -->
     </Grid>
     ```
 
-- To read the current safe area insets on a Page at runtime, use the iOS-specific attached property via the platform configuration APIs:
+The default value is `Default`, which maps to edge-to-edge behavior (equivalent to `None`) unless overridden by platform conventions.
 
-    ```csharp
-    using Microsoft.Maui.Controls.PlatformConfiguration;
-    using Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific;
+You can set `SafeAreaEdges` in C# as well:
 
-    var insets = On<iOS>().SafeAreaInsets(); // returns Microsoft.Maui.Thickness
-    ```
+```csharp
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+
+// On a page
+this.SafeAreaEdges = SafeAreaEdges.All;
+
+// On a layout
+myGrid.SafeAreaEdges = SafeAreaEdges.Container;
+
+// Keyboard-aware
+myScrollView.SafeAreaEdges = SafeAreaEdges.SoftInput;
+```
+
+### Reading the current safe area insets
+
+To read the current safe area insets on a page at runtime, use the iOS-specific configuration API:
+
+```csharp
+using Microsoft.Maui.Controls.PlatformConfiguration;
+using Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific;
+
+var insets = On<iOS>().SafeAreaInsets(); // Microsoft.Maui.Thickness
+```
 
 > [!TIP]
-> Safe area insets can change at runtime (rotation, status bar changes). Handle layout updates accordingly.
+> Safe area insets can change at runtime (for example, rotation or status bar changes). Update layout when insets change.
+
+> [!SEEALSO]
+> [Safe area enhancements in .NET 10](/dotnet/maui/whats-new/dotnet-10?view=net-maui-9.0#safearea-enhancements)
 
 ::: moniker-end
 


### PR DESCRIPTION
Description:

- Document modern .NET 10 safe-area behavior using SafeAreaEdges on ContentPage, Layout, ScrollView, ContentView, and Border.
- Add XAML and C# examples for:
  - All (keep content within all safe areas)
  - None (edge-to-edge)
  - SoftInput (avoid keyboard overlap)
  - Container (avoid bars/notch; allow under keyboard)
- Clarify that Default maps to edge-to-edge unless platform conventions override it.
- Show how to read current insets with On<iOS>().SafeAreaInsets().
- Preserve <= net-maui-9.0 Page.UseSafeArea guidance under monikers.
- Add “See also” to What’s new safe-area enhancements.

Rationale:

- Aligns with .NET 10 API surface and the SafeArea enhancements.
- Gives precise, declarative control and removes ambiguity around edge-to-edge vs keyboard-aware scenarios.
- Keeps legacy guidance available for <= 9 users with correct DocFX monikers.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/ios/platform-specifics/page-safe-area-layout.md](https://github.com/dotnet/docs-maui/blob/9c208f72e4f8189ce661b6ef0f5ffed55d4ea077/docs/ios/platform-specifics/page-safe-area-layout.md) | [docs/ios/platform-specifics/page-safe-area-layout](https://review.learn.microsoft.com/en-us/dotnet/maui/ios/platform-specifics/page-safe-area-layout?branch=pr-en-us-2987) |


<!-- PREVIEW-TABLE-END -->