### PR TITLE
[NET10] ToolbarItem secondary behavior on iOS/macOS

### DIFF
--- a/docs/user-interface/controls/switch.md
+++ b/docs/user-interface/controls/switch.md
@@ -27,7 +27,7 @@ The <xref:Microsoft.Maui.Controls.Switch> control defines the following properti
 ::: moniker range=">=net-maui-10.0"
 
 - `IsToggled` is a `boolean` value that indicates whether the <xref:Microsoft.Maui.Controls.Switch> is on. The default value of this property is `false`.
-- `OffColor`is a <xref:Microsoft.Maui.Graphics.Color> that determines how the <xref:Microsoft.Maui.Controls.Switch> is rendered in the off state.
+- `OffColor` is a <xref:Microsoft.Maui.Graphics.Color> that determines how the <xref:Microsoft.Maui.Controls.Switch> is rendered in the off state.
 - `OnColor` is a <xref:Microsoft.Maui.Graphics.Color> that determines how the <xref:Microsoft.Maui.Controls.Switch> is rendered in the toggled, or on state.
 - `ThumbColor` is the <xref:Microsoft.Maui.Graphics.Color> of the switch thumb.
 

--- a/docs/user-interface/toolbaritem.md
+++ b/docs/user-interface/toolbaritem.md
@@ -1,7 +1,7 @@
 ---
 title: "Display toolbar items"
 description: "Learn how to add toolbar items, which are a special type of button, to the app's navigation bar."
-ms.date: 09/30/2024
+ms.date: 08/18/2025
 ---
 
 # Display toolbar items
@@ -100,6 +100,8 @@ The <xref:Microsoft.Maui.Controls.ToolbarItemOrder> enum has `Default`, `Primary
 
 When the <xref:Microsoft.Maui.Controls.ToolbarItem.Order> property is set to `Primary`, the <xref:Microsoft.Maui.Controls.ToolbarItem> object appears in the navigation bar on all platforms. <xref:Microsoft.Maui.Controls.ToolbarItem> objects are prioritized over the page title, which will be truncated to make room for the items.
 
+::: moniker range="<=net-maui-9.0"
+
 When the <xref:Microsoft.Maui.Controls.ToolbarItem.Order> property is set to `Secondary`, behavior varies across platforms. On iOS and Mac Catalyst, `Secondary` toolbar items appear as a horizontal list. On Android and Windows, the `Secondary` items menu appears as three dots that can be tapped:
 
 :::image type="content" source="media/toolbaritem/android-dots.png" alt-text="Screenshot of secondary toolbar ellipsis on Android.":::
@@ -108,5 +110,19 @@ Tapping the three dots reveals items in a vertical list:
 
 :::image type="content" source="media/toolbaritem/android-secondaries.png" alt-text="Screenshot of secondary toolbar items in vertical list on Android.":::
 
+::: moniker-end
+
+::: moniker range=">=net-maui-10.0"
+
+When the <xref:Microsoft.Maui.Controls.ToolbarItem.Order> property is set to `Secondary`, behavior varies across platforms. On iOS and Mac Catalyst, `Secondary` toolbar items are grouped into a pull‑down menu, shown under a system ellipsis icon in the navigation bar. Items within this menu are ordered by their <xref:Microsoft.Maui.Controls.ToolbarItem.Priority> value. On Android and Windows, the `Secondary` items menu appears as three dots that can be tapped:
+
+:::image type="content" source="media/toolbaritem/android-dots.png" alt-text="Screenshot of secondary toolbar ellipsis on Android.":::
+
+Tapping the three dots reveals items in a vertical list:
+
+:::image type="content" source="media/toolbaritem/android-secondaries.png" alt-text="Screenshot of secondary toolbar items in vertical list on Android.":::
+
+::: moniker-end
+
 > [!WARNING]
-> Icon behavior in <xref:Microsoft.Maui.Controls.ToolbarItem> objects that have their <xref:Microsoft.Maui.Controls.ToolbarItem.Order> property set to `Secondary` is inconsistent across platforms. Avoid setting the <xref:Microsoft.Maui.Controls.MenuItem.IconImageSource> property on items that appear in the secondary menu.
+> Icon behavior in <xref:Microsoft.Maui.Controls.ToolbarItem> objects that have their <xref:Microsoft.Maui.Controls.ToolbarItem.Order> property set to `Secondary` can be inconsistent across platforms. Avoid setting the <xref:Microsoft.Maui.Controls.MenuItem.IconImageSource> property on items that appear in the secondary menu.


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/user-interface/controls/switch.md](https://github.com/dotnet/docs-maui/blob/017036d1f34bf9dd14a5f63723ce46e0dd248698/docs/user-interface/controls/switch.md) | [docs/user-interface/controls/switch](https://review.learn.microsoft.com/en-us/dotnet/maui/user-interface/controls/switch?branch=pr-en-us-2988) |
| [docs/user-interface/toolbaritem.md](https://github.com/dotnet/docs-maui/blob/017036d1f34bf9dd14a5f63723ce46e0dd248698/docs/user-interface/toolbaritem.md) | [docs/user-interface/toolbaritem](https://review.learn.microsoft.com/en-us/dotnet/maui/user-interface/toolbaritem?branch=pr-en-us-2988) |


<!-- PREVIEW-TABLE-END -->