### PR TITLE
[NET10] Entry/Editor selection change tracking on Android

### DIFF
--- a/docs/user-interface/controls/editor.md
+++ b/docs/user-interface/controls/editor.md
@@ -1,7 +1,7 @@
 ---
 title: "Editor"
 description: "The .NET MAUI Editor allows you to enter and edit multiple lines of text."
-ms.date: 08/30/2024
+ms.date: 05/13/2025
 ---
 
 # Editor
@@ -43,6 +43,28 @@ These properties are backed by <xref:Microsoft.Maui.Controls.BindableProperty> o
 In addition, <xref:Microsoft.Maui.Controls.InputView> defines a `TextChanged` event, which is raised when the text in the <xref:Microsoft.Maui.Controls.Editor> changes. The `TextChangedEventArgs` object that accompanies the `TextChanged` event has `NewTextValue` and `OldTextValue` properties, which specify the new and old text, respectively.
 
 For information about specifying fonts on an <xref:Microsoft.Maui.Controls.Editor>, see [Fonts](~/user-interface/fonts.md).
+
+::: moniker range=">=net-maui-10.0"
+> [!TIP]
+> On Android, .NET 10 switches the native view for <xref:Microsoft.Maui.Controls.Editor> to `MauiAppCompatEditText`, which enables selection change tracking. As the selection changes, <xref:Microsoft.Maui.Controls.InputView.CursorPosition> and <xref:Microsoft.Maui.Controls.InputView.SelectionLength> are updated so you can react to selection moves.
+
+To observe selection updates, handle property changes for `CursorPosition` and `SelectionLength`:
+
+```csharp
+editor.PropertyChanged += (s, e) =>
+{
+    if (e.PropertyName == nameof(Editor.CursorPosition) ||
+        e.PropertyName == nameof(Editor.SelectionLength))
+    {
+        var start = editor.CursorPosition;
+        var length = editor.SelectionLength;
+        // Respond to selection change (Android .NET 10+)
+    }
+};
+```
+
+Alternatively, data bind the properties and react in your view model.
+::: moniker-end
 
 ## Create an Editor
 

--- a/docs/user-interface/controls/entry.md
+++ b/docs/user-interface/controls/entry.md
@@ -1,7 +1,7 @@
 ---
 title: "Entry"
 description: "The .NET MAUI Entry allows you to enter and edit a single line of text."
-ms.date: 08/30/2024
+ms.date: 05/13/2025
 ms.custom: sfi-ropc-nochange
 ---
 
@@ -48,6 +48,28 @@ These properties are backed by <xref:Microsoft.Maui.Controls.BindableProperty> o
 In addition, <xref:Microsoft.Maui.Controls.InputView> defines a `TextChanged` event, which is raised when the text in the <xref:Microsoft.Maui.Controls.Entry> changes. The `TextChangedEventArgs` object that accompanies the `TextChanged` event has `NewTextValue` and `OldTextValue` properties, which specify the new and old text, respectively.
 
 For information about specifying fonts on an <xref:Microsoft.Maui.Controls.Entry>, see [Fonts](~/user-interface/fonts.md).
+
+::: moniker range=">=net-maui-10.0"
+> [!TIP]
+> Android adds support for selection change notifications in .NET 10. On Android, the native control switches from `AppCompatEditText` to `MauiAppCompatEditText`, enabling selection change tracking for <xref:Microsoft.Maui.Controls.Entry>. As the selection changes, the `CursorPosition` and `SelectionLength` properties are updated so you can react to selection moves.
+
+To observe selection updates, handle property changes for `CursorPosition` and `SelectionLength`:
+
+```csharp
+entry.PropertyChanged += (s, e) =>
+{
+       if (e.PropertyName == nameof(Entry.CursorPosition) ||
+              e.PropertyName == nameof(Entry.SelectionLength))
+       {
+              var start = entry.CursorPosition;
+              var length = entry.SelectionLength;
+              // Respond to selection change (Android .NET 10+)
+       }
+};
+```
+
+Alternatively, data bind the properties and react in your view model.
+::: moniker-end
 
 ## Create an Entry
 


### PR DESCRIPTION

Summary
- On Android in .NET 10, Entry and Editor use MauiAppCompatEditText which enables selection change tracking.
- Document how selection changes are surfaced through the existing CursorPosition and SelectionLength properties.
- Provide a small code sample showing how to observe changes via PropertyChanged.

What changed
- docs/user-interface/controls/entry.md
  - Add >= net-maui-10.0 monikered tip explaining selection tracking on Android.
  - Include a short C# example.
  - Update ms.date to 2025-05-13.

- docs/user-interface/controls/editor.md
  - Add >= net-maui-10.0 monikered tip explaining selection tracking on Android.
  - Include a short C# example.
  - Update ms.date to 2025-05-13.

Rationale
- Matches “What’s new in .NET 10”: Entry/Editor on Android switch to MauiAppCompatEditText, enabling selection tracking.
- Helps developers discover how to react to selection changes in .NET 10 on Android.

Scope/Notes
- Platform: Android only (behavior is consistent with the new native view).
- No breaking changes; documentation-only.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/user-interface/controls/editor.md](https://github.com/dotnet/docs-maui/blob/309b938ceae085bd0ad50e21639a3883e832b2ed/docs/user-interface/controls/editor.md) | [docs/user-interface/controls/editor](https://review.learn.microsoft.com/en-us/dotnet/maui/user-interface/controls/editor?branch=pr-en-us-2989) |
| [docs/user-interface/controls/entry.md](https://github.com/dotnet/docs-maui/blob/309b938ceae085bd0ad50e21639a3883e832b2ed/docs/user-interface/controls/entry.md) | [docs/user-interface/controls/entry](https://review.learn.microsoft.com/en-us/dotnet/maui/user-interface/controls/entry?branch=pr-en-us-2989) |


<!-- PREVIEW-TABLE-END -->