### PR TITLE
[NET10] Webviews interception 

### DIFF
--- a/docs/user-interface/controls/blazorwebview.md
+++ b/docs/user-interface/controls/blazorwebview.md
@@ -1,7 +1,7 @@
 ---
 title: "Host a Blazor web app in a .NET MAUI app using BlazorWebView"
 description: "The .NET MAUI BlazorWebView control enables you to host a Blazor web app in your .NET MAUI app, and integrate the app with device features."
-ms.date: 11/13/2024
+ms.date: 05/13/2025
 ---
 
 # Host a Blazor web app in a .NET MAUI app using BlazorWebView
@@ -251,5 +251,51 @@ static MauiProgram()
     AppContext.SetSwitch("BlazorWebView.AppHostAddressAlways0000", true);
 }
 ```
+
+::: moniker-end
+
+::: moniker range=">=net-maui-10.0"
+
+## Intercept web requests
+
+<xref:Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView> can intercept and respond to web requests initiated from within the embedded web view. This enables scenarios such as modifying headers, redirecting requests, or supplying local responses.
+
+To intercept web requests, handle the `WebResourceRequested` event. In the event handler, set `Handled` to `true` and provide a response via `SetResponse(statusCode, statusDescription, contentType, streamOrTaskOfStream)` when you intend to fully handle the request:
+
+```csharp
+blazorWebView.WebResourceRequested += (s, e) =>
+{
+    // Example: short-circuit a specific API call with a local JSON response
+    if (e.Uri.ToString().Contains("/api/secure", StringComparison.OrdinalIgnoreCase))
+    {
+        e.Handled = true;
+        e.SetResponse(200, "OK", "application/json", GetLocalJsonStreamAsync());
+        return;
+    }
+
+    // Example: add an auth header for a particular host and allow normal processing
+    if (e.Uri.Host.Equals("api.contoso.com", StringComparison.OrdinalIgnoreCase))
+    {
+        e.RequestHeaders["Authorization"] = $"Bearer {GetToken()}";
+        // Don't set Handled; let the request proceed
+    }
+};
+
+private Task<Stream> GetLocalJsonStreamAsync()
+{
+    // Return a stream containing JSON (for example from an embedded asset)
+    var json = Encoding.UTF8.GetBytes("{\"message\":\"Hello from local\"}");
+    return Task.FromResult<Stream>(new MemoryStream(json));
+}
+```
+
+> [!CAUTION]
+> The `WebResourceRequested` callback must execute synchronously on the WebView thread. If you set `Handled = true`, you must call `SetResponse` immediately to provide a response. For asynchronous content generation, pass a `Task<Stream>` to `SetResponse` so the WebView can continue while the stream completes.
+
+Common patterns include:
+
+- Injecting or rewriting headers for specific hosts.
+- Returning local files or in-memory content for offline or testing scenarios.
+- Redirecting to a different URI by returning a 3xx status with a `Location` header.
 
 ::: moniker-end

--- a/docs/user-interface/controls/hybridwebview.md
+++ b/docs/user-interface/controls/hybridwebview.md
@@ -716,9 +716,8 @@ private void HybridWebView_WebResourceRequested(object sender, HybridWebViewWebR
 
 private Task<Stream> GetLocalImageStreamAsync()
 {
-    // Return a stream containing PNG bytes (for example from MauiAsset)
-    Stream s = FileSystem.OpenAppPackageFileAsync("wwwroot/images/sample-image.png").Result;
-    return Task.FromResult(s);
+    // Return a stream containing PNG bytes (for example from a MauiAsset)
+    return FileSystem.OpenAppPackageFileAsync("wwwroot/images/sample-image.png");
 }
 ```
 

--- a/docs/user-interface/controls/hybridwebview.md
+++ b/docs/user-interface/controls/hybridwebview.md
@@ -2,7 +2,7 @@
 title: HybridWebView
 description: Learn how to use a HybridWebView to host HTML/JS/CSS content in a WebView, and communicate between that content and .NET.
 ms.topic: concept-article
-ms.date: 04/01/2025
+ms.date: 05/13/2025
 monikerRange: ">=net-maui-9.0"
 
 #customer intent: As a developer, I want to host HTML/JS/CSS content in a web view so that I can publish the web app as a mobile app.
@@ -678,3 +678,57 @@ The `window.HybridWebView.InvokeDotNet` JavaScript function invokes a specified 
 
 > [!NOTE]
 > Invoking the `window.HybridWebView.InvokeDotNet` JavaScript function requires your app to include the *HybridWebView.js* JavaScript library listed earlier in this article.
+
+::: moniker range=">=net-maui-10.0"
+
+## Intercept web requests
+
+<xref:Microsoft.Maui.Controls.HybridWebView> can intercept and respond to web requests that originate from within the hosted web content. This enables scenarios such as modifying headers, redirecting requests, or supplying local responses.
+
+To intercept web requests, handle the `WebResourceRequested` event. In the event handler, set `Handled` to `true` and provide a response via `SetResponse(statusCode, statusDescription, contentType, streamOrTaskOfStream)`:
+
+```xaml
+<HybridWebView WebResourceRequested="HybridWebView_WebResourceRequested" />
+```
+
+```csharp
+private void HybridWebView_WebResourceRequested(object sender, HybridWebViewWebResourceRequestedEventArgs e)
+{
+    // NOTE:
+    // - This method MUST be synchronous; it's invoked on the WebView's thread.
+    // - You MUST call SetResponse (even a minimal response) if you set Handled = true.
+
+    // Example: serve a local image instead of the network resource
+    if (e.Uri.ToString().EndsWith("sample-image.png", StringComparison.OrdinalIgnoreCase))
+    {
+        e.Handled = true;
+        e.SetResponse(200, "OK", "image/png", GetLocalImageStreamAsync());
+        return;
+    }
+
+    // Example: inject an authorization header for API calls
+    if (e.Uri.Host.Equals("api.contoso.com", StringComparison.OrdinalIgnoreCase))
+    {
+        e.RequestHeaders["Authorization"] = $"Bearer {GetToken()}";
+        // Fall through without setting Handled so the request proceeds normally
+    }
+}
+
+private Task<Stream> GetLocalImageStreamAsync()
+{
+    // Return a stream containing PNG bytes (for example from MauiAsset)
+    Stream s = FileSystem.OpenAppPackageFileAsync("wwwroot/images/sample-image.png").Result;
+    return Task.FromResult(s);
+}
+```
+
+> [!CAUTION]
+> Avoid long-running work in `WebResourceRequested`. If you set `Handled = true`, you must supply a response immediately. For asynchronous content, pass a `Task<Stream>` to `SetResponse` so the WebView can continue while the stream completes.
+
+Common patterns include:
+
+- Injecting or rewriting headers for specific hosts.
+- Returning local files or in-memory content for offline or testing scenarios.
+- Redirecting to a different URI by returning a 3xx status code with an appropriate `Location` header.
+
+::: moniker-end

--- a/docs/user-interface/controls/webview.md
+++ b/docs/user-interface/controls/webview.md
@@ -554,3 +554,14 @@ await Launcher.OpenAsync("https://learn.microsoft.com/dotnet/maui");
 ```
 
 For more information, see [Launcher](~/platform-integration/appmodel/launcher.md).
+
+::: moniker range=">=net-maui-10.0"
+
+## Intercept web requests
+
+For hybrid scenarios that host web content and need to intercept requests (for example, to modify headers or provide local responses), see the interception guidance for:
+
+- [HybridWebView](~/user-interface/controls/hybridwebview.md?view=net-maui-10.0&preserve-view=true#intercept-web-requests)
+- [BlazorWebView](~/user-interface/controls/blazorwebview.md?view=net-maui-10.0&preserve-view=true#intercept-web-requests)
+
+::: moniker-end


### PR DESCRIPTION
- Add >= net-maui-10.0 “Intercept web requests” sections to:
  - HybridWebView: WebResourceRequested usage, SetResponse, RequestHeaders
  - BlazorWebView: same patterns with concise event example
- Cross-link from WebView to interception guidance for hybrid scenarios
- Include [!CAUTION] notes about synchronous handler and immediate SetResponse
- Avoid blocking .Result in sample by returning Task<Stream>


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/user-interface/controls/blazorwebview.md](https://github.com/dotnet/docs-maui/blob/6037dddb17825a9ef0bd02be39078fa1914a6920/docs/user-interface/controls/blazorwebview.md) | [docs/user-interface/controls/blazorwebview](https://review.learn.microsoft.com/en-us/dotnet/maui/user-interface/controls/blazorwebview?branch=pr-en-us-2991) |
| [docs/user-interface/controls/hybridwebview.md](https://github.com/dotnet/docs-maui/blob/6037dddb17825a9ef0bd02be39078fa1914a6920/docs/user-interface/controls/hybridwebview.md) | [docs/user-interface/controls/hybridwebview](https://review.learn.microsoft.com/en-us/dotnet/maui/user-interface/controls/hybridwebview?branch=pr-en-us-2991) |
| [docs/user-interface/controls/webview.md](https://github.com/dotnet/docs-maui/blob/6037dddb17825a9ef0bd02be39078fa1914a6920/docs/user-interface/controls/webview.md) | [docs/user-interface/controls/webview](https://review.learn.microsoft.com/en-us/dotnet/maui/user-interface/controls/webview?branch=pr-en-us-2991) |

<!-- PREVIEW-TABLE-END -->