### PR TITLE
Shell SearchHandler: document .NET 10 soft input keyboard methods

### DIFF
--- a/docs/fundamentals/shell/search.md
+++ b/docs/fundamentals/shell/search.md
@@ -1,7 +1,7 @@
 ---
 title: ".NET MAUI Shell search"
 description: "Learn how .NET MAUI Shell apps can use integrated search functionality that's provided by a search box that can be added to the top of each page."
-ms.date: 08/19/2025
+ms.date: 08/20/2025
 ---
 
 # .NET MAUI Shell search
@@ -254,3 +254,55 @@ The following XAML code example shows how to customize the default `Keyboard` to
     </SearchHandler.Keyboard>
 </SearchHandler>
 ```
+
+## Hide and show the soft input keyboard
+
+::: moniker range=">=net-maui-10.0"
+
+In .NET 10, <xref:Microsoft.Maui.Controls.SearchHandler> gains methods to programmatically control the soft input keyboard:
+
+- <xref:Microsoft.Maui.Controls.SearchHandler.ShowSoftInputAsync>
+- <xref:Microsoft.Maui.Controls.SearchHandler.HideSoftInputAsync>
+
+These methods let you bring up the keyboard when the user navigates to a page with search, and dismiss it once a result is chosen, without relying on focus changes.
+
+For example, you can auto-open the keyboard when the page appears:
+
+```csharp
+// In a ContentPage code-behind
+protected override void OnAppearing()
+{
+    base.OnAppearing();
+
+    var handler = Shell.GetSearchHandler(this);
+    handler?.ShowSoftInputAsync();
+}
+```
+
+And you can hide the keyboard after a selection is made in your custom SearchHandler:
+
+```csharp
+public class AnimalSearchHandler : SearchHandler
+{
+    protected override async void OnItemSelected(object item)
+    {
+        base.OnItemSelected(item);
+
+        // Dismiss the soft input keyboard
+        HideSoftInputAsync();
+
+        // Perform navigation or other actions
+        await Shell.Current.GoToAsync("monkeydetails", new Dictionary<string, object>
+        {
+            { "Monkey", item }
+        });
+    }
+}
+```
+
+Notes:
+
+- On platforms without a software keyboard (for example, desktop with a hardware keyboard), these methods may be no-ops.
+- If you need to direct focus to the search box, you can continue to use <xref:Microsoft.Maui.Controls.SearchHandler.Focus> and <xref:Microsoft.Maui.Controls.SearchHandler.Unfocus>. Showing or hiding the soft input is complementary to focus.
+
+::: moniker-end

--- a/docs/fundamentals/shell/search.md
+++ b/docs/fundamentals/shell/search.md
@@ -289,7 +289,7 @@ public class AnimalSearchHandler : SearchHandler
         base.OnItemSelected(item);
 
         // Dismiss the soft input keyboard
-        HideSoftInputAsync();
+        await HideSoftInputAsync();
 
         // Perform navigation or other actions
         await Shell.Current.GoToAsync("monkeydetails", new Dictionary<string, object>


### PR DESCRIPTION
This PR adds a focused .NET 10 update to the Shell SearchHandler docs to cover programmatic soft input control.

Summary
- Adds a >= net-maui-10.0 monikered section to `docs/fundamentals/shell/search.md`
- Documents `SearchHandler.ShowSoftInputAsync` and `SearchHandler.HideSoftInputAsync`
- Provides small C# examples for auto-showing the keyboard on page appear and hiding it on item selection
- Updates `ms.date`

Motivation and migration
- Prior to .NET 10, soft input control for text inputs was via `SoftInputExtensions` on `ITextInput` (Entry, Editor, SearchBar). `SearchHandler` did not have dedicated APIs to show/hide the soft input keyboard without focus gymnastics or platform code.
- In .NET 10, `SearchHandler` adds first-class methods to manage the soft input keyboard. This enables better UX patterns (auto-open at page load, dismiss on selection) without altering focus.

Source/API references
- API: `SearchHandler.ShowSoftInputAsync` (net-maui-10.0)
- API: `SearchHandler.HideSoftInputAsync` (net-maui-10.0)

Notes
- Section is fully monikered and linted; minimal change footprint per our .NET 10 docs update process.

Files changed
- docs/fundamentals/shell/search.md

ms.date
- Updated to 2025-08-20.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/shell/search.md](https://github.com/dotnet/docs-maui/blob/153691bb1efae9f3220251238f45813d211964a8/docs/fundamentals/shell/search.md) | [docs/fundamentals/shell/search](https://review.learn.microsoft.com/en-us/dotnet/maui/fundamentals/shell/search?branch=pr-en-us-3002) |


<!-- PREVIEW-TABLE-END -->