### PR TITLE
HybridWebView (.NET 10): initialization customization and platform view access

### DIFF
--- a/docs/user-interface/controls/hybridwebview.md
+++ b/docs/user-interface/controls/hybridwebview.md
@@ -685,7 +685,7 @@ The `window.HybridWebView.InvokeDotNet` JavaScript function invokes a specified 
 
 While <xref:Microsoft.Maui.Controls.HybridWebView> doesn’t expose app-facing initializing/initialized events like <xref:Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView>, you can still customize the underlying platform web views and run code after they’re ready:
 
-- Windows (WebView2): the platform view is <xref:Microsoft.Maui.Platform.MauiHybridWebView>, which inherits `WebView2` and adds `RunAfterInitialize(Action)` so you can safely access `CoreWebView2` once it’s ready.
+- Windows (WebView2): the platform view is <xref:Microsoft.Maui.Controls.HybridWebView>, which inherits `WebView2` and adds `RunAfterInitialize(Action)` so you can safely access `CoreWebView2` once it’s ready.
 - Android (android.webkit.WebView): access and configure the platform `WebView` via the handler once it’s created.
 - iOS/Mac Catalyst (WKWebView): access and configure the platform `WKWebView` after creation. Some options (such as certain `WKWebViewConfiguration` settings) must be set at creation time; .NET MAUI sets sensible defaults for these.
 

--- a/docs/user-interface/controls/hybridwebview.md
+++ b/docs/user-interface/controls/hybridwebview.md
@@ -173,7 +173,7 @@ To create a .NET MAUI app with a <xref:Microsoft.Maui.Controls.HybridWebView>:
         </html>
         ```
 
-::: moniker range="<=net-maui-9.0"
+    ::: moniker range="<=net-maui-9.0"
     - *Resources\Raw\wwwroot\scripts\HybridWebView.js* with the standard <xref:Microsoft.Maui.Controls.HybridWebView> JavaScript library:
 
         ```js
@@ -323,8 +323,7 @@ To create a .NET MAUI app with a <xref:Microsoft.Maui.Controls.HybridWebView>:
         window.HybridWebView.Init();
         ```
 
-::: moniker-end
-
+    ::: moniker-end
     Then, add any additional web content to your project.
 
     > [!WARNING]

--- a/docs/user-interface/controls/hybridwebview.md
+++ b/docs/user-interface/controls/hybridwebview.md
@@ -172,6 +172,7 @@ To create a .NET MAUI app with a <xref:Microsoft.Maui.Controls.HybridWebView>:
         </body>
         </html>
         ```
+::: moniker range="<=net-maui-9.0"
 
     - *Resources\Raw\wwwroot\scripts\HybridWebView.js* with the standard <xref:Microsoft.Maui.Controls.HybridWebView> JavaScript library:
 
@@ -321,6 +322,7 @@ To create a .NET MAUI app with a <xref:Microsoft.Maui.Controls.HybridWebView>:
 
         window.HybridWebView.Init();
         ```
+::: moniker-end
 
     Then, add any additional web content to your project.
 

--- a/docs/user-interface/controls/hybridwebview.md
+++ b/docs/user-interface/controls/hybridwebview.md
@@ -47,6 +47,7 @@ To create a .NET MAUI app with a <xref:Microsoft.Maui.Controls.HybridWebView>:
 
     - *Resources\Raw\wwwroot\index.html* with content for the main UI:
         ::: moniker range="<=net-maui-9.0"
+
         ```html
         <!DOCTYPE html>
 
@@ -172,8 +173,10 @@ To create a .NET MAUI app with a <xref:Microsoft.Maui.Controls.HybridWebView>:
         </body>
         </html>
         ```
+
         ::: moniker-end
         ::: moniker range=">=net-maui-10.0"
+
         ```html
         <!DOCTYPE html>
 
@@ -299,8 +302,8 @@ To create a .NET MAUI app with a <xref:Microsoft.Maui.Controls.HybridWebView>:
         </body>
         </html>
         ```
-        ::: moniker-end
 
+        ::: moniker-end
     ::: moniker range="<=net-maui-9.0"
     - *Resources\Raw\wwwroot\scripts\HybridWebView.js* with the standard <xref:Microsoft.Maui.Controls.HybridWebView> JavaScript library:
 

--- a/docs/user-interface/controls/hybridwebview.md
+++ b/docs/user-interface/controls/hybridwebview.md
@@ -172,8 +172,8 @@ To create a .NET MAUI app with a <xref:Microsoft.Maui.Controls.HybridWebView>:
         </body>
         </html>
         ```
-::: moniker range="<=net-maui-9.0"
 
+::: moniker range="<=net-maui-9.0"
     - *Resources\Raw\wwwroot\scripts\HybridWebView.js* with the standard <xref:Microsoft.Maui.Controls.HybridWebView> JavaScript library:
 
         ```js
@@ -322,6 +322,7 @@ To create a .NET MAUI app with a <xref:Microsoft.Maui.Controls.HybridWebView>:
 
         window.HybridWebView.Init();
         ```
+
 ::: moniker-end
 
     Then, add any additional web content to your project.

--- a/docs/user-interface/controls/hybridwebview.md
+++ b/docs/user-interface/controls/hybridwebview.md
@@ -46,7 +46,7 @@ To create a .NET MAUI app with a <xref:Microsoft.Maui.Controls.HybridWebView>:
     A simple app might have the following files and contents:
 
     - *Resources\Raw\wwwroot\index.html* with content for the main UI:
-
+        ::: moniker range="<=net-maui-9.0"
         ```html
         <!DOCTYPE html>
 
@@ -56,12 +56,7 @@ To create a .NET MAUI app with a <xref:Microsoft.Maui.Controls.HybridWebView>:
             <title></title>
             <link rel="icon" href="data:,">
             <link rel="stylesheet" href="styles/app.css">
-            ::: moniker range="<=net-maui-9.0"
             <script src="scripts/HybridWebView.js"></script>
-            ::: moniker-end
-            ::: moniker range=">=net-maui-10.0"
-            <script src="_framework/hybridwebview.js"></script>
-            ::: moniker-end
             <script>
                 function LogMessage(msg) {
                     var messageLog = document.getElementById("messageLog");
@@ -177,6 +172,134 @@ To create a .NET MAUI app with a <xref:Microsoft.Maui.Controls.HybridWebView>:
         </body>
         </html>
         ```
+        ::: moniker-end
+        ::: moniker range=">=net-maui-10.0"
+        ```html
+        <!DOCTYPE html>
+
+        <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+        <head>
+            <meta charset="utf-8" />
+            <title></title>
+            <link rel="icon" href="data:,">
+            <link rel="stylesheet" href="styles/app.css">
+            <script src="_framework/hybridwebview.js"></script>
+            <script>
+                function LogMessage(msg) {
+                    var messageLog = document.getElementById("messageLog");
+                    messageLog.value += '\r\n' + msg;
+                }
+
+                window.addEventListener(
+                    "HybridWebViewMessageReceived",
+                    function (e) {
+                        LogMessage("Raw message: " + e.detail.message);
+                    });
+
+                function AddNumbers(a, b) {
+                    var result = {
+                        "result": a + b,
+                        "operationName": "Addition"
+                    };
+                    return result;
+                }
+
+                var count = 0;
+
+                async function EvaluateMeWithParamsAndAsyncReturn(s1, s2) {
+                    const response = await fetch("/asyncdata.txt");
+                    if (!response.ok) {
+                        throw new Error(`HTTP error: ${response.status}`);
+                    }
+                    var jsonData = await response.json();
+
+                    jsonData[s1] = s2;
+
+                    const msg = 'JSON data is available: ' + JSON.stringify(jsonData);
+                    window.HybridWebView.SendRawMessage(msg)
+
+                    return jsonData;
+                }
+
+                async function InvokeDoSyncWork() {
+                    LogMessage("Invoking DoSyncWork");
+                    await window.HybridWebView.InvokeDotNet('DoSyncWork');
+                    LogMessage("Invoked DoSyncWork");
+                }
+
+                async function InvokeDoSyncWorkParams() {
+                    LogMessage("Invoking DoSyncWorkParams");
+                    await window.HybridWebView.InvokeDotNet('DoSyncWorkParams', [123, 'hello']);
+                    LogMessage("Invoked DoSyncWorkParams");
+                }
+
+                async function InvokeDoSyncWorkReturn() {
+                    LogMessage("Invoking DoSyncWorkReturn");
+                    const retValue = await window.HybridWebView.InvokeDotNet('DoSyncWorkReturn');
+                    LogMessage("Invoked DoSyncWorkReturn, return value: " + retValue);
+                }
+
+                async function InvokeDoSyncWorkParamsReturn() {
+                    LogMessage("Invoking DoSyncWorkParamsReturn");
+                    const retValue = await window.HybridWebView.InvokeDotNet('DoSyncWorkParamsReturn', [123, 'hello']);
+                    LogMessage("Invoked DoSyncWorkParamsReturn, return value: message=" + retValue.Message + ", value=" + retValue.Value);
+                }
+
+                async function InvokeDoAsyncWork() {
+                    LogMessage("Invoking DoAsyncWork");
+                    await window.HybridWebView.InvokeDotNet('DoAsyncWork');
+                    LogMessage("Invoked DoAsyncWork");
+                }
+
+                async function InvokeDoAsyncWorkParams() {
+                    LogMessage("Invoking DoAsyncWorkParams");
+                    await window.HybridWebView.InvokeDotNet('DoAsyncWorkParams', [123, 'hello']);
+                    LogMessage("Invoked DoAsyncWorkParams");
+                }
+
+                async function InvokeDoAsyncWorkReturn() {
+                    LogMessage("Invoking DoAsyncWorkReturn");
+                    const retValue = await window.HybridWebView.InvokeDotNet('DoAsyncWorkReturn');
+                    LogMessage("Invoked DoAsyncWorkReturn, return value: " + retValue);
+                }
+
+                async function InvokeDoAsyncWorkParamsReturn() {
+                    LogMessage("Invoking DoAsyncWorkParamsReturn");
+                    const retValue = await window.HybridWebView.InvokeDotNet('DoAsyncWorkParamsReturn', [123, 'hello']);
+                    LogMessage("Invoked DoAsyncWorkParamsReturn, return value: message=" + retValue.Message + ", value=" + retValue.Value);
+                }                
+
+            </script>
+        </head>
+        <body>
+            <div>
+                Hybrid sample!
+            </div>
+            <div>
+                <button onclick="window.HybridWebView.SendRawMessage('Message from JS! ' + (count++))">Send message to C#</button>
+            </div>
+            <div>
+                <button onclick="InvokeDoSyncWork()">Call C# sync method (no params)</button>
+                <button onclick="InvokeDoSyncWorkParams()">Call C# sync method (params)</button>
+                <button onclick="InvokeDoSyncWorkReturn()">Call C# method (no params) and get simple return value</button>
+                <button onclick="InvokeDoSyncWorkParamsReturn()">Call C# method (params) and get complex return value</button>
+            </div>
+            <div>
+                <button onclick="InvokeDoAsyncWork()">Call C# async method (no params)</button>
+                <button onclick="InvokeDoAsyncWorkParams()">Call C# async method (params)</button>
+                <button onclick="InvokeDoAsyncWorkReturn()">Call C# async method (no params) and get simple return value</button>
+                <button onclick="InvokeDoAsyncWorkParamsReturn()">Call C# async method (params) and get complex return value</button>
+            </div>            
+            <div>
+                Log: <textarea readonly id="messageLog" style="width: 80%; height: 10em;"></textarea>
+            </div>
+            <div>
+                Consider checking out this PDF: <a href="docs/sample.pdf">sample.pdf</a>
+            </div>
+        </body>
+        </html>
+        ```
+        ::: moniker-end
 
     ::: moniker range="<=net-maui-9.0"
     - *Resources\Raw\wwwroot\scripts\HybridWebView.js* with the standard <xref:Microsoft.Maui.Controls.HybridWebView> JavaScript library:

--- a/docs/user-interface/controls/hybridwebview.md
+++ b/docs/user-interface/controls/hybridwebview.md
@@ -56,7 +56,12 @@ To create a .NET MAUI app with a <xref:Microsoft.Maui.Controls.HybridWebView>:
             <title></title>
             <link rel="icon" href="data:,">
             <link rel="stylesheet" href="styles/app.css">
+            ::: moniker range="<=net-maui-9.0"
             <script src="scripts/HybridWebView.js"></script>
+            ::: moniker-end
+            ::: moniker range=">=net-maui-10.0"
+            <script src="_framework/hybridwebview.js"></script>
+            ::: moniker-end
             <script>
                 function LogMessage(msg) {
                     var messageLog = document.getElementById("messageLog");


### PR DESCRIPTION
This PR adds .NET 10 guidance to customize initialization and access platform web views in `HybridWebView`.

Summary of changes:
- Adds a new ">= net-maui-10.0" section "Customize initialization and access platform web views" to `docs/user-interface/controls/hybridwebview.md`.
- Documents Windows `MauiHybridWebView.RunAfterInitialize` for safe access to `CoreWebView2` after initialization.
- Shows how to access and tweak the platform views on Android (`android.webkit.WebView`) and iOS/Mac Catalyst (`WKWebView`) after creation via `HandlerChanged`.
- Includes an advanced custom handler example to provide a `WKWebViewConfiguration` at creation time when platform options must be set before the view is created.
- Updates `ms.date`.

Motivation / verification:
- HybridWebView does not expose app-facing initializing/initialized events like BlazorWebView. The recommended approach is to use platform view access and, on Windows, `RunAfterInitialize`.
- Verified against MAUI net10 source (handlers for Windows/Android/iOS/macOS) and `MauiHybridWebView` helper.

Related upstream references:
- dotnet/maui#28876 (intercept all web requests – context for recent HybridWebView docs)
- dotnet/maui#29790 (HybridWebView TypeScript)
- dotnet/maui#29794 (expose hybrid script)

Docs hygiene:
- Moniker blocks are balanced.
- Examples compile logically; no xref changes needed.

Once merged, I'll update the tracker entry to link to this PR and mark status accordingly.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/user-interface/controls/hybridwebview.md](https://github.com/dotnet/docs-maui/blob/a9b7749aff98ad1d4f97636a1704326950256116/docs/user-interface/controls/hybridwebview.md) | [docs/user-interface/controls/hybridwebview](https://review.learn.microsoft.com/en-us/dotnet/maui/user-interface/controls/hybridwebview?branch=pr-en-us-3003) |


<!-- PREVIEW-TABLE-END -->