### PR TITLE
Change parameter type in HybridWebView_WebResourceRequested

### DIFF
--- a/docs/user-interface/controls/hybridwebview.md
+++ b/docs/user-interface/controls/hybridwebview.md
@@ -919,7 +919,7 @@ To intercept web requests, handle the `WebResourceRequested` event. In the event
 ```
 
 ```csharp
-private void HybridWebView_WebResourceRequested(object sender, HybridWebViewWebResourceRequestedEventArgs e)
+private void HybridWebView_WebResourceRequested(object sender, WebViewWebResourceRequestedEventArgs e)
 {
     // NOTE:
     // - This method MUST be synchronous; it's invoked on the WebView's thread.


### PR DESCRIPTION
Corrected naming of the parameter to WebResourceRequested event.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/user-interface/controls/hybridwebview.md](https://github.com/dotnet/docs-maui/blob/8d66309e2a59c63f16355f7b2e4d80354886d0f8/docs/user-interface/controls/hybridwebview.md) | [docs/user-interface/controls/hybridwebview](https://review.learn.microsoft.com/en-us/dotnet/maui/user-interface/controls/hybridwebview?branch=pr-en-us-3008) |

<!-- PREVIEW-TABLE-END -->