### PR TITLE
Revise XAML source generation instructions for .NET MAUI

### DIFF
--- a/docs/whats-new/dotnet-10.md
+++ b/docs/whats-new/dotnet-10.md
@@ -409,21 +409,19 @@ The secondary items are grouped into a pull-down menu with the system ellipsis i
 
 ### Source Generator
 
+> [!NOTE]
+> The below are the instructions for .NET MAUI 10 RC1 and newer. Before RC1 enabling source generation was different. Please update to RC1 and use the below instructions. Any other code you have implemented to enable source generation can now be removed.
+
 .NET MAUI now includes a source generator for XAML that improves build performance and enables better tooling support. This generator creates strongly-typed code for your XAML files at compile time, reducing runtime overhead and providing better IntelliSense support.
 
 The source generator decorates generated types with the `[Generated]` attribute for better tooling integration and debugging support.
 
-To enable XAML source generation, opt-in to preview features and then decorate your C# with the `XamlProcessing` directive.
+To enable XAML source generation, add the below property to the project file of your .NET MAUI project. Make sure to add it in a `PropertyGroup`, which can be a new one or an existing one in your csproj file.
 
 ```xml
 <PropertyGroup>
-  <EnablePreviewFeatures>true</EnablePreviewFeatures>
+  <MauiXamlInflator>SourceGen</MauiXamlInflator>
 </PropertyGroup>
-```
-
-```csharp
-[assembly: XamlProcessing(XamlInflator.SourceGen)]
-namespace MyApp;
 ```
 
 ### Implicit and Global XML namespaces


### PR DESCRIPTION
Updated instructions for enabling XAML source generation in .NET MAUI 10 RC1 and newer, including changes to the project file configuration.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/whats-new/dotnet-10.md](https://github.com/dotnet/docs-maui/blob/2e90d0df7a1726328a1799be88ee7e08e6206e3d/docs/whats-new/dotnet-10.md) | [docs/whats-new/dotnet-10](https://review.learn.microsoft.com/en-us/dotnet/maui/whats-new/dotnet-10?branch=pr-en-us-3025) |

<!-- PREVIEW-TABLE-END -->