### PR TITLE
Update android/app-links.md

### DIFF
--- a/docs/android/app-links.md
+++ b/docs/android/app-links.md
@@ -215,6 +215,16 @@ public static class MauiProgram
                             Task.Run(() => HandleAppLink(data));
                         }
                     });
+                    android.OnNewIntent((activity, intent) =>
+                    {
+                        var action = intent?.Action;
+                        var data = intent?.Data?.ToString();
+
+                        if (action == Android.Content.Intent.ActionView && data is not null)
+                        {
+                            Task.Run(() => HandleAppLink(data));
+                        }
+                    });
                 });
 #endif
             });


### PR DESCRIPTION
The code example in Android app links document shows how to handle app link when the app is not running. This PR updates the code fragment who handle the `OnNewIntent` event which will handle links when the app is already running.