### PR TITLE
Update XAML documentation to reflect XAML processing approach

### DIFF
--- a/docs/xaml/xamlc.md
+++ b/docs/xaml/xamlc.md
@@ -16,12 +16,15 @@ ms.date: 11/14/2024
 
 .NET MAUI provides different XAML inflators that control how XAML is processed and converted into user interface elements:
 
-- **Default inflator** - Processes XAML at build time and embeds it as resources in the assembly. XAML is inflated at runtime.
-- **Source generation inflator** - Generates C# code at build time from XAML, which is then compiled into the assembly. This provides the best performance and smallest app size.
+- **Runtime** - XAML files are embedded as resources in the assembly and inflated at runtime. This is the default for Debug builds.
+- **XamlC** - XAML is validated at build time and converted to IL that's written to the assembly. This is the default for Release builds.
+- **SourceGen** - XAML is processed at build time and C# code is generated via source generation. This provides the best performance and smallest app size.
+
+By default, .NET MAUI uses **Runtime** inflator for Debug builds (for faster builds) and **XamlC** inflator for Release builds (for better runtime performance).
 
 ## Using source generation (recommended)
 
-Source generation is the recommended approach for processing XAML in .NET MAUI applications. It generates C# code from your XAML at build time, resulting in better performance and smaller app sizes.
+Source generation is the recommended approach for processing XAML in .NET MAUI applications. It generates C# code from your XAML at build time, resulting in better performance and smaller app sizes compared to both Runtime and XamlC inflators.
 
 To enable source generation for your entire project, add the following property to your project file:
 
@@ -31,7 +34,7 @@ To enable source generation for your entire project, add the following property 
 </PropertyGroup>
 ```
 
-With source generation enabled, your XAML files are processed at build time and converted to C# code, which is then compiled into your application. This eliminates the need for runtime XAML parsing and improves application startup performance.
+With source generation enabled, your XAML files are processed at build time and converted to C# code, which is then compiled into your application. This eliminates the need for runtime XAML parsing and produces more optimized code than XamlC.
 
 > [!TIP]
 > Source generation is particularly beneficial for release builds where performance and app size are critical. We recommend trying source generation in your projects to take advantage of these benefits.
@@ -46,19 +49,25 @@ In rare cases where you need to use a different inflator for specific XAML files
 ```xml
 <ItemGroup>
   <MauiXaml Update="Views\MySpecialPage.xaml">
-    <Inflator>Default</Inflator>
+    <Inflator>Runtime</Inflator>
   </MauiXaml>
 </ItemGroup>
 ```
 
-This allows you to use the default inflator for specific files while using source generation for the rest of your project.
+This allows you to use a different inflator for specific files while using source generation for the rest of your project. Valid values are:
+
+- `Runtime` - Inflate at runtime
+- `XamlC` - Compile to IL
+- `SourceGen` - Generate C# source code
+
+You can also specify multiple inflators separated by semicolons (e.g., `Runtime;SourceGen`) for testing purposes, though this is primarily used in the .NET MAUI test suite.
 
 > [!NOTE]
 > Per-file inflator selection should only be used in exceptional cases where specific XAML files have compatibility issues with source generation.
 
 ## Legacy XamlCompilation attribute
 
-The `XamlCompilationAttribute` class was used in earlier versions to control XAML compilation behavior. This attribute is now obsolete and should not be used in new projects. Instead, rely on the default XAML processing behavior or use the `MauiXamlInflator` property to enable source generation.
+The `XamlCompilationAttribute` class was used in earlier versions to control XAML compilation behavior. This attribute is now considered legacy and should not be used in new projects. Instead, rely on the default XAML processing behavior or configure the inflator using the `MauiXamlInflator` project property.
 
 If your project contains code like this:
 
@@ -76,4 +85,4 @@ public partial class MyPage : ContentPage
 }
 ```
 
-You can safely remove these attributes and trust the default XAML processing behavior, which is optimized for .NET MAUI applications.
+You can safely remove these attributes. The default XAML processing behavior is optimized for .NET MAUI applications, using Runtime inflator for Debug builds and XamlC inflator for Release builds. If you want better performance, configure `MauiXamlInflator` property instead of using the attribute.

--- a/docs/xaml/xamlc.md
+++ b/docs/xaml/xamlc.md
@@ -1,67 +1,79 @@
 ---
-title: "XAML compilation"
-description: ".NET MAUI XAML is compiled directly into intermediate language (IL) with the XAML compiler (XAMLC)."
-ms.date: 02/24/2022
+title: "XAML processing"
+description: ".NET MAUI XAML is processed and inflated at build time or runtime using different inflators, including source generation."
+ms.date: 11/14/2024
 ---
 
-# XAML compilation
+# XAML processing
 
-.NET Multi-platform App UI (.NET MAUI) XAML is compiled directly into intermediate language (IL) with the XAML compiler (XAMLC). XAML compilation offers a number of benefits:
+.NET Multi-platform App UI (.NET MAUI) XAML is processed and inflated into the corresponding user interface. XAML processing offers a number of benefits:
 
 - It performs compile-time checking of XAML, notifying you of any errors.
-- It removes some of the load and instantiation time for XAML elements.
-- It helps to reduce the file size of the final assembly by no longer including .xaml files.
+- It improves the load and instantiation time for XAML elements.
+- It helps to reduce the file size of the final assembly.
 
-XAML compilation is enabled by default in .NET MAUI apps. For apps built using the debug configuration, XAML compilation provides compile-time validation of XAML, but does not convert the XAML to IL in the assembly. Instead, XAML files are included as embedded resources in the app package, and evaluated at runtime. For apps built using the release configuration, XAML compilation provides compile-time validation of XAML, and converts the XAML to IL that's written to the assembly. However, XAML compilation behavior can be overridden in both configurations with the <xref:Microsoft.Maui.Controls.Xaml.XamlCompilationAttribute> class.
+## XAML inflators
+
+.NET MAUI provides different XAML inflators that control how XAML is processed and converted into user interface elements:
+
+- **Default inflator** - Processes XAML at build time and embeds it as resources in the assembly. XAML is inflated at runtime.
+- **Source generation inflator** - Generates C# code at build time from XAML, which is then compiled into the assembly. This provides the best performance and smallest app size.
+
+## Using source generation (recommended)
+
+Source generation is the recommended approach for processing XAML in .NET MAUI applications. It generates C# code from your XAML at build time, resulting in better performance and smaller app sizes.
+
+To enable source generation for your entire project, add the following property to your project file:
+
+```xml
+<PropertyGroup>
+  <MauiXamlInflator>SourceGen</MauiXamlInflator>
+</PropertyGroup>
+```
+
+With source generation enabled, your XAML files are processed at build time and converted to C# code, which is then compiled into your application. This eliminates the need for runtime XAML parsing and improves application startup performance.
+
+> [!TIP]
+> Source generation is particularly beneficial for release builds where performance and app size are critical. We recommend trying source generation in your projects to take advantage of these benefits.
 
 > [!IMPORTANT]
-> Compiled bindings can be enabled to improve data binding performance in .NET MAUI applications. For more information, see [Compiled Bindings](~/fundamentals/data-binding/compiled-bindings.md).
+> Compiled bindings can be enabled to further improve data binding performance in .NET MAUI applications. For more information, see [Compiled Bindings](~/fundamentals/data-binding/compiled-bindings.md).
 
-## Disable XAML compilation
+## Per-file inflator selection
 
-XAML compilation can be disabled by passing `XamlCompilationOptions.Skip` to the <xref:Microsoft.Maui.Controls.Xaml.XamlCompilationAttribute>:
+In rare cases where you need to use a different inflator for specific XAML files, you can set the `Inflator` metadata on individual `MauiXaml` items in your project file:
 
-```csharp
-[assembly: XamlCompilation(XamlCompilationOptions.Skip)]
+```xml
+<ItemGroup>
+  <MauiXaml Update="Views\MySpecialPage.xaml">
+    <Inflator>Default</Inflator>
+  </MauiXaml>
+</ItemGroup>
 ```
 
-In this example, XAML compilation is disabled within the assembly, with XAML errors being reported at runtime rather than compile-time.
+This allows you to use the default inflator for specific files while using source generation for the rest of your project.
 
-XAML compilation can also be disabled at the type level:
+> [!NOTE]
+> Per-file inflator selection should only be used in exceptional cases where specific XAML files have compatibility issues with source generation.
 
-```csharp
-[XamlCompilation (XamlCompilationOptions.Skip)]
-public partial class MyPage : ContentPage
-{
-    ...
-}
-```
+## Legacy XamlCompilation attribute
 
-In this example, XAML compilation is disabled only for the `MyPage` class.
+The `XamlCompilationAttribute` class was used in earlier versions to control XAML compilation behavior. This attribute is now obsolete and should not be used in new projects. Instead, rely on the default XAML processing behavior or use the `MauiXamlInflator` property to enable source generation.
 
-> [!WARNING]
-> Disabling XAML compilation is not recommended because XAML is then parsed and interpreted at runtime, which will reduce app performance.
-
-## Enable XAML compilation
-
-Because XAML compilation is enabled by default in .NET MAUI apps, removing any `XamlCompilation(XamlCompilationOptions.Skip)` statements will ensure that XAML compilation is enabled.
-
-Alternatively, XAML compilation can be forcibly enabled by passing `XamlCompilationOptions.Compile` to the <xref:Microsoft.Maui.Controls.Xaml.XamlCompilationAttribute>:
+If your project contains code like this:
 
 ```csharp
 [assembly: XamlCompilation(XamlCompilationOptions.Compile)]
 ```
 
-In this example, XAML compilation is enabled for all of the XAML contained within the assembly, with XAML errors being reported at compile-time rather than runtime.
-
-XAML compilation can also be enabled at the type level:
+or
 
 ```csharp
-[XamlCompilation (XamlCompilationOptions.Compile)]
+[XamlCompilation(XamlCompilationOptions.Skip)]
 public partial class MyPage : ContentPage
 {
     ...
 }
 ```
 
-In this example, XAML compilation is enabled only for the `MyPage` class.
+You can safely remove these attributes and trust the default XAML processing behavior, which is optimized for .NET MAUI applications.


### PR DESCRIPTION
This PR updates the XAML compilation documentation to reflect the modern XAML processing approach in .NET MAUI.

## Changes

- **Title change**: 'XAML compilation' → 'XAML processing'
- **Removed XamlCompilation attribute recommendations**: The documentation no longer recommends using the  attribute, which is now considered legacy
- **Added source generation documentation**: New section recommending the use of  for better performance
- **Per-file inflator selection**: Documented how to use the  metadata on  items for rare cases requiring different inflators per file
- **Legacy section**: Added information about the obsolete  for developers with existing code

## Rationale

The terminology has shifted from 'XAML compilation' to 'XAML processing' to better reflect how XAML is handled in modern .NET MAUI applications. The new source generation approach provides better performance and smaller app sizes compared to traditional XAML compilation.

This documentation update helps developers:
- Understand the modern XAML processing approach
- Adopt source generation for improved performance
- Migrate away from legacy XamlCompilation attributes
- Trust the defaults while having fine-grained control when needed