### PR TITLE
Document implementation restrictions when intercepting web requests

### DIFF
--- a/docs/user-interface/controls/hybridwebview.md
+++ b/docs/user-interface/controls/hybridwebview.md
@@ -1024,4 +1024,19 @@ Common patterns include:
 - Returning local files or in-memory content for offline or testing scenarios.
 - Redirecting to a different URI by returning a 3xx status code with an appropriate `Location` header.
 
+### Implementation Restrictions
+
+* **Android**
+  * Android does not directly allow "intercept-and-continue" for requests. The implementation is to rather notify you that a request is about to happen and you can either replace the whole request or do nothing and let the webview do it.  
+  * Android does not support custom schemes.
+* **iOS/Mac Catalyst**
+  * iOS and Mac Catalyst do not allow interception of `http` and `https` requests.
+
+| Platform      | Intercept HTTPS | Intercept Custom Schemes | Request Modification |
+|---------------|------------------|---------------------------|----------------------|
+| Android       | ✅               | ❌                        | ❌                   |
+| iOS           | ❌               | ✅                        | ❌                   |
+| Mac Catalyst  | ❌               | ✅                        | ❌                   |
+| Windows       | ✅               | ✅                        | ✅                   |
+
 ::: moniker-end


### PR DESCRIPTION
Added implementation restrictions when intercepting requests for hybridwebview on different platforms.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/user-interface/controls/hybridwebview.md](https://github.com/dotnet/docs-maui/blob/dfa20df49ef7bc09c4ceed442ef2f3863d7dce02/docs/user-interface/controls/hybridwebview.md) | [docs/user-interface/controls/hybridwebview](https://review.learn.microsoft.com/en-us/dotnet/maui/user-interface/controls/hybridwebview?branch=pr-en-us-3096) |

<!-- PREVIEW-TABLE-END -->