### PR TITLE
Update include syntax for picker documentation

### DIFF
--- a/docs/user-interface/controls/picker.md
+++ b/docs/user-interface/controls/picker.md
@@ -262,6 +262,6 @@ This method obtains the `SelectedIndex` property value, and uses the value to re
 
 ::: moniker range=">=net-maui-10.0"
 
-::: include ../../includes/pickers-open-close-dotnet10.md
+[!INCLUDE [pickers-open-close-dotnet10](../../includes/pickers-open-close-dotnet10.md)]
 
 ::: moniker-end


### PR DESCRIPTION
There's a small error in the Picker page: https://learn.microsoft.com/en-us/dotnet/maui/user-interface/controls/picker?view=net-maui-10.0

<img width="788" height="411" alt="image" src="https://github.com/user-attachments/assets/f07d9a26-cf24-4c70-8641-d7032f3ad179" />


Looking at other examples I think this is the right fix