### PR TITLE
Correct the default value for Label.LineBreakMode property

### DIFF
--- a/docs/user-interface/controls/label.md
+++ b/docs/user-interface/controls/label.md
@@ -104,8 +104,8 @@ Label label = new Label { Text = "First line\nSecond line" };
 
 Text wrapping and truncation can be controlled by setting the `LineBreakMode` property to a value of the `LineBreakMode` enumeration:
 
-- `NoWrap` — does not wrap text, displaying only as much text as can fit on one line. This is the default value of the `LineBreakMode` property.
-- `WordWrap` — wraps text at the word boundary.
+- `NoWrap` — does not wrap text, displaying only as much text as can fit on one line. 
+- `WordWrap` — wraps text at the word boundary. This is the default value of the `LineBreakMode` property.
 - `CharacterWrap` — wraps text onto a new line at a character boundary.
 - `HeadTruncation` — truncates the head of the text, showing the end.
 - `MiddleTruncation` — displays the beginning and end of the text, with the middle replace by an ellipsis.

--- a/docs/user-interface/controls/label.md
+++ b/docs/user-interface/controls/label.md
@@ -104,7 +104,7 @@ Label label = new Label { Text = "First line\nSecond line" };
 
 Text wrapping and truncation can be controlled by setting the `LineBreakMode` property to a value of the `LineBreakMode` enumeration:
 
-- `NoWrap` — does not wrap text, displaying only as much text as can fit on one line. 
+- `NoWrap` — does not wrap text, displaying only as much text as can fit on one line.
 - `WordWrap` — wraps text at the word boundary. This is the default value of the `LineBreakMode` property.
 - `CharacterWrap` — wraps text onto a new line at a character boundary.
 - `HeadTruncation` — truncates the head of the text, showing the end.


### PR DESCRIPTION
### Description of Change:

- The default value of the **`Label.LineBreakMode`** property has been updated from **NoWrap** to **WordWrap** to align with the actual MAUI behavior.

- **Maui actual default value in source**: [LineBreakMode](https://github.com/dotnet/maui/blob/40b590ac00e557d56adaee552c4e8702ad3c8dd1/src/Controls/src/Core/Label/Label.cs#L104)

- **Maui Documentation Link**: [LineBreakMode](https://learn.microsoft.com/en-us/dotnet/maui/user-interface/controls/label?view=net-maui-10.0#control-text-truncation-and-wrapping)

- **Xamarin API Reference:**  [LineBreakMode](https://github.com/xamarin/Xamarin.Forms-api-docs/blob/main/docs/Xamarin.Forms/Label.xml)

### Issues Fixed

Fixes #3167
