### PR TITLE
Add example code for CreateWindow override in App class (#2245)

### DIFF
--- a/docs/fundamentals/app-lifecycle.md
+++ b/docs/fundamentals/app-lifecycle.md
@@ -139,7 +139,22 @@ namespace MyMauiApp
 }
 ```
 
-The `Window`-derived class can then be consumed by overriding the `CreateWindow` method in your `App` class to return a `MyWindow` instance.
+The `Window`-derived class can then be consumed by overriding the `CreateWindow` method in your `App` class to return a `MyWindow` instance:
+
+```csharp
+public partial class App : Application
+{
+    public App()
+    {
+        InitializeComponent();
+    }
+
+    protected override Window CreateWindow(IActivationState? activationState)
+    {
+        return new MyWindow();
+    }
+}
+```
 
 ::: moniker range="=net-maui-8.0"
 


### PR DESCRIPTION
**Description:**

Fixes #2245

**Changes**
This PR adds missing example code showing how to override the CreateWindow method in the App class to use a custom Window subclass.

**What changed:**
Added code example demonstrating the CreateWindow override in the App class
Shows how to return a custom MyWindow instance with proper IActivationState handling

**Files changed:**
[app-lifecycle.md](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) - Added CreateWindow override example code

**Why:**
The documentation showed how to create a custom Window-derived class but didn't include example code for actually consuming it in the App class. This left developers uncertain about the proper implementation pattern, especially regarding the IActivationState parameter handling.

Example added:

```csharp
public partial class App : Application
{
    public App()
    {
        InitializeComponent();
    }

    protected override Window CreateWindow(IActivationState? activationState)
    {
        return new MyWindow();
    }
}