### PR TITLE
Added WebView alternate way using source property

### DIFF
--- a/docs/user-interface/controls/webview.md
+++ b/docs/user-interface/controls/webview.md
@@ -190,11 +190,24 @@ To display a local HTML file, add the file to the *Resources\Raw* folder of your
 </WebView>
 ```
 
+Alternatively, you can directly load a local HTML file by setting the `Source` property to a file path:
+
+```xaml
+<WebView Source="file.html" />
+```
+
+The equivalent C# code is:
+
+```csharp
+WebView webView = new WebView
+{
+    Source = "file.html"
+};
+```
+
 The local HTML file can load Cascading Style Sheets (CSS), JavaScript, and images, if they've also been added to your app project with the **MauiAsset** build action.
 
 For more information about raw assets, see [Raw assets](~/fundamentals/single-project.md#raw-assets).
-
-<!-- Todo: This isn't ideal. You should be able to do <WebView Source="file.html" /> but you can't, as of P13. -->
 
 ## Reload content
 


### PR DESCRIPTION
### Description of Change:
This pull request updates the documentation for the `WebView` control to clarify how to load local HTML files. The main improvement is the addition of clear examples showing how to set the `Source` property directly to a local file, both in XAML and C#.

**Documentation improvements:**

* Added examples demonstrating how to load a local HTML file in the `WebView` by setting the `Source` property directly in both XAML and C#.

### Issues Fixed : 
Fixes #2204 