### PR TITLE
Map pin clustering docs for .NET MAUI 11

### DIFF
--- a/docs/user-interface/controls/map.md
+++ b/docs/user-interface/controls/map.md
@@ -777,6 +777,62 @@ The `MapItemTemplateSelector` class defines `DefaultTemplate` and `SanFranTempla
 
 For more information about data template selectors, see [Create a DataTemplateSelector](~/fundamentals/datatemplate.md#create-a-datatemplateselector).
 
+### Pin clustering
+
+When a map displays many pins in a small area, they can overlap and become difficult to interact with. Pin clustering groups nearby pins into a single cluster marker that expands as you zoom in.
+
+To enable clustering, set the `IsClusteringEnabled` property on the <xref:Microsoft.Maui.Controls.Maps.Map> control:
+
+```xaml
+<maps:Map IsClusteringEnabled="True" />
+```
+
+When `IsClusteringEnabled` is `true`, nearby pins are automatically grouped into cluster markers at lower zoom levels. Zooming in expands clusters to reveal individual pins.
+
+#### Clustering identifiers
+
+By default, all pins share the same clustering group. To create separate clustering groups — for example, to cluster restaurants independently from parks — set the `ClusteringIdentifier` property on each <xref:Microsoft.Maui.Controls.Maps.Pin>:
+
+```csharp
+map.Pins.Add(new Pin
+{
+    Label = "Pike Place Coffee",
+    Location = new Location(47.6097, -122.3331),
+    ClusteringIdentifier = "coffee"
+});
+
+map.Pins.Add(new Pin
+{
+    Label = "Occidental Square",
+    Location = new Location(47.6064, -122.3325),
+    ClusteringIdentifier = "parks"
+});
+```
+
+Pins with the same `ClusteringIdentifier` cluster together. Pins with different identifiers form separate clusters even when they are geographically close.
+
+#### Handle cluster taps
+
+When a user taps a cluster marker, the `ClusterClicked` event fires. The <xref:Microsoft.Maui.Controls.Maps.ClusterClickedEventArgs> provides:
+
+- `Pins` — a read-only list of the <xref:Microsoft.Maui.Controls.Maps.Pin> objects in the cluster.
+- `Location` — the geographic <xref:Microsoft.Maui.Devices.Sensors.Location> of the cluster.
+- `Handled` — set to `true` to prevent the default zoom-to-cluster behavior.
+
+```csharp
+map.ClusterClicked += (sender, e) =>
+{
+    string names = string.Join(", ", e.Pins.Select(p => p.Label));
+    DisplayAlert($"Cluster ({e.Pins.Count} pins)", names, "OK");
+
+    // Suppress default zoom behavior:
+    // e.Handled = true;
+};
+```
+
+> [!NOTE]
+> Pin clustering is supported on Android and iOS/Mac Catalyst. On Android, clusters recalculate when the zoom level changes. On iOS/Mac Catalyst, the platform's native `MKClusterAnnotation` support manages cluster display.
+
 ## Polygons, polylines, and circles
 
 `Polygon`, `Polyline`, and `Circle` elements allow you to highlight specific areas on a map. A `Polygon` is a fully enclosed shape that can have a stroke and fill color. A `Polyline` is a line that does not fully enclose an area. A `Circle` highlights a circular area of the map:

--- a/docs/whats-new/dotnet-11.md
+++ b/docs/whats-new/dotnet-11.md
@@ -1,7 +1,7 @@
 ---
 title: What's new in .NET MAUI for .NET 11
 description: Learn about the new features introduced in .NET MAUI for .NET 11.
-ms.date: 1/27/2026
+ms.date: 03/10/2026
 ---
 
 # What's new in .NET MAUI for .NET 11
@@ -24,17 +24,36 @@ This is a description of the feature and essential code snippets to adopt it.
 
 .NET MAUI in .NET 11 includes control enhancements and deprecations.
 
-### A specific control
+### Map pin clustering
 
-What was added, removed, changed.
+The <xref:Microsoft.Maui.Controls.Maps.Map> control now supports pin clustering, which automatically groups nearby pins into cluster markers at lower zoom levels. This long-requested feature is supported on Android and iOS/Mac Catalyst.
+
+New APIs:
+
+- `Map.IsClusteringEnabled` — enables or disables pin clustering.
+- `Pin.ClusteringIdentifier` — groups pins into named clusters for independent clustering.
+- `Map.ClusterClicked` — event fired when a cluster marker is tapped.
+- `ClusterClickedEventArgs` — provides the list of pins in the cluster, the cluster location, and a `Handled` property to suppress default zoom behavior.
+
+```xaml
+<maps:Map IsClusteringEnabled="True"
+          ClusterClicked="OnClusterClicked" />
+```
+
+For more information, see [Pin clustering](~/user-interface/controls/map.md?view=net-maui-11.0&preserve-view=true#pin-clustering).
+
+> [!div class="nextstepaction"]
+> [Explore the sample](/samples/dotnet/maui-samples/userinterface-map-clustering)
 
 ## Platform features
 
 .NET MAUI's platform features have received some updates in .NET 11.
 
-### Feature description
+### `maui` CLI
 
-Description...
+.NET MAUI 11 introduces the `maui` CLI, a unified command-line tool for managing your development environment. Key commands include `maui doctor`, `maui android install`, and `maui apple install`, with structured `--json` output for CI/CD and AI agent integration.
+
+For more information, see [.NET MAUI CLI reference](~/get-started/maui-cli.md?view=net-maui-11.0&preserve-view=true).
 
 ## .NET for Android
 


### PR DESCRIPTION
## Summary

Documents the new **Map pin clustering** APIs in .NET MAUI 11 preview 2 ([dotnet/maui#33831](https://github.com/dotnet/maui/pull/33831)).

### Changes

- **docs/user-interface/controls/map.md** — Added "Pin clustering" section after "Display a pin collection" covering:
  - Enabling clustering with `IsClusteringEnabled`
  - Assigning `ClusteringIdentifier` to group pins
  - Handling `ClusterClicked` event
  - Platform notes (iOS/Mac Catalyst native support, Android grid-based, Windows not yet supported)
- **docs/whats-new/dotnet-11.md** — Added Map pin clustering entry with sample badge, and maui CLI entry

### Companion PR

- Sample: dotnet/maui-samples#743


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/user-interface/controls/map.md](https://github.com/dotnet/docs-maui/blob/b34cb70f36cd947a82bd3822d0201c9da2a74995/docs/user-interface/controls/map.md) | [docs/user-interface/controls/map](https://review.learn.microsoft.com/en-us/dotnet/maui/user-interface/controls/map?branch=pr-en-us-3222) |
| [docs/whats-new/dotnet-11.md](https://github.com/dotnet/docs-maui/blob/b34cb70f36cd947a82bd3822d0201c9da2a74995/docs/whats-new/dotnet-11.md) | [docs/whats-new/dotnet-11](https://review.learn.microsoft.com/en-us/dotnet/maui/whats-new/dotnet-11?branch=pr-en-us-3222) |

<!-- PREVIEW-TABLE-END -->