### PR TITLE
File handling (.NET MAUI): document Android content URI and iOS sandb…

### DIFF
--- a/docs/platform-integration/storage/file-picker.md
+++ b/docs/platform-integration/storage/file-picker.md
@@ -125,6 +125,17 @@ The `PickOptions.PickerTitle` is displayed on the initial prompt to the user, bu
 
 When filtering files by type, use the file's MIME type. For a list of MIME types, see [Mozilla - Common MIME types](https://developer.mozilla.org/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types).
 
+> [!WARNING]
+> On Android, `FileResult.FullPath` may return a `content://` URI rather than a filesystem path. Passing a `content://` URI directly to `File.OpenRead()` or similar APIs will fail with a `FileNotFoundException`. Always use <xref:Microsoft.Maui.Storage.FileBase.OpenReadAsync%2A> to read the file contents:
+>
+> ```csharp
+> // Correct: works on all platforms, including Android content URIs
+> using var stream = await result.OpenReadAsync();
+>
+> // Incorrect: may fail on Android when FullPath is a content:// URI
+> using var stream = File.OpenRead(result.FullPath);
+> ```
+
 # [iOS/Mac Catalyst](#tab/macios)
 
 When filtering by file type, use Uniform Type Identifiers (UTType) values, specifically the identifier value. For more information, see [System-Declared Uniform Type Identifiers (Apple developer archive)](https://developer.apple.com/library/archive/documentation/Miscellaneous/Reference/UTIRef/Articles/System-DeclaredUniformTypeIdentifiers.html) and [System-declared uniform type identifiers](https://developer.apple.com/documentation/uniformtypeidentifiers/system-declared_uniform_type_identifiers).

--- a/docs/platform-integration/storage/file-system-helpers.md
+++ b/docs/platform-integration/storage/file-system-helpers.md
@@ -75,6 +75,17 @@ Returns the [Library](https://developer.apple.com/library/content/documentation/
 
   > [!IMPORTANT]
   > The Application ID, which is part of the directory name, changes on every build so you have to retrieve the correct ID each time you build your app for a Simulator or device.
+  >
+  > On iOS, the app sandbox path contains an application GUID segment that changes across clean builds and app reinstalls. Never hard-code or persist absolute sandbox paths — they will break after an update or reinstall. Always reconstruct paths at runtime using `FileSystem.Current.AppDataDirectory`:
+  >
+  > ```csharp
+  > // Correct: always construct the path at runtime
+  > string path = Path.Combine(FileSystem.Current.AppDataDirectory, "myfile.db");
+  >
+  > // Incorrect: never persist or hard-code the absolute path —
+  > // the GUID segment changes on clean builds and reinstalls
+  > // e.g. "/var/mobile/Containers/Data/Application/SOME-GUID/Library/myfile.db"
+  > ```
 
 - `FileSystem.OpenAppPackageFileAsync`\
 Files that were added to the project with the **Build Action** of **MauiAsset** can be opened with this method. .NET MAUI projects will process any file in the _Resources\Raw_ folder as a **MauiAsset**.


### PR DESCRIPTION


- Add [!WARNING] in file-picker.md Android platform-differences tab: FileResult.FullPath may return a content:// URI on Android; always use OpenReadAsync() instead of File.OpenRead(FullPath).
- Expand [!IMPORTANT] in file-system-helpers.md iOS/Mac Catalyst tab: AppDataDirectory path contains a GUID that changes on clean builds and reinstalls; never persist absolute paths, always reconstruct at runtime using FileSystem.Current.AppDataDirectory.

Fixes: https://github.com/dotnet/docs-maui/issues/3231