### PR TITLE
Data binding (.NET MAUI): clarify ObservableCollection mutations requ…

### DIFF
--- a/docs/fundamentals/data-binding/index.md
+++ b/docs/fundamentals/data-binding/index.md
@@ -23,3 +23,25 @@ Data bindings between two <xref:Microsoft.Maui.Controls.View> derivatives are of
 
 > [!IMPORTANT]
 > .NET MAUI marshals binding updates to the UI thread. When using MVVM this enables you to update data-bound viewmodel properties from any thread, with .NET MAUI's binding engine bringing the updates to the UI thread.
+
+> [!WARNING]
+> Auto-marshaling applies only to `INotifyPropertyChanged.PropertyChanged` notifications. **`ObservableCollection<T>` mutations (Add, Remove, Clear, etc.) are not automatically marshaled to the UI thread.** Calling these methods from a background thread raises `CollectionChanged` on that thread, which can cause a UI exception or layout corruption.
+>
+> Always dispatch collection mutations to the main thread:
+>
+> ```csharp
+> // Option 1: dispatch mutations to the main thread
+> await Task.Run(async () =>
+> {
+>     var newItems = await api.FetchItemsAsync();
+>     MainThread.BeginInvokeOnMainThread(() =>
+>     {
+>         foreach (var item in newItems)
+>             Items.Add(item);
+>     });
+> });
+>
+> // Option 2: replace the whole collection (PropertyChanged is auto-marshaled)
+> var newItems = await Task.Run(() => api.FetchItemsAsync());
+> Items = new ObservableCollection<MyItem>(newItems); // safe — raises PropertyChanged
+> ```


### PR DESCRIPTION


- Add [!WARNING] after the existing marshaling [!IMPORTANT] note in index.md to clarify that auto-marshaling covers only INotifyPropertyChanged.PropertyChanged, not ObservableCollection mutations (Add, Remove, Clear, etc.).
- Document that mutating ObservableCollection from a background thread raises CollectionChanged on that thread and can cause UI exceptions or layout corruption.
- Add two safe code patterns: MainThread.BeginInvokeOnMainThread for mutations, and full collection replacement for auto-marshaled PropertyChanged.

Fixes: https://github.com/dotnet/docs-maui/issues/3232