### PR TITLE
Document implicit XAML namespace declarations for .NET 11

### DIFF
--- a/docs/xaml/fundamentals/get-started.md
+++ b/docs/xaml/fundamentals/get-started.md
@@ -30,6 +30,13 @@ The *MainPage.xaml* file has the following structure:
 
 The two XML namespace (`xmlns`) declarations refer to URIs on microsoft.com. However, there's no content at these URIs, and they basically function as version identifiers.
 
+::: moniker range=">=net-maui-11.0"
+
+> [!NOTE]
+> Starting in .NET 11, these two standard namespace declarations are implicit and can be omitted from your XAML files. The compiler injects them automatically. For more information, see [Implicit namespace declarations](~/xaml/namespaces/index.md#implicit-namespace-declarations).
+
+::: moniker-end
+
 The first XML namespace declaration means that tags defined within the XAML file with no prefix refer to classes in .NET MAUI, for example <xref:Microsoft.Maui.Controls.ContentPage>. The second namespace declaration defines a prefix of `x`. This is used for several elements and attributes that are intrinsic to XAML itself and which are supported by other implementations of XAML. However, these elements and attributes are slightly different depending on the year embedded in the URI. .NET MAUI supports the [2009 XAML specification](/dotnet/desktop/xaml-services/xaml-2009-language-features).
 
 At the end of the first tag, the `x` prefix is used for an attribute named `Class`. Because the use of this `x` prefix is virtually universal for the XAML namespace, XAML attributes such as `Class` are almost always referred to as `x:Class`. The `x:Class` attribute specifies a fully qualified .NET class name: the `MainPage` class in the `MyMauiApp` namespace. This means that this XAML file defines a new class named `MainPage` in the `MyMauiApp` namespace that derives from <xref:Microsoft.Maui.Controls.ContentPage> (the tag in which the `x:Class` attribute appears).
@@ -144,6 +151,37 @@ using XmlnsPrefixAttribute = Microsoft.Maui.Controls.XmlnsPrefixAttribute;
 
 [assembly: XmlnsPrefix("MyApp.Controls", "controls")]
 ```
+
+::: moniker-end
+
+::: moniker range=">=net-maui-11.0"
+
+### Implicit namespace declarations
+
+Starting in .NET 11, the standard XAML namespace declarations are implicit by default — no opt-in is required. The compiler automatically injects `xmlns="http://schemas.microsoft.com/dotnet/2021/maui"` and `xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"`, so your XAML files can omit them:
+
+**Before (.NET 10 and earlier)**
+
+```xml
+<ContentPage
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="MyApp.Pages.MyContentPage">
+</ContentPage>
+```
+
+**After (.NET 11)**
+
+```xml
+<ContentPage x:Class="MyApp.Pages.MyContentPage">
+</ContentPage>
+```
+
+Custom namespaces still require explicit `xmlns:` declarations. For more information, see [Implicit namespace declarations](~/xaml/namespaces/index.md#implicit-namespace-declarations).
+
+::: moniker-end
+
+::: moniker range="net-maui-10.0"
 
 To enable the most streamlined experience (implicit default namespaces), add:
 

--- a/docs/xaml/namespaces/index.md
+++ b/docs/xaml/namespaces/index.md
@@ -1,12 +1,12 @@
 ---
 title: "XAML namespaces"
 description: ".NET MAUI XAML uses the xmlns XML attribute for namespace declarations. The default namespace specifies that elements defined within the XAML file with no prefix refer to .NET MAUI classes."
-ms.date: 10/19/2023
+ms.date: 07/15/2025
 ---
 
 # XAML namespaces
 
-XAML uses the `xmlns` XML attribute for namespace declarations. There are two XAML namespace declarations that are always within the root element of a XAML file. The first defines the default namespace:
+XAML uses the `xmlns` XML attribute for namespace declarations. There are two standard XAML namespace declarations that typically appear within the root element of a XAML file. The first defines the default namespace:
 
 ```xaml
 xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
@@ -42,6 +42,67 @@ For more information about the `x:ClassModifier` attribute, see [Class modifiers
 > In addition to the constructs listed above, .NET MAUI also includes markup extensions that can be consumed through the `x` namespace prefix. For more information, see [Consume XAML Markup Extensions](~/xaml/markup-extensions/consume.md).
 
 In XAML, namespace declarations inherit from parent element to child element. Therefore, when defining a namespace in the root element of a XAML file, all elements within that file inherit the namespace declaration.
+
+## Implicit namespace declarations
+
+::: moniker range=">=net-maui-11.0"
+
+Starting in .NET 11, implicit XAML namespace declarations are enabled by default. The compiler automatically injects the two standard namespace declarations, so you no longer need to include them in the root element of your XAML files:
+
+- `xmlns="http://schemas.microsoft.com/dotnet/2021/maui"` — the default .NET MAUI namespace.
+- `xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"` — the XAML language namespace providing `x:Class`, `x:Name`, and other intrinsic constructs.
+
+This means a content page that previously required explicit namespace declarations:
+
+```xaml
+<!-- .NET 10 and earlier: explicit namespace declarations required -->
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="MyApp.MainPage">
+    <Label Text="Hello, World!" />
+</ContentPage>
+```
+
+Can now be written without them:
+
+```xaml
+<!-- .NET 11: standard namespaces are implicit -->
+<ContentPage x:Class="MyApp.MainPage">
+    <Label Text="Hello, World!" />
+</ContentPage>
+```
+
+Existing XAML files that include explicit declarations continue to compile without changes. Explicit declarations can also be used to disambiguate duplicate type names when needed.
+
+> [!IMPORTANT]
+> Custom namespaces still require explicit `xmlns:` declarations. Only the default .NET MAUI namespace and the `x:` XAML language namespace are implicitly available.
+
+For example, you still need to declare a prefix for your own CLR namespaces or third-party libraries:
+
+```xaml
+<ContentPage x:Class="MyApp.MainPage"
+             xmlns:local="clr-namespace:MyApp.Controls"
+             xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit">
+    <local:CustomControl />
+</ContentPage>
+```
+
+::: moniker-end
+
+::: moniker range="net-maui-10.0"
+
+In .NET 10, implicit namespace declarations are available as a preview feature. To opt in, add the following to your project file:
+
+```xml
+<PropertyGroup>
+    <DefineConstants>$(DefineConstants);MauiAllowImplicitXmlnsDeclaration</DefineConstants>
+    <EnablePreviewFeatures>true</EnablePreviewFeatures>
+</PropertyGroup>
+```
+
+When enabled, you can omit the standard `xmlns` and `xmlns:x` declarations from your XAML files. Custom namespaces still require explicit `xmlns:` declarations.
+
+::: moniker-end
 
 ## Declare namespaces for types
 


### PR DESCRIPTION
## Summary

Documents that implicit XAML namespace declarations are enabled by default in .NET 11 (dotnet/maui#33834).

### Changes
- **docs/xaml/namespaces/index.md** — New "Implicit namespace declarations" section with before/after XAML examples
- **docs/xaml/fundamentals/get-started.md** — Moniker-gated note pointing to the new section

All content gated with `>=net-maui-11.0` moniker range.

Companion to dotnet/core#10348.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/xaml/fundamentals/get-started.md](https://github.com/dotnet/docs-maui/blob/e40930d47a9378198de3472b4af9ed62c5de7814/docs/xaml/fundamentals/get-started.md) | [docs/xaml/fundamentals/get-started](https://review.learn.microsoft.com/en-us/dotnet/maui/xaml/fundamentals/get-started?branch=pr-en-us-3281) |
| [docs/xaml/namespaces/index.md](https://github.com/dotnet/docs-maui/blob/e40930d47a9378198de3472b4af9ed62c5de7814/docs/xaml/namespaces/index.md) | [docs/xaml/namespaces/index](https://review.learn.microsoft.com/en-us/dotnet/maui/xaml/namespaces/index?branch=pr-en-us-3281) |

<!-- PREVIEW-TABLE-END -->