### PR TITLE
Revise .NET MAUI preview release links in documentation

### DIFF
--- a/docs/whats-new/dotnet-11.md
+++ b/docs/whats-new/dotnet-11.md
@@ -8,10 +8,9 @@ ms.date: 04/02/2026
 
 The focus of .NET Multi-platform App UI (.NET MAUI) in .NET 11 is to improve product quality. For information about what's new in each .NET MAUI in .NET 11 release, see the following release notes:
 
-<!-- markdownlint-disable-next-line MD042 -->
-- [.NET MAUI in .NET 11 Preview 1]()
-<!-- markdownlint-disable-next-line MD042 -->
-- [.NET MAUI in .NET 11 Preview 3]()
+- [.NET MAUI in .NET 11 Preview 1](https://github.com/dotnet/core/blob/main/release-notes/11.0/preview/preview1/dotnetmaui.md)
+- [.NET MAUI in .NET 11 Preview 2](https://github.com/dotnet/core/blob/main/release-notes/11.0/preview/preview2/dotnetmaui.md)
+- [.NET MAUI in .NET 11 Preview 3](https://github.com/dotnet/core/blob/main/release-notes/11.0/preview/preview3/dotnetmaui.md)
 
 > [!IMPORTANT]
 > Due to working with external dependencies, such as Xcode or Android SDK Tools, the .NET MAUI support policy differs from the [.NET and .NET Core support policy](https://dotnet.microsoft.com/platform/support/policy/maui). For more information, see [.NET MAUI support policy](https://dotnet.microsoft.com/platform/support/policy/maui).


### PR DESCRIPTION
Updated links to .NET MAUI preview releases for .NET 11.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/whats-new/dotnet-11.md](https://github.com/dotnet/docs-maui/blob/df412f88878fd5844e08140c34c8452672970939/docs/whats-new/dotnet-11.md) | [docs/whats-new/dotnet-11](https://review.learn.microsoft.com/en-us/dotnet/maui/whats-new/dotnet-11?branch=pr-en-us-3289) |

<!-- PREVIEW-TABLE-END -->