### PR TITLE
fix: docs-from-code  remove labeled, add manual dispatch

### DIFF
--- a/.github/workflows/docs-from-code.lock.yml
+++ b/.github/workflows/docs-from-code.lock.yml
@@ -26,14 +26,19 @@
 # the issue body (which contains the source PR details and suggested changes),
 # writes the documentation updates, and creates a draft PR.
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"481ded108fef353d0250e99c31f0e2a19cf730d9e5aaa3745d24821f717ce65c","compiler_version":"v0.53.5"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"7e9b77e689c671b33f9054c037e6e811c962638375544dd4f4fa4a98f6817b9c","compiler_version":"v0.53.5"}
 
 name: "Docs from Code — Create Draft PR"
 "on":
   issues:
     types:
     - opened
-    - labeled
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Issue number to process
+        required: true
+        type: string
 
 permissions: {}
 
@@ -124,11 +129,11 @@ jobs:
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_SAFE_OUTPUTS: ${{ env.GH_AW_SAFE_OUTPUTS }}
+          GH_AW_EXPR_726AD1D2: ${{ github.event.issue.number || github.event.inputs.issue_number }}
           GH_AW_GITHUB_ACTOR: ${{ github.actor }}
           GH_AW_GITHUB_EVENT_COMMENT_ID: ${{ github.event.comment.id }}
           GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: ${{ github.event.discussion.number }}
           GH_AW_GITHUB_EVENT_ISSUE_NUMBER: ${{ github.event.issue.number }}
-          GH_AW_GITHUB_EVENT_ISSUE_TITLE: ${{ github.event.issue.title }}
           GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
@@ -190,8 +195,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
-          GH_AW_GITHUB_EVENT_ISSUE_NUMBER: ${{ github.event.issue.number }}
-          GH_AW_GITHUB_EVENT_ISSUE_TITLE: ${{ github.event.issue.title }}
+          GH_AW_EXPR_726AD1D2: ${{ github.event.issue.number || github.event.inputs.issue_number }}
         with:
           script: |
             const { setupGlobals } = require('/opt/gh-aw/actions/setup_globals.cjs');
@@ -202,11 +206,11 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
+          GH_AW_EXPR_726AD1D2: ${{ github.event.issue.number || github.event.inputs.issue_number }}
           GH_AW_GITHUB_ACTOR: ${{ github.actor }}
           GH_AW_GITHUB_EVENT_COMMENT_ID: ${{ github.event.comment.id }}
           GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: ${{ github.event.discussion.number }}
           GH_AW_GITHUB_EVENT_ISSUE_NUMBER: ${{ github.event.issue.number }}
-          GH_AW_GITHUB_EVENT_ISSUE_TITLE: ${{ github.event.issue.title }}
           GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
@@ -223,11 +227,11 @@ jobs:
             return await substitutePlaceholders({
               file: process.env.GH_AW_PROMPT,
               substitutions: {
+                GH_AW_EXPR_726AD1D2: process.env.GH_AW_EXPR_726AD1D2,
                 GH_AW_GITHUB_ACTOR: process.env.GH_AW_GITHUB_ACTOR,
                 GH_AW_GITHUB_EVENT_COMMENT_ID: process.env.GH_AW_GITHUB_EVENT_COMMENT_ID,
                 GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: process.env.GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER,
                 GH_AW_GITHUB_EVENT_ISSUE_NUMBER: process.env.GH_AW_GITHUB_EVENT_ISSUE_NUMBER,
-                GH_AW_GITHUB_EVENT_ISSUE_TITLE: process.env.GH_AW_GITHUB_EVENT_ISSUE_TITLE,
                 GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER: process.env.GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER,
                 GH_AW_GITHUB_REPOSITORY: process.env.GH_AW_GITHUB_REPOSITORY,
                 GH_AW_GITHUB_RUN_ID: process.env.GH_AW_GITHUB_RUN_ID,

--- a/.github/workflows/docs-from-code.md
+++ b/.github/workflows/docs-from-code.md
@@ -7,7 +7,13 @@ description: |
 
 on:
   issues:
-    types: [opened, labeled]
+    types: [opened]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Issue number to process"
+        required: true
+        type: string
 
 if: >-
   startsWith(github.event.issue.title, '[maui-labs docs]')
@@ -46,14 +52,15 @@ Read a `[maui-labs docs]` issue and create a draft PR with the documentation cha
 
 ## Context
 
-- **Issue Number**: `${{ github.event.issue.number }}`
-- **Issue Title**: `${{ github.event.issue.title }}`
+- **Issue Number**: `${{ github.event.issue.number || github.event.inputs.issue_number }}`
 - **Repository**: `dotnet/docs-maui`
 
 ## Step 1: Read the Issue
 
-Read the full issue body for issue #`${{ github.event.issue.number }}`. The issue
-was created by an automated workflow on `dotnet/maui-labs` and contains:
+Read the full issue body for issue #`${{ github.event.issue.number || github.event.inputs.issue_number }}`.
+If triggered via `workflow_dispatch`, use the `issue_number` input.
+
+The issue was created by an automated workflow on `dotnet/maui-labs` and contains:
 
 - **Source PR** — link to the maui-labs PR that triggered this
 - **Summary of Changes** — what user-facing changes were made


### PR DESCRIPTION
The `labeled` event caused false triggers when the triage bot added labels. Simplified to `opened` only + `workflow_dispatch` for manual testing.trigger

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [.github/workflows/docs-from-code.md](https://github.com/dotnet/docs-maui/blob/1a9627a69f4d689bb20d05cc74ffea08640f2b0b/.github/workflows/docs-from-code.md) | [.github/workflows/docs-from-code](https://review.learn.microsoft.com/en-us/dotnet/maui/.github/workflows/docs-from-code?branch=pr-en-us-3312) |

<!-- PREVIEW-TABLE-END -->