### PR TITLE
Document MonochromeFile attribute for Android themed icons (.NET 11)

### DIFF
--- a/docs/user-interface/images/app-icons.md
+++ b/docs/user-interface/images/app-icons.md
@@ -1,7 +1,7 @@
 ---
 title: "Add an app icon to a .NET MAUI app project"
 description: "Learn how to add an app icon to a .NET MAUI app project. The icon is the logo that represents your app in multiple places, such as the Store, launcher, or app shortcut."
-ms.date: 08/30/2024
+ms.date: 05/12/2026
 no-loc: ["MauiIcon"]
 ---
 
@@ -187,6 +187,28 @@ Adaptive launcher icons are composed icons, using a background layer and a foreg
 ```
 
 The `ForegroundScale` attribute can be optionally specified to rescale the foreground image so that it fits on the app icon. It's a percentage value so 0.65 will be translated as 65%.
+
+:::moniker range=">=net-maui-11.0"
+
+#### Themed icon monochrome layer
+
+On Android 13 and higher, the system can render a themed app icon that uses a single monochrome glyph tinted with colors derived from the user's wallpaper. By default, .NET MAUI uses the `ForegroundFile` image as the monochrome layer. To use a different glyph for the themed icon, specify the `MonochromeFile` attribute on the `<MauiIcon>` item:
+
+```xml
+<ItemGroup>
+    <MauiIcon Include="Resources\AppIcon\appicon.svg"
+              ForegroundFile="Resources\AppIcon\appiconfg.svg"
+              MonochromeFile="Resources\AppIcon\appiconmono.svg"
+              ForegroundScale="0.65"
+              Color="#512BD4" />
+</ItemGroup>
+```
+
+The `MonochromeFile` image should be a single-color glyph designed to read clearly when tinted by the system. The image is included in the generated adaptive icon as the `<monochrome>` layer of the `adaptive-icon` drawable. If `MonochromeFile` isn't specified, the foreground image continues to be used as the monochrome source.
+
+For more information about themed icons on Android, see [Adaptive icons](https://developer.android.com/develop/ui/views/launch/icon_design_adaptive) and [Support themed app icons](https://developer.android.com/about/versions/13/features#themed-app-icons) on developer.android.com.
+
+:::moniker-end
 
 # [iOS/Mac Catalyst](#tab/macios)
 


### PR DESCRIPTION
Adds a `>=net-maui-11.0` monikered subsection to **app-icons.md** under *Adaptive launcher* covering the new `MonochromeFile` attribute on `<MauiIcon>`. This lets single-project Android adaptive icons use a dedicated glyph for the themed (monochrome) icon layer on Android 13+ instead of reusing the `ForegroundFile` image.

Upstream: dotnet/maui#34569

Verified against `dotnet/maui` branch `net11.0`:

- `src/SingleProject/Resizetizer/src/ResizeImageInfo.cs` reads `MonochromeFile` metadata.
- `src/SingleProject/Resizetizer/src/AndroidAdaptiveIconGenerator.cs` emits a `<monochrome>` layer when `MonochromeFile` is set, falling back to the foreground image otherwise.
- `Microsoft.Maui.Resizetizer.After.targets` plumbs `MonochromeFile` through to the resize tasks.

Ref: companion entry already in `docs/whats-new/dotnet-11.md` (PR #3329).

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/user-interface/images/app-icons.md](https://github.com/dotnet/docs-maui/blob/dd8187a9c33150bdf24b5945feb04c04cf5de53b/docs/user-interface/images/app-icons.md) | [docs/user-interface/images/app-icons](https://review.learn.microsoft.com/en-us/dotnet/maui/user-interface/images/app-icons?branch=pr-en-us-3330) |

<!-- PREVIEW-TABLE-END -->