### PR TITLE
Document Shell and ToolbarItem badges (.NET 11)

### DIFF
--- a/docs/fundamentals/shell/flyout.md
+++ b/docs/fundamentals/shell/flyout.md
@@ -1,7 +1,7 @@
 ---
 title: ".NET MAUI Shell flyout"
 description: "Learn how to customize and control a .NET MAUI flyout, which is the optional root menu for a .NET MAUI Shell app."
-ms.date: 11/28/2025
+ms.date: 05/12/2026
 ---
 
 # .NET MAUI Shell flyout
@@ -770,6 +770,44 @@ The following example shows hiding an item in the flyout:
 
 > [!NOTE]
 > There's also a `Shell.FlyoutItemIsVisible` attached property, which can be set on <xref:Microsoft.Maui.Controls.FlyoutItem>,  <xref:Microsoft.Maui.Controls.MenuItem>, <xref:Microsoft.Maui.Controls.Tab>, and <xref:Microsoft.Maui.Controls.ShellContent> objects.
+
+:::moniker range=">=net-maui-11.0"
+
+## FlyoutItem badges
+
+A badge can be displayed on a flyout item to surface unread counts or status indicators. Badges are set on the Shell navigation item by using three bindable properties inherited from `BaseShellItem`:
+
+- `BadgeText`, of type `string`, is the text displayed on the badge. Set to a non-empty value to show a text or count badge, an empty string to show a dot indicator, or `null` (the default) to hide the badge.
+- `BadgeColor`, of type <xref:Microsoft.Maui.Graphics.Color>, is the background color of the badge. When `null`, the platform default is used.
+- `BadgeTextColor`, of type <xref:Microsoft.Maui.Graphics.Color>, is the foreground (text) color of the badge. When `null`, the platform default is used (typically white).
+
+The following example sets a numeric badge on a flyout item:
+
+```xaml
+<Shell ...>
+    <FlyoutItem Title="Inbox"
+                Icon="inbox.png"
+                BadgeText="3"
+                BadgeColor="Red"
+                BadgeTextColor="White">
+        <ShellContent ContentTemplate="{DataTemplate views:InboxPage}" />
+    </FlyoutItem>
+</Shell>
+```
+
+To bind the badge text to a view model, use a regular data binding:
+
+```xaml
+<FlyoutItem Title="Inbox"
+            Icon="inbox.png"
+            BadgeText="{Binding UnreadCount}">
+    <ShellContent ContentTemplate="{DataTemplate views:InboxPage}" />
+</FlyoutItem>
+```
+
+For more information on how badges are rendered on each platform, see [Tab badges](tabs.md#tab-badges).
+
+:::moniker-end
 
 ## Open and close the flyout programmatically
 

--- a/docs/fundamentals/shell/tabs.md
+++ b/docs/fundamentals/shell/tabs.md
@@ -1,7 +1,7 @@
 ---
 title: ".NET MAUI Shell tabs"
 description: "Learn how to customize and control a .NET MAUI TabBar, which represents the bottom tab bar in a .NET MAUI Shell app."
-ms.date: 11/28/2025
+ms.date: 05/12/2026
 ---
 
 # .NET MAUI Shell tabs
@@ -282,3 +282,45 @@ In addition, <xref:Microsoft.Maui.Controls.Tab> objects can be hidden by setting
 ```
 
 In this example, the second tab is hidden.
+
+:::moniker range=">=net-maui-11.0"
+
+## Tab badges
+
+A badge can be displayed on a tab to surface unread counts or status indicators. Badges are set on the Shell navigation item (`Tab`, `ShellContent`, or `FlyoutItem`) by using three bindable properties inherited from `BaseShellItem`:
+
+- `BadgeText`, of type `string`, is the text displayed on the badge. Set to a non-empty value to show a text or count badge, an empty string to show a dot indicator, or `null` (the default) to hide the badge.
+- `BadgeColor`, of type <xref:Microsoft.Maui.Graphics.Color>, is the background color of the badge. When `null`, the platform default is used.
+- `BadgeTextColor`, of type <xref:Microsoft.Maui.Graphics.Color>, is the foreground (text) color of the badge. When `null`, the platform default is used (typically white).
+
+The following example sets a numeric badge on a tab:
+
+```xaml
+<TabBar>
+    <ShellContent Title="Inbox"
+                  Icon="inbox.png"
+                  BadgeText="3"
+                  BadgeColor="Red"
+                  BadgeTextColor="White"
+                  ContentTemplate="{DataTemplate views:InboxPage}" />
+    <ShellContent Title="Sent"
+                  Icon="sent.png"
+                  ContentTemplate="{DataTemplate views:SentPage}" />
+</TabBar>
+```
+
+To bind the badge text to a view model, use a regular data binding:
+
+```xaml
+<ShellContent Title="Inbox"
+              Icon="inbox.png"
+              BadgeText="{Binding UnreadCount}" />
+```
+
+Badge rendering varies by platform:
+
+- **Android** uses the Material Design `BadgeDrawable`. `BadgeTextColor` maps to `BadgeDrawable.BadgeTextColor`.
+- **iOS and Mac Catalyst** use `UITabBarItem.BadgeValue`. `BadgeTextColor` maps to `UITabBarItem.SetBadgeTextAttributes`.
+- **Windows** uses the WinUI `InfoBadge` control. Only numeric `BadgeText` values display as a count; non-numeric text and the empty string display as a dot indicator. `BadgeTextColor` maps to `InfoBadge.Foreground`.
+
+:::moniker-end

--- a/docs/user-interface/toolbaritem.md
+++ b/docs/user-interface/toolbaritem.md
@@ -1,7 +1,7 @@
 ---
 title: "Display toolbar items"
 description: "Learn how to add toolbar items, which are a special type of button, to the app's navigation bar."
-ms.date: 08/18/2025
+ms.date: 05/12/2026
 ---
 
 # Display toolbar items
@@ -147,3 +147,43 @@ On iOS and Mac Catalyst, secondary items are shown in a pull‑down menu ordered
 > Keep labels short so they fit comfortably in the pull‑down. Avoid icons for `Secondary` items due to platform inconsistency.
 
 ::: moniker-end
+
+:::moniker range=">=net-maui-11.0"
+
+## Display a badge on a ToolbarItem
+
+A badge can be displayed on a <xref:Microsoft.Maui.Controls.ToolbarItem> to surface counts or status indicators. The `ToolbarItem` class defines three bindable properties for badge support:
+
+- `BadgeText`, of type `string`, is the text displayed on the badge. Set to a non-empty value to show a text or count badge, an empty string to show a dot indicator, or `null` (the default) to hide the badge.
+- `BadgeColor`, of type <xref:Microsoft.Maui.Graphics.Color>, is the background color of the badge. When `null`, the platform default is used.
+- `BadgeTextColor`, of type <xref:Microsoft.Maui.Graphics.Color>, is the foreground (text) color of the badge. When `null`, the platform default is used.
+
+The following example sets a numeric badge on a toolbar item:
+
+```xaml
+<ContentPage.ToolbarItems>
+    <ToolbarItem Text="Inbox"
+                 IconImageSource="inbox.png"
+                 BadgeText="3"
+                 BadgeColor="Red"
+                 BadgeTextColor="White" />
+</ContentPage.ToolbarItems>
+```
+
+To bind the badge text to a view model, use a regular data binding:
+
+```xaml
+<ToolbarItem Text="Inbox"
+             IconImageSource="inbox.png"
+             BadgeText="{Binding UnreadCount}" />
+```
+
+Badges are only displayed on primary toolbar items — items whose <xref:Microsoft.Maui.Controls.ToolbarItem.Order> is set to <xref:Microsoft.Maui.Controls.ToolbarItemOrder.Primary> or <xref:Microsoft.Maui.Controls.ToolbarItemOrder.Default>. Secondary (overflow) items don't display badges.
+
+Badge rendering varies by platform:
+
+- **Android** uses the Material Design `BadgeDrawable`. Numeric and text badges are supported. `BadgeTextColor` maps to `BadgeDrawable.BadgeTextColor`.
+- **iOS and Mac Catalyst** use `UIBarButtonItem.Badge`, which requires iOS 26 or higher. On earlier iOS versions, the badge is silently ignored. `BadgeTextColor` maps to `UIBarButtonItemBadge.ForegroundColor`.
+- **Windows** uses the WinUI `InfoBadge` overlaid on the toolbar button. Numeric values display as counts; non-numeric text and the empty string display as a dot indicator. `BadgeTextColor` maps to `InfoBadge.Foreground`.
+
+:::moniker-end


### PR DESCRIPTION
Adds `>=net-maui-11.0` monikered sections documenting the new badge properties for Shell navigation items and `ToolbarItem` in .NET MAUI 11 (Preview 4).

**Files**

- `docs/fundamentals/shell/tabs.md` — new *Tab badges* section.
- `docs/fundamentals/shell/flyout.md` — new *FlyoutItem badges* section.
- `docs/user-interface/toolbaritem.md` — new *Display a badge on a ToolbarItem* section.

**Properties documented (all bindable, default `null`)**

- `BadgeText` (`string`) — non-empty = text/count, empty = dot indicator, null = hidden.
- `BadgeColor` (`Color`) — badge background; null = platform default.
- `BadgeTextColor` (`Color`) — badge foreground; null = platform default.

**Verified against `dotnet/maui` branch `net11.0`:**

- `src/Controls/src/Core/Shell/BaseShellItem.cs` — `BadgeText`/`BadgeColor`/`BadgeTextColor` BindableProperties (OneWay).
- `src/Controls/src/Core/Toolbar/ToolbarItem.cs` — same three properties on `ToolbarItem`. Platform notes call out iOS 26 `UIBarButtonItem.Badge` requirement and primary-only display per the in-source remarks.

Platform mapping captured: Android `BadgeDrawable`, iOS/MacCatalyst `UITabBarItem.BadgeValue` / `UIBarButtonItem.Badge` (iOS 26+), Windows `InfoBadge` (numeric only).

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/shell/flyout.md](https://github.com/dotnet/docs-maui/blob/2c0ae537e14cabd17deed0d8a949af730b676424/docs/fundamentals/shell/flyout.md) | [docs/fundamentals/shell/flyout](https://review.learn.microsoft.com/en-us/dotnet/maui/fundamentals/shell/flyout?branch=pr-en-us-3333) |
| [docs/fundamentals/shell/tabs.md](https://github.com/dotnet/docs-maui/blob/2c0ae537e14cabd17deed0d8a949af730b676424/docs/fundamentals/shell/tabs.md) | [docs/fundamentals/shell/tabs](https://review.learn.microsoft.com/en-us/dotnet/maui/fundamentals/shell/tabs?branch=pr-en-us-3333) |
| [docs/user-interface/toolbaritem.md](https://github.com/dotnet/docs-maui/blob/2c0ae537e14cabd17deed0d8a949af730b676424/docs/user-interface/toolbaritem.md) | [docs/user-interface/toolbaritem](https://review.learn.microsoft.com/en-us/dotnet/maui/user-interface/toolbaritem?branch=pr-en-us-3333) |

<!-- PREVIEW-TABLE-END -->