### PR TITLE
Allow MauiBot to trigger docs-from-code workflow

### DIFF
--- a/.github/workflows/docs-from-code.lock.yml
+++ b/.github/workflows/docs-from-code.lock.yml
@@ -1150,7 +1150,7 @@ jobs:
     if: startsWith(github.event.issue.title, '[maui-labs docs]') && github.repository_owner == 'dotnet'
     runs-on: ubuntu-slim
     outputs:
-      activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}
+      activated: ${{ steps.check_membership.outputs.is_team_member == 'true' || github.actor == 'MauiBot' }}
       matched_command: ''
     steps:
       - name: Setup Scripts

--- a/.github/workflows/docs-from-code.lock.yml
+++ b/.github/workflows/docs-from-code.lock.yml
@@ -51,8 +51,8 @@ jobs:
   activation:
     needs: pre_activation
     if: >
-      (needs.pre_activation.outputs.activated == 'true') && (startsWith(github.event.issue.title, '[maui-labs docs]') &&
-      github.repository_owner == 'dotnet')
+      (needs.pre_activation.outputs.activated == 'true') && ((startsWith(github.event.issue.title, '[maui-labs docs]') ||
+      github.event_name == 'workflow_dispatch') && github.repository_owner == 'dotnet')
     runs-on: ubuntu-slim
     permissions:
       contents: read
@@ -1147,7 +1147,7 @@ jobs:
             await main();
 
   pre_activation:
-    if: startsWith(github.event.issue.title, '[maui-labs docs]') && github.repository_owner == 'dotnet'
+    if: (startsWith(github.event.issue.title, '[maui-labs docs]') || github.event_name == 'workflow_dispatch') && github.repository_owner == 'dotnet'
     runs-on: ubuntu-slim
     outputs:
       activated: ${{ steps.check_membership.outputs.is_team_member == 'true' || github.actor == 'MauiBot' }}


### PR DESCRIPTION
## Problem

The 'Docs from  Create Draft PR' workflow fails when triggered by MauiBot opening an issue because MauiBot only has `read` permission on this repo. The `pre_activation` job's permission check requires `admin`, `maintainer`, or `write`, so all subsequent jobs get skipped.Code 

See: https://github.com/dotnet/docs-maui/actions/runs/25920414126

## Fix

Add `github.actor == 'MauiBot'` as an alternative condition in the `activated` output. This allows MauiBot-triggered issues to proceed to the agent job without requiring write access, while still enforcing the permission check for all other users.

## Alternative considered

Granting MauiBot write access at the org level would also fix this but requires org admin involvement.