### PR TITLE
Remove .NET 11 what’s new moniker checks

### DIFF
--- a/docs/whats-new/dotnet-11.md
+++ b/docs/whats-new/dotnet-11.md
@@ -1,7 +1,7 @@
 ---
 title: What's new in .NET MAUI for .NET 11
 description: Learn about the new features introduced in .NET MAUI for .NET 11.
-ms.date: 05/12/2026
+ms.date: 05/24/2026
 ---
 
 # What's new in .NET MAUI for .NET 11
@@ -20,8 +20,6 @@ In .NET 11, .NET MAUI ships as a .NET workload and multiple NuGet packages. The 
 
 ## CoreCLR is the default runtime
 
-:::moniker range=">=net-maui-11.0"
-
 Starting in .NET 11 Preview 4, CoreCLR is the default runtime on all .NET MAUI platforms for projects built with and targeting .NET 11. This unifies the runtime across .NET MAUI with benefits for debugging, profiling, Hot Reload, app size, and app performance. For a detailed overview of this transition, see the [announcement blog post](https://aka.ms/maui-coreclr).
 
 If you need to opt out of CoreCLR and use the Mono runtime instead, set `$(UseMonoRuntime)` to `true` in your project file:
@@ -32,11 +30,7 @@ If you need to opt out of CoreCLR and use the Mono runtime instead, set `$(UseMo
 </PropertyGroup>
 ```
 
-:::moniker-end
-
 ## `x:Code` directive for inline C# in XAML
-
-:::moniker range=">=net-maui-11.0"
 
 Starting in .NET 11 Preview 4, the XAML source generator supports an `x:Code` directive that lets you inline a small block of C# directly inside a XAML file. This makes it easier to keep view-local glue code next to the markup it serves without creating a code-behind partial just for a single helper. The `EnablePreviewFeatures` flag is required for this. For more information, see [GitHub PR #34715](https://github.com/dotnet/maui/pull/34715).
 
@@ -54,11 +48,7 @@ Starting in .NET 11 Preview 4, the XAML source generator supports an `x:Code` di
 </ContentPage>
 ```
 
-:::moniker-end
-
 ## Compiled bindings inside DataTemplates
-
-:::moniker range=">=net-maui-11.0"
 
 Starting in .NET 11 Preview 4, compiled bindings with explicit sources defined inside a <xref:Microsoft.Maui.Controls.DataTemplate> now resolve correctly, fixing a regression that broke <xref:Microsoft.Maui.Controls.TapGestureRecognizer> bindings inside <xref:Microsoft.Maui.Controls.CollectionView> items in .NET 10. For more information, see [GitHub PR #34447](https://github.com/dotnet/maui/pull/34447).
 
@@ -67,27 +57,15 @@ The XAML source generator now also:
 - Emits diagnostics when an `x:DataType` or binding is invalid. For more information, see [GitHub PR #34078](https://github.com/dotnet/maui/pull/34078).
 - Correctly distinguishes static extension classes from `enum` types when resolving XAML markup. For more information, see [GitHub PR #34446](https://github.com/dotnet/maui/pull/34446).
 
-:::moniker-end
-
 ## Implicit XAML namespace declarations
-
-:::moniker range=">=net-maui-11.0"
 
 Starting in .NET 11, implicit XAML namespace declarations are enabled by default. XAML files no longer need the standard `xmlns` and `xmlns:x` declarations at the root element — the compiler injects them automatically. Existing explicit declarations still compile and can be used to disambiguate duplicate type names. For more information, see [GitHub PR #33834](https://github.com/dotnet/maui/pull/33834).
 
-:::moniker-end
-
 ## Lazy ResourceDictionary
-
-:::moniker range=">=net-maui-11.0"
 
 XAML Source Generation now registers resource dictionary entries as factories, inflating each resource on demand instead of eagerly loading everything at startup. This can yield up to an ~8× improvement in resource dictionary initialization time for apps with large dictionaries. The optimization is automatic when XAML source generation is enabled — no code changes are required. For more information, see [GitHub PR #33826](https://github.com/dotnet/maui/pull/33826).
 
-:::moniker-end
-
 ## InvalidateStyle and InvalidateVisualStates
-
-:::moniker range=">=net-maui-11.0"
 
 Two new APIs make it easier to reapply styles and visual states that have been mutated in place:
 
@@ -106,23 +84,15 @@ myButton.InvalidateStyle();
 VisualStateManager.InvalidateVisualStates(myButton);
 ```
 
-:::moniker-end
-
 ## Trimmable CSS
 
-:::moniker range=">=net-maui-11.0"
-
 .NET MAUI CSS support is now fully trimmable. If your app doesn't use CSS stylesheets, the CSS infrastructure is trimmed away during publish, reducing app size. No code changes are needed — the linker removes unused CSS types automatically. For more information, see [GitHub PR #33160](https://github.com/dotnet/maui/pull/33160).
-
-:::moniker-end
 
 ## Controls
 
 .NET MAUI in .NET 11 includes control enhancements and deprecations.
 
 ### Material 3 on Android
-
-:::moniker range=">=net-maui-11.0"
 
 In .NET 11 Preview 4, the Android handlers for several core controls use Material 3 styling and behaviors out of the box, bringing them in line with modern Android design and unlocking the Material 3 theming system:
 
@@ -133,11 +103,7 @@ In .NET 11 Preview 4, the Android handlers for several core controls use Materia
 
 ![Dark and light control samples for the Material 3 design system in .NET MAUI.](media/dotnet-11/material3.png)
 
-:::moniker-end
-
 ### LongPressGestureRecognizer
-
-:::moniker range=">=net-maui-11.0"
 
 .NET 11 adds a built-in <xref:Microsoft.Maui.Controls.LongPressGestureRecognizer> for handling long-press gestures. It supports a configurable press duration, a movement threshold to cancel the gesture if the user's finger moves too far, state tracking via `GestureState`, and command binding with `Command` and `CommandParameter`. For more information, see [GitHub PR #33432](https://github.com/dotnet/maui/pull/33432).
 
@@ -160,11 +126,7 @@ void OnLongPressed(object sender, LongPressGestureRecognizerEventArgs e)
 }
 ```
 
-:::moniker-end
-
 ### Map
-
-:::moniker range=">=net-maui-11.0"
 
 The <xref:Microsoft.Maui.Controls.Maps.Map> control receives a significant set of enhancements in .NET 11 Preview 3:
 
@@ -208,23 +170,15 @@ Apply a custom JSON style to the map on Android using the `MapStyle` property. T
 
 For more information, see GitHub PRs [#29101](https://github.com/dotnet/maui/pull/29101), [#33831](https://github.com/dotnet/maui/pull/33831), [#33950](https://github.com/dotnet/maui/pull/33950), [#33982](https://github.com/dotnet/maui/pull/33982), [#33985](https://github.com/dotnet/maui/pull/33985), [#33792](https://github.com/dotnet/maui/pull/33792), [#33799](https://github.com/dotnet/maui/pull/33799), [#33991](https://github.com/dotnet/maui/pull/33991), and [#33993](https://github.com/dotnet/maui/pull/33993).
 
-:::moniker-end
-
 ## Platform features
 
 .NET MAUI's platform features have received some updates in .NET 11.
 
 ### MonochromeFile for Android adaptive icons
 
-:::moniker range=">=net-maui-11.0"
-
 Starting in .NET 11 Preview 4, single-project app icons can declare a dedicated monochrome layer for Android themed icons via a new `MonochromeFile` attribute on `MauiIcon`. This lets your themed icon use a different glyph than the foreground layer, instead of being a tinted reuse of it. For more information, see [GitHub PR #34569](https://github.com/dotnet/maui/pull/34569).
 
-:::moniker-end
-
 ### iOS PostNotifications permission
-
-:::moniker range=">=net-maui-11.0"
 
 `Permissions.PostNotifications` is now implemented on iOS, providing a cross-platform API for requesting notification authorization. Previously this permission was only functional on Android. Use it to request authorization before scheduling local notifications on iOS. For more information, see [GitHub PR #30132](https://github.com/dotnet/maui/pull/30132).
 
@@ -235,8 +189,6 @@ if (status == PermissionStatus.Granted)
     // Schedule notifications
 }
 ```
-
-:::moniker-end
 
 ## .NET for Android
 
@@ -307,17 +259,11 @@ Console output of your application should appear directly in the terminal, and C
 
 ## `dotnet watch` for Android
 
-:::moniker range=">=net-maui-11.0"
-
 Starting in .NET 11 Preview 4, `dotnet watch` works for Android devices and emulators. After selecting a target framework and device, `dotnet watch` deploys your app and applies Hot Reload changes as you edit — no manual rebuild required.
 
 ![GIF of `dotnet watch` on Windows for Android.](media/dotnet-11/net11p4-dotnet-watch-android.gif)
 
-:::moniker-end
-
 ## `dotnet watch` for iOS
-
-:::moniker range=">=net-maui-11.0"
 
 Starting in .NET 11 Preview 4, several long-standing issues have been fixed to make `dotnet watch` usable end-to-end on a `dotnet new maui` project running in the iOS Simulator:
 
@@ -338,8 +284,6 @@ Starting in .NET 11 Preview 4, several long-standing issues have been fixed to m
 > </PropertyGroup>
 > ```
 
-:::moniker-end
-
 ## .NET for iOS
 
 .NET 11 on iOS, tvOS, Mac Catalyst, and macOS supports the following platform versions:
@@ -357,31 +301,19 @@ For information about known issues, see [Known issues in .NET 11](https://github
 
 ### Xcode 26.4
 
-:::moniker range=">=net-maui-11.0"
-
 Starting in .NET 11 Preview 4, Xcode 26.4 Stable is the supported Xcode version, with refreshed bindings across UIKit, AVFoundation, WebKit, Metal, Photos, PassKit, CarPlay, AuthenticationServices, and more. For more information, see [dotnet/macios #25005](https://github.com/dotnet/macios/pull/25005).
 
 One Apple-side breaking change: `HMError.QuotaExceeded` was removed by Apple and is no longer available. For more information, see [dotnet/macios #25024](https://github.com/dotnet/macios/pull/25024).
 
-:::moniker-end
-
 ### HTTP digest authentication
-
-:::moniker range=">=net-maui-11.0"
 
 Starting in .NET 11 Preview 4, HTTP digest authentication is supported in <xref:Foundation.NSUrlSessionHandler>. For more information, see [dotnet/macios #25180](https://github.com/dotnet/macios/pull/25180).
 
-:::moniker-end
-
 ### CoreCLR for Apple platforms
-
-:::moniker range=">=net-maui-11.0"
 
 Starting in .NET 11 Preview 4, CoreCLR is the default runtime for .NET for iOS, Mac Catalyst, macOS, and tvOS. For more information, see [CoreCLR is the default runtime](#coreclr-is-the-default-runtime) and [dotnet/macios #25050](https://github.com/dotnet/macios/pull/25050).
 
 Preview 4 also includes a broad reliability and packaging pass across `NSUrlSessionHandler`, MSBuild, the linker, and runtime internals. For the complete list of changes, see the [Preview 4 changelog](https://github.com/dotnet/macios/compare/release/11.0.1xx-preview3...release/11.0.1xx-preview4).
-
-:::moniker-end
 
 ## See also
 


### PR DESCRIPTION
## Summary
- Remove `>=net-maui-11.0` moniker blocks from `docs/whats-new/dotnet-11.md`
- Update `ms.date` for the changed page

## Motivation
The .NET 11 what's new article should render its content even when an older .NET MAUI docs view, such as `net-maui-10.0`, is selected.

## Validation
- Confirmed no moniker blocks remain in `docs/whats-new/dotnet-11.md`
- Ran `git diff --check`

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/whats-new/dotnet-11.md](https://github.com/dotnet/docs-maui/blob/5b8d5dfed2971a6f7e0f224af4f7b77172a582f6/docs/whats-new/dotnet-11.md) | [docs/whats-new/dotnet-11](https://review.learn.microsoft.com/en-us/dotnet/maui/whats-new/dotnet-11?branch=pr-en-us-3354) |

<!-- PREVIEW-TABLE-END -->