### PR TITLE
Document CancellationToken support for view animations in .NET MAUI 11

### DIFF
--- a/docs/user-interface/animation/basic.md
+++ b/docs/user-interface/animation/basic.md
@@ -34,6 +34,8 @@ In this example, all animations that are running on the <xref:Microsoft.Maui.Con
 
 Starting in .NET MAUI 11, the `ViewExtensions` animation methods (`FadeToAsync`, `RotateToAsync`, `ScaleToAsync`, `TranslateToAsync`, and the relative variants) accept an optional <xref:System.Threading.CancellationToken>. Passing a token lets you cancel a specific awaited animation without having to call `CancelAnimations`, which cancels every animation on the element. This is useful when an element is running more than one animation, or when an animation should stop in response to a separate user action.
 
+The cancellation-aware overloads return `Task<bool>`. The result is `true` when the animation was canceled and `false` when it ran to completion. The animation methods don't throw on cancellation, so there's no exception to catch.
+
 The following example fades a label out, and cancels the fade if the user presses a button before it completes:
 
 ```csharp
@@ -41,13 +43,12 @@ CancellationTokenSource cts = new();
 
 async void OnFadeClicked(object sender, EventArgs e)
 {
-    try
+    bool canceled = await label.FadeToAsync(0, 2000, Easing.SinIn, cts.Token);
+
+    if (canceled)
     {
-        await label.FadeToAsync(0, 2000, Easing.SinIn, cts.Token);
-    }
-    catch (TaskCanceledException)
-    {
-        // The fade was canceled before it completed.
+        // The fade was canceled before it completed; the label keeps
+        // whatever opacity it had reached.
     }
 }
 
@@ -57,7 +58,7 @@ void OnCancelClicked(object sender, EventArgs e)
 }
 ```
 
-When the token is canceled, the awaited animation method throws <xref:System.Threading.Tasks.TaskCanceledException>. The element keeps whatever intermediate value it had reached, so a typical pattern is to immediately reset or animate the element to a known state in the `catch` block.
+When the token is canceled, the underlying animation is aborted and the element keeps whatever intermediate value it had reached. A typical pattern is to read the `bool` return value and either reset the element to a known state or animate it from where it stopped.
 
 > [!NOTE]
 > The non-`Async` versions of these methods (`FadeTo`, `RotateTo`, and so on) are now marked `[Obsolete]` in favor of the `Async`-suffixed equivalents. Migrate to the new methods to take advantage of `CancellationToken` support.

--- a/docs/user-interface/animation/basic.md
+++ b/docs/user-interface/animation/basic.md
@@ -63,4 +63,4 @@ When the token is canceled, the underlying animation is aborted and the element 
 > [!NOTE]
 > The non-`Async` versions of these methods (`FadeTo`, `RotateTo`, and so on) are now marked `[Obsolete]` in favor of the `Async`-suffixed equivalents. Migrate to the new methods to take advantage of `CancellationToken` support.
 
-:::moniker-end
+::: moniker-end

--- a/docs/user-interface/animation/basic.md
+++ b/docs/user-interface/animation/basic.md
@@ -1,7 +1,7 @@
 ---
 title: "Basic animation"
 description: "The .NET MAUI ViewExtensions class, in the Microsoft.Maui.Controls namespace, provides extension methods that can be used to create and cancel basic animations."
-ms.date: 04/03/2025
+ms.date: 06/05/2026
 ---
 
 # Basic animation
@@ -27,3 +27,39 @@ image.CancelAnimations();
 ```
 
 In this example, all animations that are running on the <xref:Microsoft.Maui.Controls.Image> instance are immediately canceled.
+
+:::moniker range=">=net-maui-11.0"
+
+### Cancel an animation with a CancellationToken
+
+Starting in .NET MAUI 11, the `ViewExtensions` animation methods (`FadeToAsync`, `RotateToAsync`, `ScaleToAsync`, `TranslateToAsync`, and the relative variants) accept an optional <xref:System.Threading.CancellationToken>. Passing a token lets you cancel a specific awaited animation without having to call `CancelAnimations`, which cancels every animation on the element. This is useful when an element is running more than one animation, or when an animation should stop in response to a separate user action.
+
+The following example fades a label out, and cancels the fade if the user presses a button before it completes:
+
+```csharp
+CancellationTokenSource cts = new();
+
+async void OnFadeClicked(object sender, EventArgs e)
+{
+    try
+    {
+        await label.FadeToAsync(0, 2000, Easing.SinIn, cts.Token);
+    }
+    catch (TaskCanceledException)
+    {
+        // The fade was canceled before it completed.
+    }
+}
+
+void OnCancelClicked(object sender, EventArgs e)
+{
+    cts.Cancel();
+}
+```
+
+When the token is canceled, the awaited animation method throws <xref:System.Threading.Tasks.TaskCanceledException>. The element keeps whatever intermediate value it had reached, so a typical pattern is to immediately reset or animate the element to a known state in the `catch` block.
+
+> [!NOTE]
+> The non-`Async` versions of these methods (`FadeTo`, `RotateTo`, and so on) are now marked `[Obsolete]` in favor of the `Async`-suffixed equivalents. Migrate to the new methods to take advantage of `CancellationToken` support.
+
+:::moniker-end


### PR DESCRIPTION
Adds a new "Cancel an animation with a `CancellationToken`" subsection under "Canceling animations" in `docs/user-interface/animation/basic.md`. The section explains that the `Async`-suffixed animation methods (`FadeToAsync`, `RotateToAsync`, `ScaleToAsync`, `TranslateToAsync`, and the relative variants) accept an optional `CancellationToken` in .NET MAUI 11, with a runnable snippet and a note that the non-`Async` overloads are now `[Obsolete]`.

Tracks dotnet/maui#33372 and aligns with the .NET 11 Preview 5 release notes (dotnet/core#10433).

## Internal previews

- [docs/user-interface/animation/basic](https://review.learn.microsoft.com/dotnet/maui/user-interface/animation/basic?branch=pr-en-us-XXXX) (link will populate once OpenPublishing builds)
