### PR TITLE
Document back button accessibility label in .NET MAUI 11

### DIFF
--- a/docs/fundamentals/shell/navigation.md
+++ b/docs/fundamentals/shell/navigation.md
@@ -1,7 +1,7 @@
 ---
 title: ".NET MAUI Shell navigation"
 description: "Learn how .NET MAUI Shell apps can utilize a URI-based navigation experience that permits navigation to any page in the app, without having to follow a set navigation hierarchy."
-ms.date: 01/14/2025
+ms.date: 06/05/2026
 ---
 
 # .NET MAUI Shell navigation
@@ -588,6 +588,25 @@ Back button appearance and behavior can be redefined by setting the <xref:Micros
 - `IsEnabled`, of type `boolean`, indicates whether the back button is enabled. The default value is `true`.
 - `IsVisible`, of type `boolean`, indicates whether the back button is visible. The default value is `true`.
 - `TextOverride`, of type `string`, the text used for the back button.
+
+:::moniker range=">=net-maui-11.0"
+
+Starting in .NET MAUI 11, <xref:Microsoft.Maui.Controls.BackButtonBehavior> also defines an `AccessibilityLabel` property of type `string`, which sets the accessibility label that screen readers announce for the back button. This is independent of `TextOverride`, so the visible label can stay short while the spoken label stays descriptive. The following example sets both properties together:
+
+```xaml
+<ContentPage ...>
+    <Shell.BackButtonBehavior>
+        <BackButtonBehavior Command="{Binding BackCommand}"
+                            IconOverride="back.png"
+                            AccessibilityLabel="Back to order list" />
+    </Shell.BackButtonBehavior>
+    ...
+</ContentPage>
+```
+
+Setting an explicit `AccessibilityLabel` is recommended whenever `IconOverride` is set or `TextOverride` is hidden, because screen readers would otherwise announce a generic value or no value at all. For more accessibility guidance, see [Accessibility](~/fundamentals/accessibility.md).
+
+:::moniker-end
 
 ::: moniker range="=net-maui-8.0"
 

--- a/docs/fundamentals/shell/navigation.md
+++ b/docs/fundamentals/shell/navigation.md
@@ -589,9 +589,9 @@ Back button appearance and behavior can be redefined by setting the <xref:Micros
 - `IsVisible`, of type `boolean`, indicates whether the back button is visible. The default value is `true`.
 - `TextOverride`, of type `string`, the text used for the back button.
 
-:::moniker range=">=net-maui-11.0"
+::: moniker range=">=net-maui-11.0"
 
-Starting in .NET MAUI 11, <xref:Microsoft.Maui.Controls.BackButtonBehavior> also defines an `AccessibilityLabel` property of type `string`, which sets the accessibility label that screen readers announce for the back button. This is independent of `TextOverride`, so the visible label can stay short while the spoken label stays descriptive. The following example sets both properties together:
+Starting in .NET MAUI 11, <xref:Microsoft.Maui.Controls.BackButtonBehavior> also defines an `AccessibilityLabel` property of type `string`, which sets the accessibility label that screen readers announce for the back button. This is independent of `TextOverride`, so the visible label can stay short while the spoken label stays descriptive. The following example sets a custom icon and accessibility label together:
 
 ```xaml
 <ContentPage ...>
@@ -606,7 +606,7 @@ Starting in .NET MAUI 11, <xref:Microsoft.Maui.Controls.BackButtonBehavior> also
 
 Setting an explicit `AccessibilityLabel` is recommended whenever `IconOverride` is set or `TextOverride` is hidden, because screen readers would otherwise announce a generic value or no value at all. For more accessibility guidance, see [Accessibility](~/fundamentals/accessibility.md).
 
-:::moniker-end
+::: moniker-end
 
 ::: moniker range="=net-maui-8.0"
 

--- a/docs/user-interface/pages/navigationpage.md
+++ b/docs/user-interface/pages/navigationpage.md
@@ -24,12 +24,12 @@ The .NET Multi-platform App UI (.NET MAUI) <xref:Microsoft.Maui.Controls.Navigat
 - `TitleIconImageSource`, of type <xref:Microsoft.Maui.Controls.ImageSource>, defines the icon that represents the title on the navigation bar. This is an attached property.
 - `TitleView`, of type <xref:Microsoft.Maui.Controls.View>, defines the view that can be displayed in the navigation bar. This is an attached property.
 
-:::moniker range=">=net-maui-11.0"
+::: moniker range=">=net-maui-11.0"
 
 > [!NOTE]
 > Starting in .NET MAUI 11, <xref:Microsoft.Maui.Controls.NavigationPage> also defines a `BackButtonAccessibilityLabel` attached property of type `string`, which sets the accessibility label that screen readers announce for the back button on the navigation bar. See [Set the back button accessibility label](#set-the-back-button-accessibility-label) for an example.
 
-:::moniker-end
+::: moniker-end
 
 These properties are backed by <xref:Microsoft.Maui.Controls.BindableProperty> objects, which means that they can be targets of data bindings, and styled.
 
@@ -215,11 +215,11 @@ In this example, the current page is removed from the modal stack, with the new 
 
 On Android, you can always return to the previous page by pressing the standard *Back* button on the device. If the modal page requires a self-contained task to be completed before leaving the page, the app must disable the *Back* button. This can be accomplished by overriding the `Page.OnBackButtonPressed` method on the modal page.
 
-:::moniker range=">=net-maui-11.0"
+::: moniker range=">=net-maui-11.0"
 
 ### Set the back button accessibility label
 
-Starting in .NET MAUI 11, you can set the accessibility label that screen readers (TalkBack on Android, VoiceOver on iOS and Mac Catalyst, Narrator on Windows) announce for the back button on a <xref:Microsoft.Maui.Controls.NavigationPage> navigation bar. The label is set with the `NavigationPage.BackButtonAccessibilityLabel` attached property, which lives on the destination page—the page the back button returns *to* on the user's behalf:
+Starting in .NET MAUI 11, you can set the accessibility label that screen readers (TalkBack on Android, VoiceOver on iOS and Mac Catalyst, Narrator on Windows) announce for the back button on a <xref:Microsoft.Maui.Controls.NavigationPage> navigation bar. The label is set with the `NavigationPage.BackButtonAccessibilityLabel` attached property on the page whose navigation bar displays the back button:
 
 ```xaml
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
@@ -235,7 +235,7 @@ Setting an explicit label is recommended when the back button title is hidden, a
 
 For more accessibility guidance, see [Accessibility](~/fundamentals/accessibility.md).
 
-:::moniker-end
+::: moniker-end
 
 ## Page navigation events
 

--- a/docs/user-interface/pages/navigationpage.md
+++ b/docs/user-interface/pages/navigationpage.md
@@ -1,7 +1,7 @@
 ---
 title: "NavigationPage"
 description: "The .NET MAUI NavigationPage is used to perform hierarchical navigation through a stack of last-in, first-out (LIFO) pages."
-ms.date: 11/28/2025
+ms.date: 06/05/2026
 ---
 
 # NavigationPage
@@ -23,6 +23,13 @@ The .NET Multi-platform App UI (.NET MAUI) <xref:Microsoft.Maui.Controls.Navigat
 - `RootPage`, of type <xref:Microsoft.Maui.Controls.Page>, represents the root page of the navigation stack. This is a read-only property.
 - `TitleIconImageSource`, of type <xref:Microsoft.Maui.Controls.ImageSource>, defines the icon that represents the title on the navigation bar. This is an attached property.
 - `TitleView`, of type <xref:Microsoft.Maui.Controls.View>, defines the view that can be displayed in the navigation bar. This is an attached property.
+
+:::moniker range=">=net-maui-11.0"
+
+> [!NOTE]
+> Starting in .NET MAUI 11, <xref:Microsoft.Maui.Controls.NavigationPage> also defines a `BackButtonAccessibilityLabel` attached property of type `string`, which sets the accessibility label that screen readers announce for the back button on the navigation bar. See [Set the back button accessibility label](#set-the-back-button-accessibility-label) for an example.
+
+:::moniker-end
 
 These properties are backed by <xref:Microsoft.Maui.Controls.BindableProperty> objects, which means that they can be targets of data bindings, and styled.
 
@@ -207,6 +214,28 @@ In this example, the current page is removed from the modal stack, with the new 
 ### Disable the back button
 
 On Android, you can always return to the previous page by pressing the standard *Back* button on the device. If the modal page requires a self-contained task to be completed before leaving the page, the app must disable the *Back* button. This can be accomplished by overriding the `Page.OnBackButtonPressed` method on the modal page.
+
+:::moniker range=">=net-maui-11.0"
+
+### Set the back button accessibility label
+
+Starting in .NET MAUI 11, you can set the accessibility label that screen readers (TalkBack on Android, VoiceOver on iOS and Mac Catalyst, Narrator on Windows) announce for the back button on a <xref:Microsoft.Maui.Controls.NavigationPage> navigation bar. The label is set with the `NavigationPage.BackButtonAccessibilityLabel` attached property, which lives on the destination page—the page the back button returns *to* on the user's behalf:
+
+```xaml
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="MyApp.DetailPage"
+             Title="Order details"
+             NavigationPage.BackButtonAccessibilityLabel="Back to order list">
+    <!-- ... -->
+</ContentPage>
+```
+
+Setting an explicit label is recommended when the back button title is hidden, abbreviated, or shows only an icon, because screen readers would otherwise announce a generic value or no value at all. The label is independent of the `BackButtonTitle` attached property, so the visible title can stay short while the spoken label stays descriptive.
+
+For more accessibility guidance, see [Accessibility](~/fundamentals/accessibility.md).
+
+:::moniker-end
 
 ## Page navigation events
 


### PR DESCRIPTION
Adds documentation for the new accessibility-label APIs that flow to the toolbar back button in .NET MAUI 11:

- `NavigationPage.BackButtonAccessibilityLabel` attached property — new "Set the back button accessibility label" subsection in `docs/user-interface/pages/navigationpage.md`, plus a moniker-gated NOTE in the property overview list.
- `BackButtonBehavior.AccessibilityLabel` property — new moniker-gated block in the "Back button behavior" section of `docs/fundamentals/shell/navigation.md`.

Both additions cross-link to `docs/fundamentals/accessibility.md`.

Tracks dotnet/maui#35011 and aligns with the .NET 11 Preview 5 release notes (dotnet/core#10433).