### PR TITLE
Clarify Windows Arm Android device debugging requirements

### DIFF
--- a/docs/android/device/setup.md
+++ b/docs/android/device/setup.md
@@ -16,7 +16,7 @@ While the [Android emulator](../emulator/debug-on-emulator.md) is a great way to
 
 To debug a .NET MAUI Android app on a physical Android device, use a development computer that meets the operating system requirements for your Visual Studio version. For Visual Studio 2026, the requirements list supported versions of Windows 11 editions, including ARM64 editions, and list Windows 10 ARM64 as unsupported. For the full list of supported and unsupported operating systems, see [Visual Studio 2026 System Requirements](/visualstudio/releases/2026/vs-system-requirements).
 
-On Windows on Arm (ARM64), the Android emulator isn't supported. Use a physical Android device connected by USB for Android debugging instead. For more information, see [Android emulator troubleshooting](../emulator/troubleshooting.md#windows-arm-device-compatibility).
+On Windows on Arm (ARM64), the Android emulator isn't supported. This is an Android Emulator limitation; Google documents the supported host processors for emulator VM acceleration in [Virtualization extension requirements](https://developer.android.com/studio/run/emulator-acceleration#extensions) on developer.android.com. Use a physical Android device connected by USB for Android debugging instead. For more information, see [Android emulator troubleshooting](../emulator/troubleshooting.md#windows-arm-device-compatibility).
 
 ## Enable developer mode on the device
 

--- a/docs/android/device/setup.md
+++ b/docs/android/device/setup.md
@@ -1,7 +1,7 @@
 ---
 title: "Set up a device for development"
 description: "This article discusses how to enable development mode on an Android device so that you can deploy and debug a .NET MAUI application."
-ms.date: 02/13/2025
+ms.date: 06/12/2026
 ms.custom: sfi-image-nochange
 ---
 
@@ -11,6 +11,12 @@ While the [Android emulator](../emulator/debug-on-emulator.md) is a great way to
 
 > [!IMPORTANT]
 > The steps in this article are written generically, to work on as many devices as possible. If you can't find these settings on your device, consult your device manufacturer's documentation.
+
+## Development computer requirements
+
+To debug a .NET MAUI Android app on a physical Android device, use a development computer that meets the operating system requirements for your Visual Studio version. For Visual Studio 2026, the requirements list supported versions of Windows 11 editions, including ARM64 editions, and list Windows 10 ARM64 as unsupported. For the full list of supported and unsupported operating systems, see [Visual Studio 2026 System Requirements](/visualstudio/releases/2026/vs-system-requirements).
+
+On Windows on Arm (ARM64), the Android emulator isn't supported. Use a physical Android device connected by USB for Android debugging instead. For more information, see [Android emulator troubleshooting](../emulator/troubleshooting.md#windows-arm-device-compatibility).
 
 ## Enable developer mode on the device
 


### PR DESCRIPTION
The Android physical-device setup article did not explain what Windows host requirements apply when debugging Android apps, which left Windows on Arm users without a clear support reference.

This update adds a short development computer requirements section that points to the Visual Studio 2026 system requirements for supported Windows versions, notes that Windows 10 ARM64 is listed as unsupported there, and links to the existing Android emulator troubleshooting guidance that directs Windows on Arm users to use a physical Android device because the emulator is unsupported.

The wording intentionally avoids making a debugger-specific support claim beyond the verified first-party documentation.

Fixes #3374

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/android/device/setup.md](https://github.com/dotnet/docs-maui/blob/b0a146ab39434c2f787ae0b75d3f393c97e55c5b/docs/android/device/setup.md) | [docs/android/device/setup](https://review.learn.microsoft.com/en-us/dotnet/maui/android/device/setup?branch=pr-en-us-3376) |


<!-- PREVIEW-TABLE-END -->