### PR TITLE
Update ms.service in docfx.json

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -58,7 +58,7 @@
       "open_source_feedback_productLogoLightUrl": "https://learn.microsoft.com/media/logos/logo_net.svg",
       "open_source_feedback_productLogoDarkUrl": "https://learn.microsoft.com/media/logos/logo_net.svg",
       "ms.author": "daortin",
-      "ms.service": "dotnet-mobile",
+      "ms.service": "dotnet-mobile-development",
       "ms.subservice": "dotnet-maui",
       "ms.topic": "concept-article",
       "uhfHeaderId": "MSDocsHeader-DotNetMaui",

--- a/docs/migration/skiasharp.md
+++ b/docs/migration/skiasharp.md
@@ -22,7 +22,7 @@ SkiaSharp for .NET MAUI is packaged as a series of NuGet packages. After you've 
 
 ## Update namespaces
 
-Xamarin.Forms apps that use SkiaSharp typically use types from the <xref:SkiaSharp> namespace and the <xref:SkiaSharp.Views.Forms> namespace. In SkiaSharp for .NET MAUI, you'll continue to use the <xref:SkiaSharp> namespace but the types that were in the <xref:SkiaSharp.Views.Forms> namespace have moved into the <xref:SkiaSharp.Views.Maui> and <xref:SkiaSharp.Views.Maui.Controls> namespaces.
+Xamarin.Forms apps that use SkiaSharp typically use types from the <xref:SkiaSharp> namespace and the `SkiaSharp.Views.Forms` namespace. In SkiaSharp for .NET MAUI, you'll continue to use the <xref:SkiaSharp> namespace but the types that were in the `SkiaSharp.Views.Forms` namespace have moved into the <xref:SkiaSharp.Views.Maui> and <xref:SkiaSharp.Views.Maui.Controls> namespaces.
 
 The following table shows the namespaces you'll need to use to build your SkiaSharp code in a .NET MAUI app:
 


### PR DESCRIPTION
`dotnet-mobile` is deprecated in favor of `dotnet-mobile-development` (see https://learn.microsoft.com/en-us/help/platform/metadata-taxonomies/msservice#planned_for_deprecation_table).