### PR TITLE
[Net11 Preview6] Shell: Document Android Handler implementation and ShellRenderer usage

### DIFF
--- a/docs/fundamentals/shell/index.md
+++ b/docs/fundamentals/shell/index.md
@@ -18,7 +18,20 @@ ms.date: 08/30/2024
 ::: moniker range=">=net-maui-11.0"
 
 > [!NOTE]
-> On Android, <xref:Microsoft.Maui.Controls.Shell> uses a handler-based implementation starting in .NET 11, providing improved performance and greater customization flexibility. In .NET 10 and earlier, <xref:Microsoft.Maui.Controls.Shell> used the `ShellRenderer`-based implementation on Android.
+> On Android, <xref:Microsoft.Maui.Controls.Shell> uses a handler-based implementation in .NET 11, aligning with the handler architecture. In .NET 10 and earlier, <xref:Microsoft.Maui.Controls.Shell> used the `ShellRenderer`-based implementation on Android.
+
+## Revert to ShellRenderer behavior
+
+We recommend using the new handler-based <xref:Microsoft.Maui.Controls.Shell> on Android, but if you want to opt out and revert to the `ShellRenderer` behavior, you can use the following code in your `MauiProgram.cs`:
+
+```csharp
+#if ANDROID
+    .ConfigureMauiHandlers(handlers =>
+    {
+        handlers.AddHandler<Shell, Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer>();
+    })
+#endif
+```
 
 ::: moniker-end
 
@@ -69,20 +82,3 @@ Shell uses a URI-based navigation experience that uses routes to navigate to any
 Then, when a result is selected from the search suggestions area, custom logic can be executed such as navigating to a detail page.
 
 For more information, see [.NET MAUI Shell search](search.md).
-
-::: moniker range=">=net-maui-11.0"
-
-## Revert to ShellRenderer behavior
-
-We recommend using the new handler-based <xref:Microsoft.Maui.Controls.Shell> on Android, but if you want to opt out and revert to the `ShellRenderer` behavior, you can use the following code in your `MauiProgram.cs`:
-
-```csharp
-#if ANDROID
-    .ConfigureMauiHandlers(handlers =>
-    {
-        handlers.AddHandler<Shell, Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer>();
-    })
-#endif
-```
-
-::: moniker-end

--- a/docs/fundamentals/shell/index.md
+++ b/docs/fundamentals/shell/index.md
@@ -15,6 +15,13 @@ ms.date: 08/30/2024
 - A URI-based navigation scheme that permits navigation to any page in the app.
 - An integrated search handler.
 
+::: moniker range=">=net-maui-11.0"
+
+> [!NOTE]
+> On Android, <xref:Microsoft.Maui.Controls.Shell> uses a handler-based implementation starting in .NET 11, providing improved performance and greater customization flexibility. In .NET 10 and earlier, <xref:Microsoft.Maui.Controls.Shell> used the `ShellRenderer`-based implementation on Android.
+
+::: moniker-end
+
 ## App visual hierarchy
 
 In a .NET MAUI Shell app, the visual hierarchy of the app is described in a class that subclasses the <xref:Microsoft.Maui.Controls.Shell> class. This class can consist of three main hierarchical objects:
@@ -62,3 +69,20 @@ Shell uses a URI-based navigation experience that uses routes to navigate to any
 Then, when a result is selected from the search suggestions area, custom logic can be executed such as navigating to a detail page.
 
 For more information, see [.NET MAUI Shell search](search.md).
+
+::: moniker range=">=net-maui-11.0"
+
+## Revert to ShellRenderer behavior
+
+We recommend using the new handler-based <xref:Microsoft.Maui.Controls.Shell> on Android, but if you want to opt out and revert to the `ShellRenderer` behavior, you can use the following code in your `MauiProgram.cs`:
+
+```csharp
+#if ANDROID
+    .ConfigureMauiHandlers(handlers =>
+    {
+        handlers.AddHandler<Shell, Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer>();
+    })
+#endif
+```
+
+::: moniker-end

--- a/docs/fundamentals/shell/index.md
+++ b/docs/fundamentals/shell/index.md
@@ -26,10 +26,10 @@ We recommend using the new handler-based <xref:Microsoft.Maui.Controls.Shell> on
 
 ```csharp
 #if ANDROID
-    .ConfigureMauiHandlers(handlers =>
-    {
-        handlers.AddHandler<Shell, Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer>();
-    })
+builder.ConfigureMauiHandlers(handlers =>
+{
+    handlers.AddHandler<Shell, Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer>();
+});
 #endif
 ```
 

--- a/docs/whats-new/dotnet-11.md
+++ b/docs/whats-new/dotnet-11.md
@@ -48,6 +48,21 @@ In .NET 11 Preview 4, the Android handlers for several core controls use Materia
 
 In .NET 11 Preview 5, the underlying Material 3 helper types (`MauiMaterialEditText`, `MauiMaterialDatePicker`, `MauiMaterialPicker`, `MauiMaterialTimePicker`, `MauiMaterialTextView`, `MauiMaterialSearchBarTextInputLayout`, `MaterialActivityIndicator`, and `MauiMaterialContextThemeWrapper`) are public so you can subclass them from your own handler customizations. For more information, see [GitHub PR #35323](https://github.com/dotnet/maui/pull/35323) and [Material 3](~/user-interface/material-design.md).
 
+### Shell handler on Android
+
+Starting in .NET 11 Preview 6, <xref:Microsoft.Maui.Controls.Shell> on Android uses a handler-based implementation, aligning with the current .NET MAUI handler architecture. In .NET 10 and earlier, <xref:Microsoft.Maui.Controls.Shell> used the `ShellRenderer`-based implementation on Android. For more information, see [GitHub PR #34758](https://github.com/dotnet/maui/pull/34758) and [Shell](~/fundamentals/shell/index.md#revert-to-shellrenderer-behavior).
+
+If you need to revert to the previous `ShellRenderer` behavior, you can use the following code in your `MauiProgram.cs`:
+
+```csharp
+#if ANDROID
+builder.ConfigureMauiHandlers(handlers =>
+{
+    handlers.AddHandler<Shell, Microsoft.Maui.Controls.Handlers.Compatibility.ShellRenderer>();
+});
+#endif
+```
+
 ### BoxView Fill property
 
 :::moniker range=">=net-maui-11.0"


### PR DESCRIPTION
### Summary
In .NET 11, the Android Shell implementation moves from the renderer-based approach (ShellRenderer) to the handler-based architecture, aligning with the current .NET MAUI handler model.
This PR updates the Shell overview documentation to describe the Android handler-based implementation and provides an opt-out path for developers who need to continue using the ShellRenderer behavior.

### Related
MAUI PR: https://github.com/dotnet/maui/pull/34758 

**Notes**
Changes are scoped to the >= net-maui-11.0 moniker. Existing .NET 10 and earlier documentation remains unchanged. 
	
**Platform scope:** Android only.