### PR TITLE
[Net11 Preview 6] WinUI: Document for CollectionViewHandler2 implementation

### DIFF
--- a/docs/user-interface/controls/collectionview/index.md
+++ b/docs/user-interface/controls/collectionview/index.md
@@ -16,22 +16,41 @@ The following screenshot shows a <xref:Microsoft.Maui.Controls.CollectionView> t
 
 <xref:Microsoft.Maui.Controls.CollectionView> should be used for presenting lists of data that require scrolling or selection. A bindable layout can be used when the data to be displayed doesn't require scrolling or selection. For more information, see [BindableLayout](~/user-interface/layouts/bindablelayout.md).
 
-::: moniker range=">=net-maui-10.0"
+::: moniker range="net-maui-10.0 net-maui-11.0"
 
 > [!NOTE]
-> On iOS and Mac Catalyst, the optimized handlers that were optional in .NET 9 are the default handlers for <xref:Microsoft.Maui.Controls.CollectionView> in .NET 10, providing improved performance and stability.
+> `CollectionView` optimized handlers became default at different times per platform:
+>
+> | Platform | Default starting in | Previously optional in |
+> | --- | --- | --- |
+> | iOS / Mac Catalyst | .NET 10 | .NET 9 |
+> | Windows | .NET 11 | .NET 10 |
+>
+> These optimized handlers provide improved stability and performance.
 
-## Revert to .NET 9 behavior
+## Revert to previous behavior
 
-We recommend using the new handler for <xref:Microsoft.Maui.Controls.CollectionView>, but if you want to opt-out of this behavior and revert back to the .NET 9 handler, you can use the code below in your `MauiProgram.cs`.
+You can revert in either of these ways (depending on your scenario):
+
+### Option 1: Configure handlers in `MauiProgram.cs`
 
 ```csharp
-#if IOS || MACCATALYST
+#if IOS || MACCATALYST || WINDOWS
 builder.ConfigureMauiHandlers(handlers =>
 {
     handlers.AddHandler<Microsoft.Maui.Controls.CollectionView, Microsoft.Maui.Controls.Handlers.Items.CollectionViewHandler>();
 });
 #endif
+```
+
+### Option 2 (Windows only): Disable optimized CollectionView handler in project file
+
+`UseCollectionViewHandler2` is only supported for Windows targets.
+
+```xml
+<PropertyGroup>
+  <UseCollectionViewHandler2>false</UseCollectionViewHandler2>
+</PropertyGroup>
 ```
 
 ::: moniker-end

--- a/docs/user-interface/controls/collectionview/index.md
+++ b/docs/user-interface/controls/collectionview/index.md
@@ -30,9 +30,9 @@ The following screenshot shows a <xref:Microsoft.Maui.Controls.CollectionView> t
 
 ## Revert to previous behavior
 
-You can revert in either of these ways (depending on your scenario):
+We recommend using the new handler for <xref:Microsoft.Maui.Controls.CollectionView>, but if you want to opt out and revert to the previous handler behavior, you can use the code below in your `MauiProgram.cs`.
 
-### Option 1: Configure handlers in `MauiProgram.cs`
+Configure handlers in `MauiProgram.cs`:
 
 ```csharp
 #if IOS || MACCATALYST || WINDOWS
@@ -43,9 +43,7 @@ builder.ConfigureMauiHandlers(handlers =>
 #endif
 ```
 
-### Option 2 (Windows only): Disable optimized CollectionView handler in project file
-
-`UseWindowsCollectionView2Handler` is only supported for Windows targets.
+On Windows, you can also use the `UseWindowsCollectionView2Handler` build property in your project file.
 
 ```xml
 <PropertyGroup>

--- a/docs/user-interface/controls/collectionview/index.md
+++ b/docs/user-interface/controls/collectionview/index.md
@@ -16,7 +16,7 @@ The following screenshot shows a <xref:Microsoft.Maui.Controls.CollectionView> t
 
 <xref:Microsoft.Maui.Controls.CollectionView> should be used for presenting lists of data that require scrolling or selection. A bindable layout can be used when the data to be displayed doesn't require scrolling or selection. For more information, see [BindableLayout](~/user-interface/layouts/bindablelayout.md).
 
-::: moniker range="net-maui-10.0 net-maui-11.0"
+::: moniker range=">=net-maui-10.0"
 
 > [!NOTE]
 > `CollectionView` optimized handlers became default at different times per platform:
@@ -43,11 +43,11 @@ builder.ConfigureMauiHandlers(handlers =>
 #endif
 ```
 
-On Windows, you can also use the `UseWindowsCollectionView2Handler` build property in your project file.
+On Windows, you can also use the `UseWindowsCollectionView2Handler` build property in your project file:
 
 ```xml
 <PropertyGroup>
- <UseWindowsCollectionView2Handler>false</UseWindowsCollectionView2Handler>
+  <UseWindowsCollectionView2Handler>false</UseWindowsCollectionView2Handler>
 </PropertyGroup>
 ```
 

--- a/docs/user-interface/controls/collectionview/index.md
+++ b/docs/user-interface/controls/collectionview/index.md
@@ -21,10 +21,10 @@ The following screenshot shows a <xref:Microsoft.Maui.Controls.CollectionView> t
 > [!NOTE]
 > `CollectionView` optimized handlers became default at different times per platform:
 >
-> | Platform | Default starting in | Previously optional in |
+> | Platform | Availability before default | Default starting in |
 > | --- | --- | --- |
-> | iOS / Mac Catalyst | .NET 10 | .NET 9 |
-> | Windows | .NET 11 | .NET 10 |
+> | iOS / Mac Catalyst | .NET 9 (optional) | .NET 10 |
+> | Windows | Not available before .NET 11 | .NET 11 |
 >
 > These optimized handlers provide improved stability and performance.
 
@@ -45,11 +45,11 @@ builder.ConfigureMauiHandlers(handlers =>
 
 ### Option 2 (Windows only): Disable optimized CollectionView handler in project file
 
-`UseCollectionViewHandler2` is only supported for Windows targets.
+`UseWindowsCollectionView2Handler` is only supported for Windows targets.
 
 ```xml
 <PropertyGroup>
-  <UseCollectionViewHandler2>false</UseCollectionViewHandler2>
+ <UseWindowsCollectionView2Handler>false</UseWindowsCollectionView2Handler>
 </PropertyGroup>
 ```
 

--- a/docs/whats-new/dotnet-11.md
+++ b/docs/whats-new/dotnet-11.md
@@ -48,6 +48,18 @@ In .NET 11 Preview 4, the Android handlers for several core controls use Materia
 
 In .NET 11 Preview 5, the underlying Material 3 helper types (`MauiMaterialEditText`, `MauiMaterialDatePicker`, `MauiMaterialPicker`, `MauiMaterialTimePicker`, `MauiMaterialTextView`, `MauiMaterialSearchBarTextInputLayout`, `MaterialActivityIndicator`, and `MauiMaterialContextThemeWrapper`) are public so you can subclass them from your own handler customizations. For more information, see [GitHub PR #35323](https://github.com/dotnet/maui/pull/35323) and [Material 3](~/user-interface/material-design.md).
 
+### CollectionView v2 on Windows
+
+Starting in .NET 11 Preview 6, <xref:Microsoft.Maui.Controls.CollectionView> on Windows now uses optimized default handlers, providing improved performance and stability. For more information, see [GitHub PR #34600](https://github.com/dotnet/maui/pull/34600).
+
+If you need to revert to the previous handler, you can disable the CollectionView v2 handler by setting the `UseWindowsCollectionView2Handler` build property to `false` in your project file:
+
+```xml
+<PropertyGroup>
+  <UseWindowsCollectionView2Handler>false</UseWindowsCollectionView2Handler>
+</PropertyGroup>
+```
+
 ### BoxView Fill property
 
 :::moniker range=">=net-maui-11.0"
@@ -161,18 +173,6 @@ Apply a custom JSON style to the map on Android using the `MapStyle` property. T
 For more information, see GitHub PRs [#29101](https://github.com/dotnet/maui/pull/29101), [#33831](https://github.com/dotnet/maui/pull/33831), [#33950](https://github.com/dotnet/maui/pull/33950), [#33982](https://github.com/dotnet/maui/pull/33982), [#33985](https://github.com/dotnet/maui/pull/33985), [#33792](https://github.com/dotnet/maui/pull/33792), [#33799](https://github.com/dotnet/maui/pull/33799), [#33991](https://github.com/dotnet/maui/pull/33991), and [#33993](https://github.com/dotnet/maui/pull/33993).
 
 In .NET 11 Preview 5, the <xref:Microsoft.Maui.Controls.Maps.Map> control gains a Windows implementation backed by Azure Maps. To use it, call `UseMapServiceToken(...)` in `MauiProgram.cs` with an Azure Maps subscription key. The Windows implementation supports `MoveToRegion`, map types, traffic, scrolling, zooming, and standard pins; some platform-only features such as user location, custom pin info windows, and map elements/shapes aren't supported on Windows. For more information, see [GitHub PR #34138](https://github.com/dotnet/maui/pull/34138).
-
-### CollectionView v2 on Windows
-
-Starting in .NET 11 Preview 6, <xref:Microsoft.Maui.Controls.CollectionView> on Windows now uses optimized default handlers, providing improved performance and stability. For more information, see [GitHub PR #34600](https://github.com/dotnet/maui/pull/34600).
-
-If you need to revert to the previous handler, you can disable the CollectionView v2 handler by setting the `UseWindowsCollectionView2Handler` build property to `false` in your project file:
-
-```xml
-<PropertyGroup>
-  <UseWindowsCollectionView2Handler>false</UseWindowsCollectionView2Handler>
-</PropertyGroup>
-```
 
 ### BoxView Fill
 
@@ -341,8 +341,8 @@ We have enhanced the .NET CLI with [Spectre.Console](https://spectreconsole.net/
 
 So, for multi-targeted projects like .NET MAUI, it will:
 
-* Prompt for a `$(TargetFramework)`
-* Prompt for a device, emulator, simulator if there are more than one.
+- Prompt for a `$(TargetFramework)`
+- Prompt for a device, emulator, simulator if there are more than one.
 
 Console output of your application should appear directly in the terminal, and Ctrl+C will terminate the application.
 

--- a/docs/whats-new/dotnet-11.md
+++ b/docs/whats-new/dotnet-11.md
@@ -341,8 +341,8 @@ We have enhanced the .NET CLI with [Spectre.Console](https://spectreconsole.net/
 
 So, for multi-targeted projects like .NET MAUI, it will:
 
-- Prompt for a `$(TargetFramework)`
-- Prompt for a device, emulator, simulator if there are more than one.
+* Prompt for a `$(TargetFramework)`
+* Prompt for a device, emulator, simulator if there are more than one.
 
 Console output of your application should appear directly in the terminal, and Ctrl+C will terminate the application.
 

--- a/docs/whats-new/dotnet-11.md
+++ b/docs/whats-new/dotnet-11.md
@@ -162,6 +162,18 @@ For more information, see GitHub PRs [#29101](https://github.com/dotnet/maui/pul
 
 In .NET 11 Preview 5, the <xref:Microsoft.Maui.Controls.Maps.Map> control gains a Windows implementation backed by Azure Maps. To use it, call `UseMapServiceToken(...)` in `MauiProgram.cs` with an Azure Maps subscription key. The Windows implementation supports `MoveToRegion`, map types, traffic, scrolling, zooming, and standard pins; some platform-only features such as user location, custom pin info windows, and map elements/shapes aren't supported on Windows. For more information, see [GitHub PR #34138](https://github.com/dotnet/maui/pull/34138).
 
+### CollectionView v2 on Windows
+
+Starting in .NET 11 Preview 6, <xref:Microsoft.Maui.Controls.CollectionView> on Windows now uses optimized default handlers, providing improved performance and stability. For more information, see [GitHub PR #34600](https://github.com/dotnet/maui/pull/34600).
+
+If you need to revert to the previous handler, you can disable the CollectionView v2 handler by setting the `UseWindowsCollectionView2Handler` build property to `false` in your project file:
+
+```xml
+<PropertyGroup>
+  <UseWindowsCollectionView2Handler>false</UseWindowsCollectionView2Handler>
+</PropertyGroup>
+```
+
 ### BoxView Fill
 
 Starting in .NET 11 Preview 5, <xref:Microsoft.Maui.Controls.BoxView> exposes a `Fill` property of type <xref:Microsoft.Maui.Controls.Brush>. This aligns <xref:Microsoft.Maui.Controls.BoxView> with the other shape primitives and means gradients and other brushes can paint a `BoxView` without a custom handler. `BackgroundColor` still works as before. For more information, see [GitHub PR #31789](https://github.com/dotnet/maui/pull/31789).


### PR DESCRIPTION
### Summary
In .NET 11, the Windows CollectionView implementation transitions to optimized default handlers, providing improved performance and stability.

This PR updates the CollectionView documentation to describe the handler-based implementation and provides an opt-out path for developers who need to continue using the previous handler behavior.

### Related
MAUI PR: [dotnet/maui#34600](https://github.com/dotnet/maui/pull/34600)

**Notes**
Changes are scoped to the >= net-maui-11.0 moniker. Existing .NET 10 and earlier documentation remains unchanged.

**Platform scope:** Windows only.