### PR TITLE
Rename feedback field and update placeholder

### DIFF
--- a/.github/ISSUE_TEMPLATE/customer-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/customer-feedback.yml
@@ -21,11 +21,12 @@ body:
     validations:
       required: true
   - type: textarea
-    id: feedback
+    id: userfeedback
     validations:
       required: true
     attributes:
       label: Description
+      placeholder: Describe your problem or suggestion
   - type: markdown
     attributes:
       value: "## 🚧 Article information 🚧"


### PR DESCRIPTION
A recent change to GitHub prevents users from changing the description field of an issue filed through the published doc. This solves that problem.