### PR TITLE
CollectionView (.NET 11): document Windows handler update

### DIFF
--- a/docs/user-interface/controls/collectionview/index.md
+++ b/docs/user-interface/controls/collectionview/index.md
@@ -40,7 +40,7 @@ builder.ConfigureMauiHandlers(handlers =>
 
 ## Windows CollectionView handler in .NET 11
 
-In .NET 11 Preview 6 and later, Windows uses the `Microsoft.Maui.Controls.Handlers.Items2.CollectionViewHandler2` handler for <xref:Microsoft.Maui.Controls.CollectionView> by default. The handler is enabled by the `Microsoft.Maui.RuntimeFeature.IsWindowsCollectionView2HandlerEnabled` runtime feature, which is on by default.
+In .NET MAUI 11, Windows uses the `Microsoft.Maui.Controls.Handlers.Items2.CollectionViewHandler2` handler for <xref:Microsoft.Maui.Controls.CollectionView> by default. The handler is controlled by the `Microsoft.Maui.RuntimeFeature.IsWindowsCollectionView2HandlerEnabled` <xref:System.AppContext> switch, which is on by default. The `UseWindowsCollectionView2Handler` MSBuild property maps to this switch.
 
 This WinUI `ItemsRepeater`-based handler improves virtualization and scrolling behavior, and aligns the Windows <xref:Microsoft.Maui.Controls.CollectionView> architecture with the optimized handlers on other platforms. Selection visuals are also different from the legacy Windows handler: selected items are highlighted with a border that wraps the item, and the multiple-selection UI differs from the previous `ListView`-based handler.
 

--- a/docs/user-interface/controls/collectionview/index.md
+++ b/docs/user-interface/controls/collectionview/index.md
@@ -1,7 +1,7 @@
 ---
 title: "CollectionView"
 description: "The .NET MAUI CollectionView displays a scrollable list of selectable data items, using different layout specifications."
-ms.date: 08/19/2025
+ms.date: 07/08/2026
 ---
 
 # CollectionView
@@ -32,6 +32,24 @@ builder.ConfigureMauiHandlers(handlers =>
     handlers.AddHandler<Microsoft.Maui.Controls.CollectionView, Microsoft.Maui.Controls.Handlers.Items.CollectionViewHandler>();
 });
 #endif
+```
+
+::: moniker-end
+
+::: moniker range=">=net-maui-11.0"
+
+## Windows CollectionView handler in .NET 11
+
+In .NET 11 Preview 6 and later, Windows uses the `Microsoft.Maui.Controls.Handlers.Items2.CollectionViewHandler2` handler for <xref:Microsoft.Maui.Controls.CollectionView> by default. The handler is enabled by the `Microsoft.Maui.RuntimeFeature.IsWindowsCollectionView2HandlerEnabled` runtime feature, which is on by default.
+
+This WinUI `ItemsRepeater`-based handler improves virtualization and scrolling behavior, and aligns the Windows <xref:Microsoft.Maui.Controls.CollectionView> architecture with the optimized handlers on other platforms. Selection visuals are also different from the legacy Windows handler: selected items are highlighted with a border that wraps the item, and the multiple-selection UI differs from the previous `ListView`-based handler.
+
+If your app depends on legacy Windows <xref:Microsoft.Maui.Controls.CollectionView> behavior or custom handler assumptions, temporarily opt out while migrating by setting the `UseWindowsCollectionView2Handler` MSBuild property to `false` in your project file:
+
+```xml
+<PropertyGroup>
+    <UseWindowsCollectionView2Handler>false</UseWindowsCollectionView2Handler>
+</PropertyGroup>
 ```
 
 ::: moniker-end


### PR DESCRIPTION
## Summary
- Documents the .NET 11 Preview 6 Windows CollectionView2 handler default.
- Explains the WinUI `ItemsRepeater`-based benefits, selection visual difference, and temporary opt-out path.
- Updates the CollectionView page `ms.date` to 07/08/2026.

## Source verification
- Upstream MAUI PR: https://github.com/dotnet/maui/pull/34600
- Verified Preview 6 source for Windows handler registration, runtime feature default, MSBuild property mapping, and `ItemsRepeater` template usage.

## Validation
- `git diff --check`
- Focused moniker balance check for `docs/user-interface/controls/collectionview/index.md`

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/user-interface/controls/collectionview/index.md](https://github.com/dotnet/docs-maui/blob/ecc3354b37b6a254750217c1c7e699a880116705/docs/user-interface/controls/collectionview/index.md) | [docs/user-interface/controls/collectionview/index](https://review.learn.microsoft.com/en-us/dotnet/maui/user-interface/controls/collectionview/index?branch=pr-en-us-3402) |


<!-- PREVIEW-TABLE-END -->