### PR TITLE
Migration (.NET 11): document compatibility package removal

### DIFF
--- a/docs/migration/custom-renderers.md
+++ b/docs/migration/custom-renderers.md
@@ -1,7 +1,7 @@
 ---
 title: "Reuse custom renderers in .NET MAUI"
 description: "Learn how to adapt Xamarin.Forms custom renderers to work in a .NET MAUI app."
-ms.date: 04/13/2023
+ms.date: 07/08/2026
 ---
 
 # Reuse custom renderers in .NET MAUI
@@ -9,6 +9,13 @@ ms.date: 04/13/2023
 [![Browse sample.](~/media/code-sample.png) Browse the sample](/samples/dotnet/maui-samples/custom-renderers/)
 
 While there are many benefits to using .NET Multi-platform App UI (.NET MAUI) handlers to customize and create controls, it's still possible to use Xamarin.Forms custom renderers in .NET MAUI apps. For more information about custom renderers, see [Xamarin.Forms custom renderers](/xamarin/xamarin-forms/app-fundamentals/custom-renderer/).
+
+::: moniker range=">=net-maui-11.0"
+
+> [!IMPORTANT]
+> The optional `Microsoft.Maui.Controls.Compatibility` NuGet package is no longer built or shipped in .NET 11 and later. This article applies to shimmed renderer base classes that are still included with `Microsoft.Maui.Controls`. If your custom renderer depends on APIs or Xamarin.Forms compatibility renderers that were only available from the opt-in compatibility package, remove the package reference and migrate those usages to .NET MAUI handlers before upgrading.
+
+::: moniker-end
 
 ## Shimmed renderers
 

--- a/docs/migration/multi-project-to-multi-project.md
+++ b/docs/migration/multi-project-to-multi-project.md
@@ -1,7 +1,7 @@
 ---
 title: "Manually upgrade a Xamarin.Forms app to a multi-project .NET MAUI app"
 description: "Learn how to manually upgrade a Xamarin.Forms app to a multi-project .NET MAUI app."
-ms.date: 3/02/2023
+ms.date: 07/08/2026
 no-loc: [ "Xamarin.Forms", "Xamarin.Essentials", "Xamarin.CommunityToolkit", ".NET MAUI Community Toolkit", "SkiaSharp", "Xamarin.Forms.Maps", "Microsoft.Maui", "Microsoft.Maui.Controls", "net8.0-android", "net8.0-ios" ]
 ---
 
@@ -88,7 +88,9 @@ Before you update each platform project's entry point class, you must first enab
 
 #### Add package references
 
-In .NET 8, .NET MAUI ships as a .NET workload and multiple NuGet packages. The advantage of this approach is that it enables you to easily pin your projects to specific versions, while also enabling you to easily preview unreleased or experimental builds.
+::: moniker range="<=net-maui-10.0"
+
+In .NET 10 and earlier, .NET MAUI ships as a .NET workload and multiple NuGet packages. The advantage of this approach is that it enables you to easily pin your projects to specific versions, while also enabling you to easily preview unreleased or experimental builds.
 
 You should add the following explicit package references to an `<ItemGroup>` in each project file:
 
@@ -107,6 +109,24 @@ The `$(MauiVersion)` variable is referenced from the version of .NET MAUI you've
     </PropertyGroup>
 </Project>
 ```
+
+::: moniker-end
+
+::: moniker range=">=net-maui-11.0"
+
+In .NET 11 and later, .NET MAUI ships as a .NET workload and multiple NuGet packages. The optional `Microsoft.Maui.Controls.Compatibility` NuGet package is no longer built or shipped.
+
+You should add the following explicit package reference to an `<ItemGroup>` in each project file:
+
+```xml
+<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
+```
+
+The `$(MauiVersion)` variable is referenced from the version of .NET MAUI you've installed. If you set the `$(MauiVersion)` build property in your project file, use a .NET 11 or later version.
+
+If your migrated project explicitly references the `Microsoft.Maui.Controls.Compatibility` NuGet package, remove the package reference before targeting .NET 11. If your app depends on APIs or Xamarin.Forms compatibility renderers that were only available from that opt-in package, migrate those usages to current .NET MAUI controls or handlers before upgrading.
+
+::: moniker-end
 
 ### Android project configuration
 

--- a/docs/migration/multi-project-to-multi-project.md
+++ b/docs/migration/multi-project-to-multi-project.md
@@ -114,7 +114,7 @@ The `$(MauiVersion)` variable is referenced from the version of .NET MAUI you've
 
 ::: moniker range=">=net-maui-11.0"
 
-In .NET 11 and later, .NET MAUI ships as a .NET workload and multiple NuGet packages. The optional `Microsoft.Maui.Controls.Compatibility` NuGet package is no longer built or shipped.
+In .NET 11 and later, migrated projects still need an explicit `Microsoft.Maui.Controls` package reference. The optional `Microsoft.Maui.Controls.Compatibility` NuGet package is no longer built or shipped.
 
 You should add the following explicit package reference to an `<ItemGroup>` in each project file:
 
@@ -122,7 +122,7 @@ You should add the following explicit package reference to an `<ItemGroup>` in e
 <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 ```
 
-The `$(MauiVersion)` variable is referenced from the version of .NET MAUI you've installed. If you set the `$(MauiVersion)` build property in your project file, use a .NET 11 or later version.
+The `$(MauiVersion)` variable is referenced from the version of .NET MAUI you've installed. If you set the `$(MauiVersion)` build property in your project file, use a .NET MAUI 11 or later package version.
 
 If your migrated project explicitly references the `Microsoft.Maui.Controls.Compatibility` NuGet package, remove the package reference before targeting .NET 11. If your app depends on APIs or Xamarin.Forms compatibility renderers that were only available from that opt-in package, migrate those usages to current .NET MAUI controls or handlers before upgrading.
 


### PR DESCRIPTION
## Summary
- Documents that the optional `Microsoft.Maui.Controls.Compatibility` NuGet package is no longer built or shipped for .NET 11 and later.
- Monikers the multi-project migration package-reference guidance so .NET 10 and earlier preserve the compatibility package reference, while .NET 11+ only references `Microsoft.Maui.Controls`.
- Adds a .NET 11+ custom renderer note that advises migrating away from APIs/renderers that were only available from the opt-in compatibility package, without removing valid shimmed renderer guidance still included with `Microsoft.Maui.Controls`.

## Source verification
- Upstream MAUI PR: https://github.com/dotnet/maui/pull/35870
- Verified `release/11.0.1xx-preview6` no longer contains `src/Compatibility/Core/src/Compatibility.csproj`.
- Verified selected shimmed renderer base types and `RelativeLayout` still exist under `src/Controls/src/Core` in `release/11.0.1xx-preview6`.

## Validation
- Ran `markdownlint-cli2` on the changed docs.
- Checked whitespace and moniker block balance.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/migration/custom-renderers.md](https://github.com/dotnet/docs-maui/blob/f5119202dc16e2674ed3c6dfa69e9bd3898383fc/docs/migration/custom-renderers.md) | [docs/migration/custom-renderers](https://review.learn.microsoft.com/en-us/dotnet/maui/migration/custom-renderers?branch=pr-en-us-3404) |
| [docs/migration/multi-project-to-multi-project.md](https://github.com/dotnet/docs-maui/blob/f5119202dc16e2674ed3c6dfa69e9bd3898383fc/docs/migration/multi-project-to-multi-project.md) | [docs/migration/multi-project-to-multi-project](https://review.learn.microsoft.com/en-us/dotnet/maui/migration/multi-project-to-multi-project?branch=pr-en-us-3404) |


<!-- PREVIEW-TABLE-END -->