### PR TITLE
Accessibility (.NET 11): document Windows layout UIA behavior

### DIFF
--- a/docs/fundamentals/accessibility.md
+++ b/docs/fundamentals/accessibility.md
@@ -254,7 +254,7 @@ AutomationProperties.SetIsInAccessibleTree(entry, true);
 
 ### Windows layout UI Automation behavior in .NET 11
 
-Starting in .NET MAUI 11 Preview 6, Windows uses <xref:Microsoft.Maui.Platform.MauiLayoutAutomationPeer> for <xref:Microsoft.Maui.Controls.Layout> and <xref:Microsoft.Maui.Controls.ContentView> containers. This Windows-specific behavior keeps anonymous layout containers out of UI Automation views by default, while preserving `AutomationId` discovery for UI tests.
+Starting in .NET MAUI 11, Windows uses `MauiLayoutAutomationPeer` for <xref:Microsoft.Maui.Controls.Layout> and <xref:Microsoft.Maui.Controls.ContentView> containers. This Windows-specific behavior keeps anonymous layout containers out of UI Automation (UIA) views by default, while preserving `AutomationId` discovery for UI tests.
 
 | Windows setting on a <xref:Microsoft.Maui.Controls.Layout> or <xref:Microsoft.Maui.Controls.ContentView> | UIA raw view | UIA Control view | UIA Content view |
 | --- | --- | --- | --- |
@@ -262,7 +262,7 @@ Starting in .NET MAUI 11 Preview 6, Windows uses <xref:Microsoft.Maui.Platform.M
 | `AutomationId` only | Included | Included as `Custom` with no localized control type | Excluded |
 | [`IsInAccessibleTree`](xref:Microsoft.Maui.Controls.AutomationProperties.IsInAccessibleTreeProperty) is `true` | Included | Included | Included |
 | [`Description`](xref:Microsoft.Maui.Controls.SemanticProperties.DescriptionProperty) or [`Hint`](xref:Microsoft.Maui.Controls.SemanticProperties.HintProperty) is set | Included | Included | Excluded |
-| Explicit opt-out with [`IsInAccessibleTree`](xref:Microsoft.Maui.Controls.AutomationProperties.IsInAccessibleTreeProperty) set to `false`, or raw accessibility view | Raw only | Excluded, even when `AutomationId`, `Description`, or `Hint` is also set | Excluded |
+| Explicit opt-out with [`IsInAccessibleTree`](xref:Microsoft.Maui.Controls.AutomationProperties.IsInAccessibleTreeProperty) set to `false` | Included in the UIA raw view only | Excluded, even when `AutomationId`, `Description`, or `Hint` is also set | Excluded |
 
 Use `AutomationId` when a layout or <xref:Microsoft.Maui.Controls.ContentView> only needs a Windows UI test hook. Use [`Description`](xref:Microsoft.Maui.Controls.SemanticProperties.DescriptionProperty), [`Hint`](xref:Microsoft.Maui.Controls.SemanticProperties.HintProperty), or [`IsInAccessibleTree`](xref:Microsoft.Maui.Controls.AutomationProperties.IsInAccessibleTreeProperty) set to `true` only when the container itself should be announced by screen readers such as Narrator or NVDA. To keep a container out of the accessibility tree, set [`IsInAccessibleTree`](xref:Microsoft.Maui.Controls.AutomationProperties.IsInAccessibleTreeProperty) to `false`; this explicit opt-out wins over `AutomationId` and semantic accessibility values.
 

--- a/docs/fundamentals/accessibility.md
+++ b/docs/fundamentals/accessibility.md
@@ -1,7 +1,7 @@
 ---
 title: "Build accessible apps with semantic properties"
 description: "Learn how to use the SemanticProperties class in a .NET MAUI app, so that a screen reader can speak about the user interface elements on a page."
-ms.date: 10/03/2023
+ms.date: 07/08/2026
 ---
 
 # Build accessible apps with semantic properties
@@ -249,6 +249,24 @@ AutomationProperties.SetIsInAccessibleTree(entry, true);
 
 > [!WARNING]
 > On iOS, if the `IsInAccessibleTree` property is `true` on any control that has children the screen reader will be unable to reach the children. This is because iOS doesn't provide accessibility features that allow the navigation from a parent element into a child element.
+
+::: moniker range=">=net-maui-11.0"
+
+### Windows layout UI Automation behavior in .NET 11
+
+Starting in .NET MAUI 11 Preview 6, Windows uses <xref:Microsoft.Maui.Platform.MauiLayoutAutomationPeer> for <xref:Microsoft.Maui.Controls.Layout> and <xref:Microsoft.Maui.Controls.ContentView> containers. This Windows-specific behavior keeps anonymous layout containers out of UI Automation views by default, while preserving `AutomationId` discovery for UI tests.
+
+| Windows setting on a <xref:Microsoft.Maui.Controls.Layout> or <xref:Microsoft.Maui.Controls.ContentView> | UIA raw view | UIA Control view | UIA Content view |
+| --- | --- | --- | --- |
+| No automation or semantic accessibility signals | Excluded | Excluded | Excluded |
+| `AutomationId` only | Included | Included as `Custom` with no localized control type | Excluded |
+| [`IsInAccessibleTree`](xref:Microsoft.Maui.Controls.AutomationProperties.IsInAccessibleTreeProperty) is `true` | Included | Included | Included |
+| [`Description`](xref:Microsoft.Maui.Controls.SemanticProperties.DescriptionProperty) or [`Hint`](xref:Microsoft.Maui.Controls.SemanticProperties.HintProperty) is set | Included | Included | Excluded |
+| Explicit opt-out with [`IsInAccessibleTree`](xref:Microsoft.Maui.Controls.AutomationProperties.IsInAccessibleTreeProperty) set to `false`, or raw accessibility view | Raw only | Excluded, even when `AutomationId`, `Description`, or `Hint` is also set | Excluded |
+
+Use `AutomationId` when a layout or <xref:Microsoft.Maui.Controls.ContentView> only needs a Windows UI test hook. Use [`Description`](xref:Microsoft.Maui.Controls.SemanticProperties.DescriptionProperty), [`Hint`](xref:Microsoft.Maui.Controls.SemanticProperties.HintProperty), or [`IsInAccessibleTree`](xref:Microsoft.Maui.Controls.AutomationProperties.IsInAccessibleTreeProperty) set to `true` only when the container itself should be announced by screen readers such as Narrator or NVDA. To keep a container out of the accessibility tree, set [`IsInAccessibleTree`](xref:Microsoft.Maui.Controls.AutomationProperties.IsInAccessibleTreeProperty) to `false`; this explicit opt-out wins over `AutomationId` and semantic accessibility values.
+
+::: moniker-end
 
 ### Name
 


### PR DESCRIPTION
## Summary

- Documents the .NET 11 Preview 6 Windows UI Automation behavior for layouts and `ContentView` in `docs/fundamentals/accessibility.md`.
- Adds a behavior table for anonymous layouts, `AutomationId`-only test hooks, semantic opt-ins, `IsInAccessibleTree`, and explicit opt-out precedence.
- Updates `ms.date` to 07/08/2026.

## Source verification

- Verified against dotnet/maui PR: https://github.com/dotnet/maui/pull/35597
- Confirmed the change is present in the `release/11.0.1xx-preview5` to `release/11.0.1xx-preview6` comparison.

## Validation

- Checked moniker block balance in `docs/fundamentals/accessibility.md`.
- Checked the new markdown table structure.
- Ran `git diff --check`.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/accessibility.md](https://github.com/dotnet/docs-maui/blob/e88fb6ea30966dc365ce99b7e80fe219785bf997/docs/fundamentals/accessibility.md) | [docs/fundamentals/accessibility](https://review.learn.microsoft.com/en-us/dotnet/maui/fundamentals/accessibility?branch=pr-en-us-3406) |


<!-- PREVIEW-TABLE-END -->