### PR TITLE
Fix spelling, grammar, and outdated code in user-interface/pages and layouts docs

### DIFF
--- a/docs/user-interface/layouts/absolutelayout.md
+++ b/docs/user-interface/layouts/absolutelayout.md
@@ -68,7 +68,7 @@ The following XAML shows an <xref:Microsoft.Maui.Controls.AbsoluteLayout> whose 
 
 ```
 
-In this example, the position of each <xref:Microsoft.Maui.Controls.BoxView> object is defined using the first two absolute values that are specified in the `AbsoluteLayout.LayoutBounds` attached property. The size of each <xref:Microsoft.Maui.Controls.BoxView> is defined using the third and forth values. The position of the <xref:Microsoft.Maui.Controls.Label> object is defined using the two absolute values that are specified in the `AbsoluteLayout.LayoutBounds` attached property. Size values are not specified for the <xref:Microsoft.Maui.Controls.Label>, and so it's unconstrained and sizes itself. In all cases, the absolute values represent device-independent units.
+In this example, the position of each <xref:Microsoft.Maui.Controls.BoxView> object is defined using the first two absolute values that are specified in the `AbsoluteLayout.LayoutBounds` attached property. The size of each <xref:Microsoft.Maui.Controls.BoxView> is defined using the third and fourth values. The position of the <xref:Microsoft.Maui.Controls.Label> object is defined using the two absolute values that are specified in the `AbsoluteLayout.LayoutBounds` attached property. Size values are not specified for the <xref:Microsoft.Maui.Controls.Label>, and so it's unconstrained and sizes itself. In all cases, the absolute values represent device-independent units.
 
 The following screenshot shows the resulting layout:
 
@@ -204,7 +204,7 @@ The following XAML shows an <xref:Microsoft.Maui.Controls.AbsoluteLayout> whose 
 </ContentPage>
 ```
 
-In this example, each child is positioned using proportional values but sized using absolute values. This is accomplished by setting the `AbsoluteLayout.LayoutFlags` attached property of each child to `PositionProportional`. The first two values that are specified in the `AbsoluteLayout.LayoutBounds` attached property, for each child, define the position using proportional values. The size of each child is defined with the third and forth absolute values, using device-independent units.
+In this example, each child is positioned using proportional values but sized using absolute values. This is accomplished by setting the `AbsoluteLayout.LayoutFlags` attached property of each child to `PositionProportional`. The first two values that are specified in the `AbsoluteLayout.LayoutBounds` attached property, for each child, define the position using proportional values. The size of each child is defined with the third and fourth absolute values, using device-independent units.
 
 The following screenshot shows the resulting layout:
 

--- a/docs/user-interface/layouts/custom.md
+++ b/docs/user-interface/layouts/custom.md
@@ -281,7 +281,7 @@ public override Size ArrangeChildren(Rect bounds)
 }
 ```
 
-The `ArrangeChildren` method enumerates through all the visible children in the layout to size and position them within the layout. It does this by invoking <xref:Microsoft.Maui.IView.Arrange%2A> on each child with appropriate bounds, that take into account the <xref:Microsoft.Maui.Controls.Layout.Padding> and <xref:Microsoft.Maui.Controls.StackBase.Spacing> of the underlying layout. It then returns the actual size of the layout. The <xref:Microsoft.Maui.Layouts.LayoutExtensions.AdjustForFill%2A> method is called to ensure that the size takes into account whether the the layout has its <xref:Microsoft.Maui.IView.HorizontalLayoutAlignment> and <xref:Microsoft.Maui.IView.VerticalLayoutAlignment> properties set to <xref:Microsoft.Maui.Controls.LayoutOptions.Fill?displayProperty=nameWithType>.
+The `ArrangeChildren` method enumerates through all the visible children in the layout to size and position them within the layout. It does this by invoking <xref:Microsoft.Maui.IView.Arrange%2A> on each child with appropriate bounds, that take into account the <xref:Microsoft.Maui.Controls.Layout.Padding> and <xref:Microsoft.Maui.Controls.StackBase.Spacing> of the underlying layout. It then returns the actual size of the layout. The <xref:Microsoft.Maui.Layouts.LayoutExtensions.AdjustForFill%2A> method is called to ensure that the size takes into account whether the layout has its <xref:Microsoft.Maui.IView.HorizontalLayoutAlignment> and <xref:Microsoft.Maui.IView.VerticalLayoutAlignment> properties set to <xref:Microsoft.Maui.Controls.LayoutOptions.Fill?displayProperty=nameWithType>.
 
 > [!IMPORTANT]
 > When enumerating children in the <xref:Microsoft.Maui.Layouts.ILayoutManager.ArrangeChildren%2A> implementation, skip any child whose <xref:Microsoft.Maui.IView.Visibility> property is set to <xref:Microsoft.Maui.Visibility.Collapsed>. This ensures that the custom layout won't leave space for invisible children.
@@ -379,7 +379,7 @@ public class CustomGridLayoutManager : GridLayoutManager
 }
 ```
 
-In this example, `CustomGridLayoutManager` derives from .NET MAUI's <xref:Microsoft.Maui.Layouts.GridLayoutManager> class, and overrides its <xref:Microsoft.Maui.Layouts.GridLayoutManager.Measure%2A> method. This custom layout manager ensures that at runtime the <xref:Microsoft.Maui.Controls.Grid.RowDefinitions> for the <xref:Microsoft.Maui.Controls.Grid> includes enough rows to account for each `Grid.Row` attached property set in a child view. Without this modification, the <xref:Microsoft.Maui.Controls.Grid.RowDefinitions> for the <xref:Microsoft.Maui.Controls.Grid> would need to be specified at design time.
+In this example, `CustomGridLayoutManager` derives from .NET MAUI's <xref:Microsoft.Maui.Layouts.GridLayoutManager> class, and overrides its <xref:Microsoft.Maui.Layouts.GridLayoutManager.Measure%2A> method. This custom layout manager ensures that at runtime the <xref:Microsoft.Maui.Controls.Grid.RowDefinitions> for the <xref:Microsoft.Maui.Controls.Grid> include enough rows to account for each `Grid.Row` attached property set in a child view. Without this modification, the <xref:Microsoft.Maui.Controls.Grid.RowDefinitions> for the <xref:Microsoft.Maui.Controls.Grid> would need to be specified at design time.
 
 > [!IMPORTANT]
 > When modifying the behavior of an existing layout manager, don't forget to ensure that you call the `base.Measure` method from your <xref:Microsoft.Maui.Layouts.ILayoutManager.Measure%2A> implementation.

--- a/docs/user-interface/layouts/grid.md
+++ b/docs/user-interface/layouts/grid.md
@@ -10,7 +10,7 @@ ms.date: 08/30/2024
 
 :::image type="content" source="media/grid/layouts.png" alt-text=".NET MAUI Grid." border="false":::
 
-The .NET Multi-platform App UI (.NET MAUI) <xref:Microsoft.Maui.Controls.Grid>, is a layout that organizes its children into rows and columns, which can have proportional or absolute sizes. By default, a <xref:Microsoft.Maui.Controls.Grid> contains one row and one column. In addition, a <xref:Microsoft.Maui.Controls.Grid> can be used as a parent layout that contains other child layouts.
+The .NET Multi-platform App UI (.NET MAUI) <xref:Microsoft.Maui.Controls.Grid> is a layout that organizes its children into rows and columns, which can have proportional or absolute sizes. By default, a <xref:Microsoft.Maui.Controls.Grid> contains one row and one column. In addition, a <xref:Microsoft.Maui.Controls.Grid> can be used as a parent layout that contains other child layouts.
 
 The <xref:Microsoft.Maui.Controls.Grid> should not be confused with tables, and is not intended to present tabular data. Unlike HTML tables, a <xref:Microsoft.Maui.Controls.Grid> is intended for laying out content. For displaying tabular data, consider using a [ListView](~/user-interface/controls/listview.md) or [CollectionView](~/user-interface/controls/collectionview/index.md).
 
@@ -267,9 +267,9 @@ In XAML, the row and column characteristics of a <xref:Microsoft.Maui.Controls.G
 </Grid>
 ```
 
-In this example, the <xref:Microsoft.Maui.Controls.Grid> has five rows and four columns. The third, forth, and fifth rows are set to absolute heights, with the second row auto-sizing to its content. The remaining height is then allocated to the first row.
+In this example, the <xref:Microsoft.Maui.Controls.Grid> has five rows and four columns. The third, fourth, and fifth rows are set to absolute heights, with the second row auto-sizing to its content. The remaining height is then allocated to the first row.
 
-The forth column is set to an absolute width, with the third column auto-sizing to its content. The remaining width is allocated proportionally between the first and second columns based on the number before the star. In this example, the width of the second column is twice that of the first column (because `*` is identical to `1*`).
+The fourth column is set to an absolute width, with the third column auto-sizing to its content. The remaining width is allocated proportionally between the first and second columns based on the number before the star. In this example, the width of the second column is twice that of the first column (because `*` is identical to `1*`).
 
 ## Space between rows and columns
 

--- a/docs/user-interface/layouts/horizontalstacklayout.md
+++ b/docs/user-interface/layouts/horizontalstacklayout.md
@@ -113,7 +113,7 @@ A <xref:Microsoft.Maui.Controls.HorizontalStackLayout> can be used as a parent l
 The following XAML shows an example of nesting <xref:Microsoft.Maui.Controls.VerticalStackLayout> objects in a <xref:Microsoft.Maui.Controls.HorizontalStackLayout>:
 
 ```xaml
-<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="StackLayoutDemos.Views.HorizontalStackLayoutPage">
     <HorizontalStackLayout Margin="20"

--- a/docs/user-interface/layouts/index.md
+++ b/docs/user-interface/layouts/index.md
@@ -86,7 +86,7 @@ The following XAML shows how to create a <xref:Microsoft.Maui.Controls.VerticalS
 
 ```xaml
 <VerticalStackLayout Margin="20,35,20,25">
-    <Label Text="The VericalStackLayout has its Margin property set, to control the rendering position of the VerticalStackLayout." />
+    <Label Text="The VerticalStackLayout has its Margin property set, to control the rendering position of the VerticalStackLayout." />
     <Label Text="The Padding property can be set to specify the distance between the VerticalStackLayout and its children." />
     <Label Text="The Spacing property can be set to specify the distance between views in the VerticalStackLayout." />
 </VerticalStackLayout>

--- a/docs/user-interface/layouts/verticalstacklayout.md
+++ b/docs/user-interface/layouts/verticalstacklayout.md
@@ -148,7 +148,7 @@ A <xref:Microsoft.Maui.Controls.VerticalStackLayout> can be used as a parent lay
 The following XAML shows an example of nesting <xref:Microsoft.Maui.Controls.HorizontalStackLayout> objects in a <xref:Microsoft.Maui.Controls.VerticalStackLayout>:
 
 ```xaml
-<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="StackLayoutDemos.Views.VerticalStackLayoutPage">
     <VerticalStackLayout Margin="20"

--- a/docs/user-interface/pages/contentpage.md
+++ b/docs/user-interface/pages/contentpage.md
@@ -8,7 +8,7 @@ ms.date: 09/30/2024
 
 :::image type="content" source="media/contentpage/pages.png" alt-text=".NET MAUI ContentPage." border="false":::
 
-The .NET Multi-platform App UI (.NET MAUI) <xref:Microsoft.Maui.Controls.ContentPage> displays a single view, which is often a layout such as as <xref:Microsoft.Maui.Controls.Grid> or <xref:Microsoft.Maui.Controls.StackLayout>, and is the most common page type.
+The .NET Multi-platform App UI (.NET MAUI) <xref:Microsoft.Maui.Controls.ContentPage> displays a single view, which is often a layout such as <xref:Microsoft.Maui.Controls.Grid> or <xref:Microsoft.Maui.Controls.StackLayout>, and is the most common page type.
 
 <xref:Microsoft.Maui.Controls.ContentPage> defines the following properties:
 

--- a/docs/user-interface/pages/flyoutpage.md
+++ b/docs/user-interface/pages/flyoutpage.md
@@ -36,7 +36,7 @@ The `IsGestureEnabled`, `IsPresented`, and `FlyoutLayoutBehavior` properties are
 
 ## Create a FlyoutPage
 
-To create a flyout page, create a <xref:Microsoft.Maui.Controls.FlyoutPage> object and set it's `Flyout` and `Detail` properties. The `Flyout` property should be set to <xref:Microsoft.Maui.Controls.ContentPage> object, and the `Detail` property should be set to a <xref:Microsoft.Maui.Controls.TabbedPage>, <xref:Microsoft.Maui.Controls.NavigationPage>, or <xref:Microsoft.Maui.Controls.ContentPage> object. This will help to ensure a consistent user experience across all platforms.
+To create a flyout page, create a <xref:Microsoft.Maui.Controls.FlyoutPage> object and set its `Flyout` and `Detail` properties. The `Flyout` property should be set to a <xref:Microsoft.Maui.Controls.ContentPage> object, and the `Detail` property should be set to a <xref:Microsoft.Maui.Controls.TabbedPage>, <xref:Microsoft.Maui.Controls.NavigationPage>, or <xref:Microsoft.Maui.Controls.ContentPage> object. This will help to ensure a consistent user experience across all platforms.
 
 > [!IMPORTANT]
 > A <xref:Microsoft.Maui.Controls.FlyoutPage> is designed to be the root page of an app, and using it as a child page in other page types could result in unexpected and inconsistent behavior.

--- a/docs/user-interface/pages/navigationpage.md
+++ b/docs/user-interface/pages/navigationpage.md
@@ -436,7 +436,7 @@ Contact contact = new Contact
 await Navigation.PushModalAsync(new DetailsPage(contact));
 ```
 
-In this example, a `Contact` object is passed as a constructor argument to `DetailPage`. The `Contact` object can then be displayed by `DetailsPage`.
+In this example, a `Contact` object is passed as a constructor argument to `DetailsPage`. The `Contact` object can then be displayed by `DetailsPage`.
 
 ### Pass data through a BindingContext
 

--- a/docs/user-interface/pages/tabbedpage.md
+++ b/docs/user-interface/pages/tabbedpage.md
@@ -40,7 +40,7 @@ Two approaches can be used to create a <xref:Microsoft.Maui.Controls.TabbedPage>
 Regardless of the approach taken, the location of the tab bar in a <xref:Microsoft.Maui.Controls.TabbedPage> is platform-dependent:
 
 - On iOS, the list of tabs appears at the bottom of the screen, and the page content is above. Each tab consists of a title and an icon. In portrait orientation, tab bar icons appear above tab titles. In landscape orientation, icons and titles appear side by side. In addition, a regular or compact tab bar may be displayed, depending on the device and orientation. If there are more than five tabs, a **More** tab will appear, which can be used to access the additional tabs.
-- On Android, the list of tabs appears at the top of the screen, and the page content is below. Each tab consists of a title and an icon. However, the tabs can be moved to the bottom of the screen with a platform-specific. If there are more than five tabs, and the tab list is at the bottom of the screen, a *More* tab will appear that can be used to access the additional tabs. For information about moving the tabs to the bottom of the screen, see [TabbedPage toolbar placement on Android](~/android/platform-specifics/tabbedpage-toolbar-placement.md).
+- On Android, the list of tabs appears at the top of the screen, and the page content is below. Each tab consists of a title and an icon. However, the tabs can be moved to the bottom of the screen with a platform-specific property. If there are more than five tabs, and the tab list is at the bottom of the screen, a *More* tab will appear that can be used to access the additional tabs. For information about moving the tabs to the bottom of the screen, see [TabbedPage toolbar placement on Android](~/android/platform-specifics/tabbedpage-toolbar-placement.md).
 - On Windows, the list of tabs appears at the top of the screen, and the page content is below. Each tab consists of a title. <!--However, icons can be added to each tab with a platform-specific. For more information, see [TabbedPage Icons on Windows](~/platform/windows/tabbedpage-icons.md).-->
 
 ### Populate a TabbedPage with a Page collection
@@ -132,7 +132,7 @@ Navigation can be performed within a tab, provided that the <xref:Microsoft.Maui
 
 In this example, the <xref:Microsoft.Maui.Controls.TabbedPage> is populated with two <xref:Microsoft.Maui.Controls.Page> objects. The first child is a <xref:Microsoft.Maui.Controls.ContentPage> object, and the second child is a <xref:Microsoft.Maui.Controls.NavigationPage> object containing a <xref:Microsoft.Maui.Controls.ContentPage> object.
 
-When a <xref:Microsoft.Maui.Controls.ContentPage> is wrapped in a <xref:Microsoft.Maui.Controls.NavigationPage>, forwards page navigation can be performed by calling the `PushAsync` method on the `Navigation` property of the <xref:Microsoft.Maui.Controls.ContentPage> object:
+When a <xref:Microsoft.Maui.Controls.ContentPage> is wrapped in a <xref:Microsoft.Maui.Controls.NavigationPage>, forward page navigation can be performed by calling the `PushAsync` method on the `Navigation` property of the <xref:Microsoft.Maui.Controls.ContentPage> object:
 
 ```csharp
 await Navigation.PushAsync(new UpcomingAppointmentsPage());


### PR DESCRIPTION
## Summary

Fixes documentation quality issues across 10 files in the `user-interface/pages` and `user-interface/layouts` sections.

> **Scope note:** This PR is a companion to #3426 which addressed the `user-interface/controls` section. PRs are separated by section to keep reviews focused and manageable.

## Changes by Category

### Spelling Errors (5 fixes)
- `forth` → `fourth` (absolutelayout ×2, grid ×2)
- `VericalStackLayout` → `VerticalStackLayout` (layouts/index)
- `such as as` → `such as` (contentpage)

### Grammar Issues (7 fixes)
- `it's` → `its` (possessive, flyoutpage)
- Missing article: "set to ContentPage object" → "set to a ContentPage object" (flyoutpage)
- Incomplete sentence: "with a platform-specific." → "with a platform-specific property." (tabbedpage)
- `forwards page navigation` → `forward page navigation` (tabbedpage)
- `the the layout` → `the layout` (custom)
- Subject-verb: `includes enough rows` → `include enough rows` (custom)
- Stray comma: "Grid, is a layout" → "Grid is a layout" (grid)

### Code/Text Inconsistency (1 fix)
- `DetailPage` in text → `DetailsPage` to match the code sample (navigationpage)

### Outdated Code (2 fixes)
- Xamarin.Forms namespace `xmlns="http://xamarin.com/schemas/2014/forms"` → .NET MAUI namespace `xmlns="http://schemas.microsoft.com/dotnet/2021/maui"` (horizontalstacklayout, verticalstacklayout)

## Verification
Issues verified against the live documentation at https://learn.microsoft.com/dotnet/maui/user-interface/layouts/ and https://learn.microsoft.com/dotnet/maui/user-interface/pages/

Fixes #3427