### PR TITLE
Shell (.NET 11): Add custom handlers documentation

### DIFF
--- a/docs/TOC.yml
+++ b/docs/TOC.yml
@@ -238,7 +238,7 @@
             - name: Search
               href: fundamentals/shell/search.md
             - name: Custom handlers
-              href: fundamentals/shell/customhandlers.md
+              href: fundamentals/shell/custom-handlers.md
             - name: Lifecycle
               href: fundamentals/shell/lifecycle.md
         - name: Single project

--- a/docs/TOC.yml
+++ b/docs/TOC.yml
@@ -237,6 +237,8 @@
               href: fundamentals/shell/navigation.md
             - name: Search
               href: fundamentals/shell/search.md
+            - name: Custom handlers
+              href: fundamentals/shell/customhandlers.md
             - name: Lifecycle
               href: fundamentals/shell/lifecycle.md
         - name: Single project

--- a/docs/fundamentals/shell/custom-handlers.md
+++ b/docs/fundamentals/shell/custom-handlers.md
@@ -10,7 +10,10 @@ ms.date: 07/28/2026
 
 [![Browse sample.](~/media/code-sample.png) Browse the sample](/samples/dotnet/maui-samples/fundamentals-shell)
 
-.NET MAUI Shell applications are highly customizable through the properties and methods that the various Shell classes expose. However, it's also possible to create custom handlers when more extensive platform-specific customizations are required. Custom handlers can be added to just one platform project to customize appearance and behavior, while allowing the default behavior on other platforms.
+.NET MAUI Shell applications are highly customizable through the properties and methods that the various Shell classes expose. However, it's also possible to create custom handlers when more extensive platform-specific customizations are required. Custom handlers can be registered conditionally for a single platform, while allowing the default behavior on other platforms.
+
+> [!NOTE]
+> Shell custom handlers are currently supported on Android in .NET MAUI 11 and later. iOS and Mac Catalyst continue to use the legacy `ShellRenderer`.
 
 ## Android handler customization
 
@@ -34,10 +37,9 @@ The following handler classes expose overridable members on Android:
 
 ### Android example
 
-The following code example shows a subclassed `ShellHandler`, for Android, that sets a background color on the toolbar of the Shell application:
+The following code example shows a subclassed `ShellHandler`, for Android, that sets a background image on the toolbar of the Shell application and changes the title text color:
 
 ```csharp
-using AndroidX.AppCompat.Widget;
 using Microsoft.Maui.Controls.Handlers;
 using Microsoft.Maui.Controls.Platform;
 

--- a/docs/fundamentals/shell/customhandlers.md
+++ b/docs/fundamentals/shell/customhandlers.md
@@ -1,0 +1,113 @@
+---
+title: ".NET MAUI Shell custom handlers"
+description: "Learn how to customize the appearance and behavior of a .NET MAUI Shell app using platform-specific handlers."
+ms.date: 07/28/2026
+---
+
+# .NET MAUI Shell custom handlers
+
+::: moniker range=">=net-maui-11.0"
+
+[![Browse sample.](~/media/code-sample.png) Browse the sample](/samples/dotnet/maui-samples/fundamentals-shell)
+
+.NET MAUI Shell applications are highly customizable through the properties and methods that the various Shell classes expose. However, it's also possible to create custom handlers when more extensive platform-specific customizations are required. Custom handlers can be added to just one platform project to customize appearance and behavior, while allowing the default behavior on other platforms.
+
+## Android handler customization
+
+Starting in .NET MAUI 11, Shell on Android uses a handler-based architecture by default. The Android implementation is built around `ShellHandler`, `ShellItemHandler`, and `ShellSectionHandler`. This is the recommended approach for customizing Shell on Android.
+
+### Create a custom Shell handler
+
+The process for creating a custom Shell handler on Android is:
+
+1. Create a subclass of `ShellHandler`, `ShellItemHandler`, or `ShellSectionHandler`.
+2. Override the required methods to perform the customization.
+3. Register the handler in `MauiProgram.cs`.
+
+The following handler classes expose overridable members on Android:
+
+| Handler | Overridable members |
+| --- | --- |
+| `ShellHandler` | `CreateShellItemRenderer`, `CreateShellFlyoutContentRenderer`, `CreateFragmentForPage`, `CreateShellSectionRenderer`, `CreateTrackerForToolbar`, `CreateToolbarAppearanceTracker`, `CreateTabLayoutAppearanceTracker`, `CreateBottomNavViewAppearanceTracker` |
+| `ShellItemHandler` | `OnTabReselected`, `OnSectionChanged`, `CreateMoreBottomSheet` |
+| `ShellSectionHandler` | `OnCreateNavigationAnimation` |
+
+### Android example
+
+The following code example shows a subclassed `ShellHandler`, for Android, that sets a background color on the toolbar of the Shell application:
+
+```csharp
+using AndroidX.AppCompat.Widget;
+using Microsoft.Maui.Controls.Handlers;
+using Microsoft.Maui.Controls.Platform;
+
+namespace MyApp.Platforms.Android;
+
+public class MyShellHandler : ShellHandler
+{
+    protected override IShellToolbarAppearanceTracker CreateToolbarAppearanceTracker()
+    {
+        return new MyShellToolbarAppearanceTracker(this);
+    }
+}
+```
+
+The `MyShellHandler` class overrides the `CreateToolbarAppearanceTracker` method, and returns an instance of the `MyShellToolbarAppearanceTracker` class. The `MyShellToolbarAppearanceTracker` class, which derives from the `ShellToolbarAppearanceTracker` class, is shown in the following example:
+
+```csharp
+using AndroidX.AppCompat.Widget;
+using Microsoft.Maui.Controls.Platform;
+
+namespace MyApp.Platforms.Android;
+
+public class MyShellToolbarAppearanceTracker : ShellToolbarAppearanceTracker
+{
+    public MyShellToolbarAppearanceTracker(IShellContext context) : base(context)
+    {
+    }
+
+    public override void SetAppearance(
+        Toolbar toolbar,
+        IShellToolbarTracker toolbarTracker,
+        ShellAppearance appearance)
+    {
+        base.SetAppearance(toolbar, toolbarTracker, appearance);
+
+        var context = toolbar.Context;
+        if (context is not null)
+        {
+            var resId = context.Resources?.GetIdentifier(
+                "dotnet_bot", "drawable", context.PackageName) ?? 0;
+            if (resId != 0)
+            {
+                toolbar.SetBackgroundResource(resId);
+            }
+        }
+
+        toolbar.BackgroundTintList = null;
+        toolbar.SetTitleTextColor(global::Android.Graphics.Color.Red);
+    }
+}
+```
+
+The `MyShellToolbarAppearanceTracker` class overrides the `SetAppearance` method, and modifies the toolbar by setting a background image on it and changing the title text color.
+
+### Register the Android handler
+
+Register the custom handler in `MauiProgram.cs` using `ConfigureMauiHandlers`:
+
+```csharp
+using Microsoft.Maui.Controls;
+
+var builder = MauiApp.CreateBuilder();
+builder
+    .UseMauiApp<App>()
+    .ConfigureMauiHandlers(handlers =>
+    {
+#if ANDROID
+        handlers.AddHandler<Shell, MyApp.Platforms.Android.MyShellHandler>();
+#endif
+    });
+```
+
+::: moniker-end


### PR DESCRIPTION
## Summary

Add a new conceptual page documenting Shell custom handler customization on Android,
introduced in .NET MAUI 11 where Shell moved to a handler-based architecture by default.

## .NET 11 change and motivation

Starting in .NET MAUI 11 (preview 6), Android Shell uses `ShellHandler`, `ShellItemHandler`,
and `ShellSectionHandler` instead of the legacy `ShellRenderer`. This was a missing documentation
topic — Xamarin.Forms had a dedicated [Shell custom renderers](https://learn.microsoft.com/en-us/previous-versions/xamarin/xamarin-forms/app-fundamentals/shell/customrenderers) page, but .NET MAUI
had no equivalent covering the handler approach.

## Files changed

- **`docs/fundamentals/shell/customhandlers.md`** (new) — Custom handlers page covering:
  - Overridable members table for `ShellHandler`, `ShellItemHandler`, `ShellSectionHandler`
  - `CreateToolbarAppearanceTracker` example with `ShellToolbarAppearanceTracker` subclass
  - Handler registration via `ConfigureMauiHandlers`
  - Content gated to `>=net-maui-11.0` moniker
- **`docs/TOC.yml`** — Added "Custom handlers" entry under Shell

## Platform-specific notes

- Android: Handler-based architecture is the default from .NET MAUI 11.
- iOS/Mac Catalyst: Continue to use the legacy `ShellRenderer` (not covered in this page).

## Verification

- Overridable members verified against `dotnet/maui` source on the `net10.0` branch.
- Code example tested on Android with working `SetAppearance` override.