### PR TITLE
.NET 11: document Preview 7 XAML tooling

### DIFF
--- a/docs/fundamentals/data-binding/compiled-bindings.md
+++ b/docs/fundamentals/data-binding/compiled-bindings.md
@@ -1,7 +1,7 @@
 ---
 title: "Compiled bindings"
 description: "Compiled bindings can be used to improve data binding performance in .NET MAUI applications."
-ms.date: 08/06/2026
+ms.date: 08/11/2026
 ---
 
 # Compiled bindings
@@ -188,16 +188,18 @@ Then, ensure that all your bindings are annotated with the correct `x:DataType` 
 
 ### Compile relative source ancestor bindings
 
-In .NET MAUI 11, when compilation of bindings that define the `Source` property is enabled, the XAML compiler can compile a binding that uses [`RelativeSource`](xref:Microsoft.Maui.Controls.Xaml.RelativeSourceExtension) with a resolvable `AncestorType`. The compiler uses the ancestor type as the binding source type:
+In .NET MAUI 11, when compilation of bindings that define the `Source` property is enabled, the XAML source generator can compile a binding that uses [`RelativeSource`](xref:Microsoft.Maui.Controls.Xaml.RelativeSourceExtension) with a resolvable `AncestorType`. The source generator uses the ancestor type as the binding source type, so an inline `x:DataType` isn't required:
 
 ```xaml
 <Button Command="{Binding Source={RelativeSource AncestorType={x:Type local:PeopleViewModel}},
                           Path=DeleteEmployeeCommand}" />
 ```
 
-When the ancestor type and binding path can be resolved at compile time, the compiler generates a trim-safe compiled binding rather than a reflection-based binding. This makes the binding safe for full trimming and NativeAOT.
+When the ancestor type and binding path can be resolved at compile time, the source generator generates a trim-safe compiled binding rather than a reflection-based binding. This makes the binding safe for full trimming and NativeAOT.
 
-Bindings use the runtime fallback when their source type can't be resolved at compile time. This includes `RelativeSource` bindings that use `Self` or `TemplatedParent`, and `x:Reference` bindings whose referenced element type can't be resolved.
+`RelativeSource` bindings that use `Self` or `TemplatedParent` continue to use runtime bindings.
+
+For an `x:Reference` binding, the source generator resolves the referenced element type and compiles the binding when it can resolve the binding path. If it resolves the element type but can't compile the path, it generates a string-based runtime binding and suppresses the `MAUIG2045` warning. An `x:Reference` name that isn't found in any XAML namescope produces a `MAUIG1001` XAML compiler error.
 
 ::: moniker-end
 

--- a/docs/fundamentals/data-binding/compiled-bindings.md
+++ b/docs/fundamentals/data-binding/compiled-bindings.md
@@ -201,6 +201,8 @@ When the ancestor type and binding path can be resolved at compile time, the sou
 
 For an `x:Reference` binding, the source generator resolves the referenced element type and compiles the binding when it can resolve the binding path. If it resolves the element type but can't compile the path, it generates a string-based runtime binding and suppresses the `MAUIG2045` warning. An `x:Reference` name that isn't found in any XAML namescope produces a `MAUIG1001` XAML compiler error.
 
+Similarly, if `AncestorType` can't be resolved, XAML compilation fails.
+
 ::: moniker-end
 
 ### Combine compiled bindings with classic bindings in XAML

--- a/docs/fundamentals/data-binding/compiled-bindings.md
+++ b/docs/fundamentals/data-binding/compiled-bindings.md
@@ -197,7 +197,7 @@ In .NET MAUI 11, when compilation of bindings that define the `Source` property 
 
 When the ancestor type and binding path can be resolved at compile time, the compiler generates a trim-safe compiled binding rather than a reflection-based binding. This makes the binding safe for full trimming and NativeAOT.
 
-Bindings use the runtime fallback when their source type can't be resolved at compile time. This includes `RelativeSource` bindings that use `Self` or `TemplatedParent`, bindings with an unresolved `AncestorType`, and `x:Reference` bindings whose referenced element type can't be resolved.
+Bindings use the runtime fallback when their source type can't be resolved at compile time. This includes `RelativeSource` bindings that use `Self` or `TemplatedParent`, and `x:Reference` bindings whose referenced element type can't be resolved.
 
 ::: moniker-end
 

--- a/docs/fundamentals/data-binding/compiled-bindings.md
+++ b/docs/fundamentals/data-binding/compiled-bindings.md
@@ -1,7 +1,7 @@
 ---
 title: "Compiled bindings"
 description: "Compiled bindings can be used to improve data binding performance in .NET MAUI applications."
-ms.date: 03/24/2026
+ms.date: 08/06/2026
 ---
 
 # Compiled bindings
@@ -181,6 +181,23 @@ Then, ensure that all your bindings are annotated with the correct `x:DataType` 
 
 > [!NOTE]
 > In cases where there's a binding with a `Source`, but it inherits the `x:DataType` from the parent, there can be a mismatch between the `x:DataType` and the type of the `Source`. In this scenario, a warning will be generated and a fallback to a reflection-based binding that resolves the binding path at runtime will occur.
+
+::: moniker-end
+
+::: moniker range=">=net-maui-11.0"
+
+### Compile relative source ancestor bindings
+
+In .NET MAUI 11, when compilation of bindings that define the `Source` property is enabled, the XAML compiler can compile a binding that uses [`RelativeSource`](xref:Microsoft.Maui.Controls.Xaml.RelativeSourceExtension) with a resolvable `AncestorType`. The compiler uses the ancestor type as the binding source type:
+
+```xaml
+<Button Command="{Binding Source={RelativeSource AncestorType={x:Type local:PeopleViewModel}},
+                          Path=DeleteEmployeeCommand}" />
+```
+
+When the ancestor type and binding path can be resolved at compile time, the compiler generates a trim-safe compiled binding rather than a reflection-based binding. This makes the binding safe for full trimming and NativeAOT.
+
+Bindings use the runtime fallback when their source type can't be resolved at compile time. This includes `RelativeSource` bindings that use `Self` or `TemplatedParent`, bindings with an unresolved `AncestorType`, and `x:Reference` bindings whose referenced element type can't be resolved.
 
 ::: moniker-end
 

--- a/docs/fundamentals/data-binding/compiled-bindings.md
+++ b/docs/fundamentals/data-binding/compiled-bindings.md
@@ -188,7 +188,7 @@ Then, ensure that all your bindings are annotated with the correct `x:DataType` 
 
 ### Compile relative source ancestor bindings
 
-In .NET MAUI 11, when compilation of bindings that define the `Source` property is enabled, the XAML source generator can compile a binding that uses [`RelativeSource`](xref:Microsoft.Maui.Controls.Xaml.RelativeSourceExtension) with a resolvable `AncestorType`. The source generator uses the ancestor type as the binding source type, so an inline `x:DataType` isn't required:
+In .NET MAUI 11, the XAML source generator can compile a binding that uses [`RelativeSource`](xref:Microsoft.Maui.Controls.Xaml.RelativeSourceExtension) with a resolvable `AncestorType`. The source generator uses the ancestor type as the binding source type, so an inline `x:DataType` isn't required:
 
 ```xaml
 <Button Command="{Binding Source={RelativeSource AncestorType={x:Type local:PeopleViewModel}},

--- a/docs/xaml/hot-reload.md
+++ b/docs/xaml/hot-reload.md
@@ -1,7 +1,7 @@
 ---
 title: "XAML Hot Reload for .NET MAUI"
 description: "Learn how to reload changes to your .NET MAUI XAML file instantly on your running app, so you don't have to rebuild your .NET MAUI project after every XAML change."
-ms.date: 03/24/2026
+ms.date: 08/06/2026
 ---
 
 # XAML Hot Reload for .NET MAUI
@@ -36,6 +36,26 @@ XAML Hot Reload is enabled by default in Visual Studio 2022. If it's been previo
 :::image type="content" source="media/hot-reload/vs-options.png" alt-text="XAML Hot Reload options for .NET MAUI in Visual Studio.":::
 
 Then, on iOS in your build settings, check that the Linker is set to "Don't Link".
+
+::: moniker range=">=net-maui-11.0"
+
+### Enable XAML Incremental Hot Reload
+
+.NET MAUI 11 Preview 7 includes a new XAML Incremental Hot Reload engine. The engine is off by default and must be explicitly enabled. To enable it only for debug builds, add the following property group to your project file:
+
+```xml
+<PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+    <EnableMauiIncrementalHotReload>true</EnableMauiIncrementalHotReload>
+</PropertyGroup>
+```
+
+XAML Incremental Hot Reload generates patches for edits to existing `x:Class`-backed XAML pages and controls, and applies them to every live instance of the affected type. Therefore, pages that have already been instantiated can be updated without being recreated or navigated to again.
+
+Supported edits include changing properties and bindings, editing resources declared in a page or control, and adding, removing, or reordering child elements. Not every XAML edit can be applied incrementally to live instances. For example, changing an `x:Name` or a root element type requires you to recreate the affected page. A change that requires C# code to be reloaded, or adding, removing, or renaming files or NuGet packages, requires you to rebuild and redeploy your app.
+
+When `EnableMauiIncrementalHotReload` is `false` or omitted, the existing XAML Hot Reload engine remains active.
+
+::: moniker-end
 
 ## Reload on multiple platforms
 

--- a/docs/xaml/hot-reload.md
+++ b/docs/xaml/hot-reload.md
@@ -1,7 +1,7 @@
 ---
 title: "XAML Hot Reload for .NET MAUI"
 description: "Learn how to reload changes to your .NET MAUI XAML file instantly on your running app, so you don't have to rebuild your .NET MAUI project after every XAML change."
-ms.date: 08/06/2026
+ms.date: 08/11/2026
 ---
 
 # XAML Hot Reload for .NET MAUI
@@ -41,19 +41,19 @@ Then, on iOS in your build settings, check that the Linker is set to "Don't Link
 
 ### Enable XAML Incremental Hot Reload
 
-.NET MAUI 11 Preview 7 includes a new XAML Incremental Hot Reload engine. The engine is off by default and must be explicitly enabled. To enable it only for debug builds, add the following property group to your project file:
+.NET MAUI 11 Preview 7 includes a new XAML Incremental Hot Reload engine. The engine is enabled by default for `Debug` builds and disabled by default for `Release` and publish builds. It generates patches for edits to existing `x:Class`-backed XAML pages and controls, and applies them to every live instance of the affected type. Therefore, pages that have already been instantiated can be updated without being recreated or navigated to again. This engine also enables XAML updates when you use `dotnet watch`.
+
+To opt out of XAML Incremental Hot Reload for debug builds, add the following property group to your project file:
 
 ```xml
 <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
-    <EnableMauiIncrementalHotReload>true</EnableMauiIncrementalHotReload>
+    <EnableMauiIncrementalHotReload>false</EnableMauiIncrementalHotReload>
 </PropertyGroup>
 ```
 
-XAML Incremental Hot Reload generates patches for edits to existing `x:Class`-backed XAML pages and controls, and applies them to every live instance of the affected type. Therefore, pages that have already been instantiated can be updated without being recreated or navigated to again.
-
 Supported edits include changing properties and bindings, editing resources declared in a page or control, and adding, removing, or reordering child elements. Not every XAML edit can be applied incrementally to live instances. For example, changing an `x:Name` or a root element type requires you to recreate the affected page. A change that requires C# code to be reloaded, or adding, removing, or renaming files or NuGet packages, requires you to rebuild and redeploy your app.
 
-When `EnableMauiIncrementalHotReload` is `false` or omitted, the existing XAML Hot Reload engine remains active.
+When `EnableMauiIncrementalHotReload` is `false`, the existing XAML Hot Reload engine remains active.
 
 ::: moniker-end
 


### PR DESCRIPTION
## Summary
- document XAML Incremental Hot Reload as enabled by default for Debug builds in .NET 11 Preview 7, with Release/publish defaults and the legacy opt-out path
- document XAML updates with `dotnet watch`
- document trim-safe SourceGen compilation for `RelativeSource AncestorType` bindings and exact runtime fallback and diagnostic behavior

## Source verification
- dotnet/maui#34338 — XAML Incremental Hot Reload implementation and `dotnet watch` update path
- dotnet/maui#37163 / `6f755e590` — Preview 7 Debug-default activation and Release/publish defaults
- dotnet/maui#34408 — `RelativeSource AncestorType` SourceGen compilation
- dotnet/maui#36905 — MAUIG2045 false-positive correction
- `Maui34056` Scenario 3 and shipped `KnownMarkups.cs` — no inline `x:DataType` requirement and exact `x:Reference` fallback behavior

## Validation
- markdownlint: 0 issues
- targeted link checks: passed
- metadata and moniker checks: passed
- factual pre-push review against shipped Preview 7 source: clean
- diff check: clean

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [docs/fundamentals/data-binding/compiled-bindings.md](https://github.com/dotnet/docs-maui/blob/494867e508d17f59da2c82a32feda62ae8ee664c/docs/fundamentals/data-binding/compiled-bindings.md) | [docs/fundamentals/data-binding/compiled-bindings](https://review.learn.microsoft.com/en-us/dotnet/maui/fundamentals/data-binding/compiled-bindings?view=net-maui-11.0&branch=pr-en-us-3454) |
| [docs/xaml/hot-reload.md](https://github.com/dotnet/docs-maui/blob/494867e508d17f59da2c82a32feda62ae8ee664c/docs/xaml/hot-reload.md) | [docs/xaml/hot-reload](https://review.learn.microsoft.com/en-us/dotnet/maui/xaml/hot-reload?view=net-maui-11.0&branch=pr-en-us-3454) |


<!-- PREVIEW-TABLE-END -->