### PR TITLE
.NET 11: document Preview 7 platform APIs

### DIFF
--- a/docs/fundamentals/app-lifecycle.md
+++ b/docs/fundamentals/app-lifecycle.md
@@ -1,7 +1,7 @@
 ---
 title: "App lifecycle"
 description: ".NET MAUI raises cross-platform lifecycle events when an app transitions between its different execution states."
-ms.date: 08/30/2024
+ms.date: 08/06/2026
 ---
 
 # App lifecycle
@@ -377,6 +377,88 @@ namespace PlatformLifecycleDemo
     }
 }
 ```
+
+::: moniker range=">=net-maui-11.0"
+
+#### Handle AppInstance activation
+
+On Windows, the `OnAppInstanceActivated` lifecycle hook receives the initial <xref:Microsoft.Windows.AppLifecycle.AppInstance> activation and subsequent file, protocol, and redirected activations. Its handler receives an <xref:Microsoft.Windows.AppLifecycle.AppActivationArguments> object and returns a `bool` that indicates whether the activation has been handled.
+
+You can use this hook to make your app single-instanced. Register an app key with <xref:Microsoft.Windows.AppLifecycle.AppInstance.FindOrRegisterForKey%2A>, and redirect activations from other instances to the registered instance:
+
+```csharp
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Maui.LifecycleEvents;
+using Microsoft.Windows.AppLifecycle;
+
+namespace PlatformLifecycleDemo;
+
+public static class MauiProgram
+{
+    public static MauiApp CreateMauiApp()
+    {
+        var builder = MauiApp.CreateBuilder();
+        builder
+            .UseMauiApp<App>()
+            .ConfigureLifecycleEvents(events =>
+            {
+#if WINDOWS
+                events.AddWindows(windows => windows
+                    .OnAppInstanceActivated(HandleAppInstanceActivated));
+#endif
+            });
+
+        return builder.Build();
+    }
+
+#if WINDOWS
+    static bool HandleAppInstanceActivated(
+        Microsoft.UI.Xaml.Application application,
+        AppActivationArguments args)
+    {
+        AppInstance keyInstance =
+            AppInstance.FindOrRegisterForKey("PlatformLifecycleDemo");
+
+        if (!keyInstance.IsCurrent)
+        {
+            _ = RedirectActivationAndExitAsync(keyInstance, args);
+            return true;
+        }
+
+        if (Application.Current?.Windows.FirstOrDefault() is Window window)
+        {
+            Application.Current.ActivateWindow(window);
+        }
+
+        return false;
+    }
+
+    static async Task RedirectActivationAndExitAsync(
+        AppInstance keyInstance,
+        AppActivationArguments args)
+    {
+        try
+        {
+            await keyInstance.RedirectActivationToAsync(args)
+                .AsTask()
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            Process.GetCurrentProcess().Kill();
+        }
+    }
+#endif
+}
+```
+
+Returning `true` from the transient instance marks the activation as handled and prevents it from creating a window. Always await <xref:Microsoft.Windows.AppLifecycle.AppInstance.RedirectActivationToAsync%2A> before terminating that process so that the running instance can consume the activation.
+
+.NET MAUI uses this activation lifecycle to support <xref:Microsoft.Maui.Authentication.WebAuthenticator> callbacks on Windows. If your app registers its own `AppInstance` key, it owns activation routing and must redirect every external activation, including protocol activations, to the instance that started the authentication operation.
+
+::: moniker-end
 
 ### Retrieve the Window object
 

--- a/docs/fundamentals/app-lifecycle.md
+++ b/docs/fundamentals/app-lifecycle.md
@@ -1,7 +1,7 @@
 ---
 title: "App lifecycle"
 description: ".NET MAUI raises cross-platform lifecycle events when an app transitions between its different execution states."
-ms.date: 08/06/2026
+ms.date: 08/11/2026
 ---
 
 # App lifecycle
@@ -384,10 +384,9 @@ namespace PlatformLifecycleDemo
 
 On Windows, the `OnAppInstanceActivated` lifecycle hook receives the initial <xref:Microsoft.Windows.AppLifecycle.AppInstance> activation and subsequent file, protocol, and redirected activations. Its handler receives an <xref:Microsoft.Windows.AppLifecycle.AppActivationArguments> object and returns a `bool` that indicates whether the activation has been handled.
 
-You can use this hook to make your app single-instanced. Register an app key with <xref:Microsoft.Windows.AppLifecycle.AppInstance.FindOrRegisterForKey%2A>, and redirect activations from other instances to the registered instance:
+You can use this hook to implement a single-instance app. Register an app key with <xref:Microsoft.Windows.AppLifecycle.AppInstance.FindOrRegisterForKey%2A>, and redirect activations from other instances to the registered instance:
 
 ```csharp
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Maui.LifecycleEvents;
@@ -423,7 +422,7 @@ public static class MauiProgram
 
         if (!keyInstance.IsCurrent)
         {
-            _ = RedirectActivationAndExitAsync(keyInstance, args);
+            _ = RedirectActivationAndExitAsync(application, keyInstance, args);
             return true;
         }
 
@@ -436,25 +435,24 @@ public static class MauiProgram
     }
 
     static async Task RedirectActivationAndExitAsync(
+        Microsoft.UI.Xaml.Application application,
         AppInstance keyInstance,
         AppActivationArguments args)
     {
         try
         {
-            await keyInstance.RedirectActivationToAsync(args)
-                .AsTask()
-                .ConfigureAwait(false);
+            await keyInstance.RedirectActivationToAsync(args).AsTask();
         }
         finally
         {
-            Process.GetCurrentProcess().Kill();
+            application.Exit();
         }
     }
 #endif
 }
 ```
 
-Returning `true` from the transient instance marks the activation as handled and prevents it from creating a window. Always await <xref:Microsoft.Windows.AppLifecycle.AppInstance.RedirectActivationToAsync%2A> before terminating that process so that the running instance can consume the activation.
+Returning `true` from the transient instance marks the activation as handled and prevents it from creating a window. Always await <xref:Microsoft.Windows.AppLifecycle.AppInstance.RedirectActivationToAsync%2A> before exiting that app instance so that the running instance can consume the activation.
 
 .NET MAUI uses this activation lifecycle to support <xref:Microsoft.Maui.Authentication.WebAuthenticator> callbacks on Windows. If your app registers its own `AppInstance` key, it owns activation routing and must redirect every external activation, including protocol activations, to the instance that started the authentication operation.
 

--- a/docs/platform-integration/device-media/picker.md
+++ b/docs/platform-integration/device-media/picker.md
@@ -194,7 +194,7 @@ foreach (var file in results)
 
 ### Save captured media to the gallery
 
-The <xref:Microsoft.Maui.Media.MediaPickerOptions.SaveToGallery> property controls whether a captured photo or video is also saved to the device's gallery. The default value is `false`, and the property only applies to <xref:Microsoft.Maui.Media.IMediaPicker.CapturePhotoAsync%2A> and <xref:Microsoft.Maui.Media.IMediaPicker.CaptureVideoAsync%2A> operations. It's ignored by media pick operations.
+The `MediaPickerOptions.SaveToGallery` property controls whether a captured photo or video is also saved to the device's gallery. The default value is `false`, and the property only applies to <xref:Microsoft.Maui.Media.IMediaPicker.CapturePhotoAsync%2A> and <xref:Microsoft.Maui.Media.IMediaPicker.CaptureVideoAsync%2A> operations. It's ignored by media pick operations.
 
 ```csharp
 FileResult? photo = await MediaPicker.Default.CapturePhotoAsync(

--- a/docs/platform-integration/device-media/picker.md
+++ b/docs/platform-integration/device-media/picker.md
@@ -1,7 +1,7 @@
 ---
 title: "Media picker for photos and videos"
 description: "Learn how to use the IMediaPicker interface in the Microsoft.Maui.Media namespace, to prompt the user to select or take a photo or video"
-ms.date: 07/08/2026
+ms.date: 08/06/2026
 no-loc: ["Microsoft.Maui", "Microsoft.Maui.Media", "MediaPicker"]
 ---
 
@@ -191,6 +191,20 @@ foreach (var file in results)
 > Media picker methods that open the camera or picker UI must be called on the UI thread because permission checks and requests are automatically handled by .NET MAUI.
 
 ::: moniker range=">=net-maui-11.0"
+
+### Save captured media to the gallery
+
+The <xref:Microsoft.Maui.Media.MediaPickerOptions.SaveToGallery> property controls whether a captured photo or video is also saved to the device's gallery. The default value is `false`, and the property only applies to <xref:Microsoft.Maui.Media.IMediaPicker.CapturePhotoAsync%2A> and <xref:Microsoft.Maui.Media.IMediaPicker.CaptureVideoAsync%2A> operations. It's ignored by media pick operations.
+
+```csharp
+FileResult? photo = await MediaPicker.Default.CapturePhotoAsync(
+    new MediaPickerOptions
+    {
+        SaveToGallery = true
+    });
+```
+
+Saving captured media to the gallery is supported on Android, iOS, and Mac Catalyst. On iOS and Mac Catalyst, the `NSPhotoLibraryAddUsageDescription` key must be present in *Info.plist*. On Android versions earlier than API 29, the `WRITE_EXTERNAL_STORAGE` permission is required. The property is ignored on Windows and Tizen.
 
 ### Recover interrupted Android media picker operations
 

--- a/docs/user-interface/controls/window.md
+++ b/docs/user-interface/controls/window.md
@@ -1,7 +1,7 @@
 ---
 title: "Window"
 description: "Learn how to use the .NET MAUI Window class to create, configure, show, and manage multi-window apps."
-ms.date: 08/19/2025
+ms.date: 08/06/2026
 ---
 
 # Window
@@ -17,6 +17,9 @@ The .NET Multi-platform App UI (.NET MAUI) <xref:Microsoft.Maui.Controls.Window>
 - <xref:Microsoft.Maui.Controls.Window.MinimumHeight>, of type `double`, represents the minimum height of the window on desktop platforms. Valid values are between 0 and `double.PositiveInfinity`.
 - <xref:Microsoft.Maui.Controls.Window.MinimumWidth>, of type `double`, represents the minimum width of the window on desktop platforms. Valid values are between 0 and `double.PositiveInfinity`.
 - <xref:Microsoft.Maui.Controls.Window.Overlays>, of type `IReadOnlyCollection<IWindowOverlay>`, represents the collection of window overlays.
+::: moniker range=">=net-maui-11.0"
+- <xref:Microsoft.Maui.Controls.Window.StatusBarTheme>, of type <xref:Microsoft.Maui.StatusBarTheme>, controls the appearance of the status bar icons on Android and iOS.
+::: moniker-end
 - <xref:Microsoft.Maui.Controls.Page>, of type <xref:Microsoft.Maui.Controls.Page>, indicates the page being displayed by the window. This property is the content property of the <xref:Microsoft.Maui.Controls.Window> class, and therefore does not need to be explicitly set.
 - <xref:Microsoft.Maui.Controls.Window.Title>, of type `string`, represents the title of the window.
 - <xref:Microsoft.Maui.Controls.Window.Width>, of type `double`, specifies the width of the window on Windows.
@@ -50,6 +53,33 @@ The <xref:Microsoft.Maui.Controls.Window> class also defines the following modal
 - <xref:Microsoft.Maui.Controls.Window.PopCanceled>, which is raised when a modal pop is cancelled.
 
 The <xref:Microsoft.Maui.Controls.VisualElement> class has a `Window` property that exposes the parent <xref:Microsoft.Maui.Controls.Window> object. This property can be accessed from any page, layout, or view, to manipulate <xref:Microsoft.Maui.Controls.Window> objects.
+
+::: moniker range=">=net-maui-11.0"
+
+## Set the status bar theme
+
+On Android and iOS, set <xref:Microsoft.Maui.Controls.Window.StatusBarTheme> to control the appearance of the operating system-drawn status bar icons independently of the app theme. The default value, <xref:Microsoft.Maui.StatusBarTheme.Default>, follows the current app theme.
+
+Choose the value that matches the surface behind the status bar:
+
+- <xref:Microsoft.Maui.StatusBarTheme.Light> indicates a light surface and displays dark icons.
+- <xref:Microsoft.Maui.StatusBarTheme.Dark> indicates a dark surface and displays light icons.
+
+For example, if the app uses a dark header behind the status bar while the rest of the app uses a light theme, set `StatusBarTheme` to `Dark`:
+
+```csharp
+protected override Window CreateWindow(IActivationState? activationState)
+{
+    return new Window(new AppShell())
+    {
+        StatusBarTheme = StatusBarTheme.Dark
+    };
+}
+```
+
+This property has no effect on Mac Catalyst, Windows, or Tizen.
+
+::: moniker-end
 
 ## Create a Window
 

--- a/docs/user-interface/controls/window.md
+++ b/docs/user-interface/controls/window.md
@@ -18,7 +18,7 @@ The .NET Multi-platform App UI (.NET MAUI) <xref:Microsoft.Maui.Controls.Window>
 - <xref:Microsoft.Maui.Controls.Window.MinimumWidth>, of type `double`, represents the minimum width of the window on desktop platforms. Valid values are between 0 and `double.PositiveInfinity`.
 - <xref:Microsoft.Maui.Controls.Window.Overlays>, of type `IReadOnlyCollection<IWindowOverlay>`, represents the collection of window overlays.
 ::: moniker range=">=net-maui-11.0"
-- <xref:Microsoft.Maui.Controls.Window.StatusBarTheme>, of type <xref:Microsoft.Maui.StatusBarTheme>, controls the appearance of the status bar icons on Android and iOS.
+- <xref:Microsoft.Maui.Controls.Window.StatusBarTheme>, of type <xref:Microsoft.Maui.StatusBarTheme>, controls the appearance of the status bar icons on Android 6.0 (API 23) or later and iOS.
 ::: moniker-end
 - <xref:Microsoft.Maui.Controls.Page>, of type <xref:Microsoft.Maui.Controls.Page>, indicates the page being displayed by the window. This property is the content property of the <xref:Microsoft.Maui.Controls.Window> class, and therefore does not need to be explicitly set.
 - <xref:Microsoft.Maui.Controls.Window.Title>, of type `string`, represents the title of the window.
@@ -58,7 +58,7 @@ The <xref:Microsoft.Maui.Controls.VisualElement> class has a `Window` property t
 
 ## Set the status bar theme
 
-On Android and iOS, set <xref:Microsoft.Maui.Controls.Window.StatusBarTheme> to control the appearance of the operating system-drawn status bar icons independently of the app theme. The default value, <xref:Microsoft.Maui.StatusBarTheme.Default>, follows the current app theme.
+On Android 6.0 (API 23) or later and iOS, set <xref:Microsoft.Maui.Controls.Window.StatusBarTheme> to control the appearance of the operating system-drawn status bar icons independently of the app theme. The default value, <xref:Microsoft.Maui.StatusBarTheme.Default>, follows the current app theme.
 
 Choose the value that matches the surface behind the status bar:
 
@@ -77,7 +77,7 @@ protected override Window CreateWindow(IActivationState? activationState)
 }
 ```
 
-This property has no effect on Mac Catalyst, Windows, or Tizen.
+This property has no effect on Android versions earlier than API 23, Mac Catalyst, Windows, or Tizen.
 
 ::: moniker-end
 

--- a/docs/user-interface/controls/window.md
+++ b/docs/user-interface/controls/window.md
@@ -18,7 +18,7 @@ The .NET Multi-platform App UI (.NET MAUI) <xref:Microsoft.Maui.Controls.Window>
 - <xref:Microsoft.Maui.Controls.Window.MinimumWidth>, of type `double`, represents the minimum width of the window on desktop platforms. Valid values are between 0 and `double.PositiveInfinity`.
 - <xref:Microsoft.Maui.Controls.Window.Overlays>, of type `IReadOnlyCollection<IWindowOverlay>`, represents the collection of window overlays.
 ::: moniker range=">=net-maui-11.0"
-- <xref:Microsoft.Maui.Controls.Window.StatusBarTheme>, of type <xref:Microsoft.Maui.StatusBarTheme>, controls the appearance of the status bar icons on Android 6.0 (API 23) or later and iOS.
+- `Window.StatusBarTheme`, of type `StatusBarTheme`, controls the appearance of the status bar icons on Android 6.0 (API 23) or later and iOS.
 ::: moniker-end
 - <xref:Microsoft.Maui.Controls.Page>, of type <xref:Microsoft.Maui.Controls.Page>, indicates the page being displayed by the window. This property is the content property of the <xref:Microsoft.Maui.Controls.Window> class, and therefore does not need to be explicitly set.
 - <xref:Microsoft.Maui.Controls.Window.Title>, of type `string`, represents the title of the window.
@@ -58,12 +58,12 @@ The <xref:Microsoft.Maui.Controls.VisualElement> class has a `Window` property t
 
 ## Set the status bar theme
 
-On Android 6.0 (API 23) or later and iOS, set <xref:Microsoft.Maui.Controls.Window.StatusBarTheme> to control the appearance of the operating system-drawn status bar icons independently of the app theme. The default value, <xref:Microsoft.Maui.StatusBarTheme.Default>, follows the current app theme.
+On Android 6.0 (API 23) or later and iOS, set `Window.StatusBarTheme` to control the appearance of the operating system-drawn status bar icons independently of the app theme. The default value, `StatusBarTheme.Default`, follows the current app theme.
 
 Choose the value that matches the surface behind the status bar:
 
-- <xref:Microsoft.Maui.StatusBarTheme.Light> indicates a light surface and displays dark icons.
-- <xref:Microsoft.Maui.StatusBarTheme.Dark> indicates a dark surface and displays light icons.
+- `StatusBarTheme.Light` indicates a light surface and displays dark icons.
+- `StatusBarTheme.Dark` indicates a dark surface and displays light icons.
 
 For example, if the app uses a dark header behind the status bar while the rest of the app uses a light theme, set `StatusBarTheme` to `Dark`:
 


### PR DESCRIPTION
## Summary
- document saving captured photos and videos to the gallery
- document Window.StatusBarTheme on Android 6.0+ and iOS
- document Windows AppInstance lifecycle activation and single-instance routing

## Validation
- markdownlint: 0 issues
- factual review against dotnet/maui #34641, #34903, and #36640: clean
- diff check: clean

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [docs/fundamentals/app-lifecycle.md](https://github.com/dotnet/docs-maui/blob/9415d5ae3e705e4335799532b51abd8be932e1c3/docs/fundamentals/app-lifecycle.md) | [docs/fundamentals/app-lifecycle](https://review.learn.microsoft.com/en-us/dotnet/maui/fundamentals/app-lifecycle?view=net-maui-11.0&branch=pr-en-us-3455) |
| [docs/platform-integration/device-media/picker.md](https://github.com/dotnet/docs-maui/blob/9415d5ae3e705e4335799532b51abd8be932e1c3/docs/platform-integration/device-media/picker.md) | [docs/platform-integration/device-media/picker](https://review.learn.microsoft.com/en-us/dotnet/maui/platform-integration/device-media/picker?view=net-maui-11.0&branch=pr-en-us-3455) |
| [docs/user-interface/controls/window.md](https://github.com/dotnet/docs-maui/blob/9415d5ae3e705e4335799532b51abd8be932e1c3/docs/user-interface/controls/window.md) | [docs/user-interface/controls/window](https://review.learn.microsoft.com/en-us/dotnet/maui/user-interface/controls/window?view=net-maui-11.0&branch=pr-en-us-3455) |


<!-- PREVIEW-TABLE-END -->