### PR TITLE
Update RefreshView documentation to integrate .NET 10 changes

### DIFF
--- a/docs/user-interface/controls/refreshview.md
+++ b/docs/user-interface/controls/refreshview.md
@@ -1,7 +1,7 @@
 ---
 title: "RefreshView"
 description: "The .NET MAUI RefreshView is a container control that provides pull to refresh functionality for scrollable content."
-ms.date: 08/30/2024
+ms.date: 08/14/2026
 no-loc: [RefreshView]
 ---
 
@@ -13,10 +13,24 @@ The .NET Multi-platform App UI (.NET MAUI) <xref:Microsoft.Maui.Controls.Refresh
 
 <xref:Microsoft.Maui.Controls.RefreshView> defines the following properties:
 
+::: moniker range="<=net-maui-9.0"
+
 - `Command`, of type <xref:System.Windows.Input.ICommand>, which is executed when a refresh is triggered.
 - `CommandParameter`, of type `object`, which is the parameter that's passed to the `Command`.
 - `IsRefreshing`, of type `bool`, which indicates the current state of the <xref:Microsoft.Maui.Controls.RefreshView>.
 - `RefreshColor`, of type <xref:Microsoft.Maui.Graphics.Color>, the color of the progress circle that appears during the refresh.
+
+::: moniker-end
+
+::: moniker range=">=net-maui-10.0"
+
+- `Command`, of type <xref:System.Windows.Input.ICommand>, which is executed when a refresh is triggered.
+- `CommandParameter`, of type `object`, which is the parameter that's passed to the `Command`.
+- `IsRefreshEnabled`, of type `bool`, which indicates whether pull to refresh is enabled.
+- `IsRefreshing`, of type `bool`, which indicates the current state of the <xref:Microsoft.Maui.Controls.RefreshView>.
+- `RefreshColor`, of type <xref:Microsoft.Maui.Graphics.Color>, the color of the progress circle that appears during the refresh.
+
+::: moniker-end
 
 These properties are backed by <xref:Microsoft.Maui.Controls.BindableProperty> objects, which means that they can be targets of data bindings, and styled.
 
@@ -99,6 +113,70 @@ In addition, the `BackgroundColor` property can be set to a <xref:Microsoft.Maui
 
 ## Disable a RefreshView
 
-An app may enter a state where pull to refresh is not a valid operation. In such cases, the <xref:Microsoft.Maui.Controls.RefreshView> can be disabled by setting its `IsEnabled` property to `false`. This will prevent users from being able to trigger pull to refresh.
+An app may enter a state where pull to refresh is not a valid operation. Choose the option that matches the behavior you want.
 
-Alternatively, when defining the `Command` property, the `CanExecute` delegate of the <xref:System.Windows.Input.ICommand> can be specified to enable or disable the command.
+::: moniker range=">=net-maui-10.0"
+
+### Use `IsRefreshEnabled` to disable only pull to refresh
+
+`IsRefreshEnabled` disables the pull to refresh gesture while keeping child content interactive:
+
+```xaml
+<RefreshView IsRefreshEnabled="{Binding CanRefresh}"
+             Command="{Binding RefreshCommand}">
+    <!-- Login form remains usable -->
+    <ScrollView>
+        <StackLayout>
+            <Entry Placeholder="Username" />
+            <Entry Placeholder="Password" IsPassword="true" />
+            <Button Text="Login" />
+        </StackLayout>
+    </ScrollView>
+</RefreshView>
+```
+
+::: moniker-end
+
+### Use `IsEnabled` to disable the entire control
+
+`IsEnabled` disables the <xref:Microsoft.Maui.Controls.RefreshView> and all child content:
+
+```xaml
+<RefreshView IsEnabled="false"
+             Command="{Binding RefreshCommand}">
+    <!-- Login form will be unusable when IsEnabled is false -->
+    <ScrollView>
+        <StackLayout>
+            <Entry Placeholder="Username" />
+            <Entry Placeholder="Password" IsPassword="true" />
+            <Button Text="Login" />
+        </StackLayout>
+    </ScrollView>
+</RefreshView>
+```
+
+### Use `Command.CanExecute` to control command execution and pull to refresh
+
+When defining the `Command` property, the `CanExecute` delegate of the <xref:System.Windows.Input.ICommand> can enable or disable command execution:
+
+::: moniker range=">=net-maui-10.0"
+In .NET 10 and later, `Command.CanExecute` also contributes to the effective `IsRefreshEnabled` value. Therefore, when `CanExecute` returns `false`, the pull to refresh gesture is disabled (even if `IsRefreshEnabled` is `true`).
+::: moniker-end
+
+```csharp
+bool canRefresh = true;
+
+RefreshView refreshView = new RefreshView();
+Command refreshCommand = new Command(
+    execute: () =>
+    {
+        // Refresh data here.
+    },
+    canExecute: () => canRefresh);
+
+refreshView.Command = refreshCommand;
+
+// Later, disable refresh command execution.
+canRefresh = false;
+refreshCommand.ChangeCanExecute();
+```

--- a/docs/whats-new/dotnet-10.md
+++ b/docs/whats-new/dotnet-10.md
@@ -1,7 +1,7 @@
 ---
 title: What's new in .NET MAUI for .NET 10
 description: Learn about the new features introduced in .NET MAUI for .NET 10.
-ms.date: 11/11/2025
+ms.date: 08/14/2026
 ---
 
 # What's new in .NET MAUI for .NET 10
@@ -160,11 +160,13 @@ Added `IsRefreshEnabled` property to be distinct from `IsEnabled` and make the b
 ```xml
 <RefreshView IsRefreshEnabled="false">
     <!-- Login form remains usable -->
-    <StackLayout>
-        <Entry Placeholder="Username" />
-        <Entry Placeholder="Password" />
-        <Button Text="Login" />
-    </StackLayout>
+    <ScrollView>
+        <StackLayout>
+            <Entry Placeholder="Username" />
+            <Entry Placeholder="Password" IsPassword="true" />
+            <Button Text="Login" />
+        </StackLayout>
+    </ScrollView>
 </RefreshView>
 ```
 


### PR DESCRIPTION
According to [.NET 10 changelogs](https://learn.microsoft.com/en-us/dotnet/maui/whats-new/dotnet-10?view=net-maui-10.0#refreshview), RefreshView now have a `IsRefreshEnabled` which is super useful while using the component.

Unfortunately, this feature is not available on the real documentation of the component.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [docs/user-interface/controls/refreshview.md](https://github.com/dotnet/docs-maui/blob/d60f6be3aaf7a1c5da952673eccf76c2fa72a1e5/docs/user-interface/controls/refreshview.md) | [docs/user-interface/controls/refreshview](https://review.learn.microsoft.com/en-us/dotnet/maui/user-interface/controls/refreshview?view=net-maui-11.0&branch=pr-en-us-3472) |
| [docs/whats-new/dotnet-10.md](https://github.com/dotnet/docs-maui/blob/d60f6be3aaf7a1c5da952673eccf76c2fa72a1e5/docs/whats-new/dotnet-10.md) | [docs/whats-new/dotnet-10](https://review.learn.microsoft.com/en-us/dotnet/maui/whats-new/dotnet-10?view=net-maui-11.0&branch=pr-en-us-3472) |


<!-- PREVIEW-TABLE-END -->