### PR TITLE
.NET 11 RC 1: document control and handler updates

### DIFF
--- a/docs/migration/custom-renderers.md
+++ b/docs/migration/custom-renderers.md
@@ -1,7 +1,7 @@
 ---
 title: "Reuse custom renderers in .NET MAUI"
 description: "Learn how to adapt Xamarin.Forms custom renderers to work in a .NET MAUI app."
-ms.date: 08/11/2026
+ms.date: 09/02/2026
 ---
 
 # Reuse custom renderers in .NET MAUI
@@ -89,7 +89,7 @@ public static class MauiProgram
 The renderers are registered with the <xref:Microsoft.Maui.Hosting.HandlerMauiAppBuilderExtensions.ConfigureMauiHandlers%2A> and <xref:Microsoft.Maui.Hosting.MauiHandlersCollectionExtensions.AddHandler%2A> method. This first argument to the <xref:Microsoft.Maui.Hosting.MauiHandlersCollectionExtensions.AddHandler%2A> method is the cross-platform control type, with the second argument being its renderer type.
 
 > [!IMPORTANT]
-> Only renderers that derive from `FrameRenderer`, `ListViewRenderer`, `NavigationRenderer` on iOS, `ShellRenderer` on iOS and Android, `TabbedRenderer` on iOS, `TableViewRenderer`, and `VisualElementRenderer` can be registered with the <xref:Microsoft.Maui.Hosting.MauiHandlersCollectionExtensions.AddHandler%2A> method.
+> Only renderers that derive from `FrameRenderer`, `ListViewRenderer`, `NavigationRenderer` on iOS, `PhoneFlyoutPageRenderer` on iOS and Mac Catalyst, `ShellRenderer` on iOS and Android, `TabbedRenderer` on iOS, `TableViewRenderer`, and `VisualElementRenderer` can be registered with the <xref:Microsoft.Maui.Hosting.MauiHandlersCollectionExtensions.AddHandler%2A> method.
 
 ::: moniker range=">=net-maui-11.0"
 
@@ -116,6 +116,23 @@ builder.ConfigureMauiHandlers(handlers =>
 #endif
 });
 ```
+
+### Migrate iOS FlyoutPage renderers
+
+Starting in .NET MAUI 11, <xref:Microsoft.Maui.Controls.FlyoutPage> uses <xref:Microsoft.Maui.Handlers.FlyoutViewHandler> by default on iOS and Mac Catalyst, instead of the `PhoneFlyoutPageRenderer` compatibility renderer. Apps with a custom `PhoneFlyoutPageRenderer` subclass should migrate those customizations to the handler's property mapper. For more information, see [Customize controls with handlers](~/user-interface/handlers/customize.md).
+
+If you need the compatibility renderer while migrating, register it explicitly with <xref:Microsoft.Maui.Hosting.HandlerMauiAppBuilderExtensions.ConfigureMauiHandlers%2A>:
+
+```csharp
+builder.ConfigureMauiHandlers(handlers =>
+{
+#if IOS || MACCATALYST
+    handlers.AddHandler<FlyoutPage, Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer>();
+#endif
+});
+```
+
+If you've derived a custom renderer from `PhoneFlyoutPageRenderer`, register your own type instead. For more information, see [FlyoutPage on iOS and Mac Catalyst](~/user-interface/pages/flyoutpage.md#flyoutpage-on-ios-and-mac-catalyst).
 
 ### Migrate iOS TabbedPage renderers
 

--- a/docs/user-interface/controls/swipeview.md
+++ b/docs/user-interface/controls/swipeview.md
@@ -1,7 +1,7 @@
 ---
 title: "SwipeView"
 description: "The .NET MAUI SwipeView is a container control that wraps around an item of content, and provides context menu items that are revealed by a swipe gesture."
-ms.date: 08/30/2024
+ms.date: 09/02/2026
 ---
 
 # SwipeView
@@ -172,6 +172,39 @@ When a `SwipeItem` is tapped, its `Invoked` event fires and is handled by its re
 
 > [!NOTE]
 > When the appearance of a `SwipeItem` is defined only using the `Text` or `IconImageSource` properties, the content is always centered.
+
+::: moniker range=">=net-maui-11.0"
+
+### Set SwipeItem icon and text colors
+
+In .NET 11, `SwipeItem` defines two bindable color properties:
+
+- `IconColor`, of type <xref:Microsoft.Maui.Graphics.Color>, sets an explicit tint for the icon.
+- `TextColor`, of type <xref:Microsoft.Maui.Graphics.Color>, sets the label text color.
+
+Both properties support `AppThemeBinding`. The following example changes the icon, text, and background colors when the app theme changes:
+
+```xaml
+<SwipeItem Text="Delete"
+           IconImageSource="delete.svg"
+           BackgroundColor="{AppThemeBinding Light=White, Dark=Black}"
+           IconColor="{AppThemeBinding Light=Black, Dark=White}"
+           TextColor="{AppThemeBinding Light=Black, Dark=White}" />
+```
+
+In .NET 11, a non-font icon keeps its authored colors when `IconColor` isn't set. This behavior differs from .NET 10, where .NET MAUI automatically changed non-font icons to white or black to contrast with `BackgroundColor`. Set `IconColor` when your app requires an explicit tint.
+
+When `IconColor` isn't set, a font icon first uses its <xref:Microsoft.Maui.Controls.FontImageSource.Color> value. If that value isn't set, it uses `TextColor`, and then a color that contrasts with `BackgroundColor`.
+
+When `TextColor` isn't set, the label uses a color that contrasts with `BackgroundColor`. The label keeps the platform default color when there is no background color, or when a font icon defines its own color.
+
+Icon color behavior varies by platform:
+
+- **Android, iOS, and Mac Catalyst** apply `IconColor` to font icons and resolved image icons.
+- **Windows** applies `IconColor` only to font icons and packaged-file icons. Packaged-file icons use the color as a monochrome mask. URI, rooted, and stream image sources keep their authored colors.
+- **Tizen** icons keep their authored colors, even when `IconColor` is set.
+
+::: moniker-end
 
 In addition to defining swipe items as `SwipeItem` objects, it's also possible to define custom swipe item views. For more information, see [Custom swipe items](#custom-swipe-items).
 

--- a/docs/user-interface/handlers/index.md
+++ b/docs/user-interface/handlers/index.md
@@ -1,7 +1,7 @@
 ---
 title: ".NET MAUI handlers"
 description: "Learn about .NET MAUI handlers, which map cross-platform controls to performant native controls on each platform."
-ms.date: 07/08/2026
+ms.date: 09/02/2026
 ---
 
 # Handlers
@@ -114,7 +114,7 @@ The following table lists the types that implement pages in .NET MAUI:
 | Page | Android Handler | iOS/Mac Catalyst Handler | Windows Handler | Property Mapper | Command Mapper |
 | -- | -- | -- | -- | -- | -- |
 | <xref:Microsoft.Maui.Controls.ContentPage> | <xref:Microsoft.Maui.Handlers.PageHandler> | <xref:Microsoft.Maui.Handlers.PageHandler> | <xref:Microsoft.Maui.Handlers.PageHandler> | <xref:Microsoft.Maui.Handlers.PageHandler.Mapper> | <xref:Microsoft.Maui.Handlers.PageHandler.CommandMapper> |
-| <xref:Microsoft.Maui.Controls.FlyoutPage> | <xref:Microsoft.Maui.Handlers.FlyoutViewHandler> | PhoneFlyoutPageRenderer | <xref:Microsoft.Maui.Handlers.FlyoutViewHandler> | `Mapper` | <xref:Microsoft.Maui.CommandMapper> |
+| <xref:Microsoft.Maui.Controls.FlyoutPage> | <xref:Microsoft.Maui.Handlers.FlyoutViewHandler> | <xref:Microsoft.Maui.Handlers.FlyoutViewHandler> | <xref:Microsoft.Maui.Handlers.FlyoutViewHandler> | `Mapper` | <xref:Microsoft.Maui.CommandMapper> |
 | <xref:Microsoft.Maui.Controls.NavigationPage> | <xref:Microsoft.Maui.Handlers.NavigationViewHandler> | <xref:Microsoft.Maui.Handlers.NavigationViewHandler> | <xref:Microsoft.Maui.Handlers.NavigationViewHandler> | `Mapper` | <xref:Microsoft.Maui.CommandMapper> |
 | <xref:Microsoft.Maui.Controls.TabbedPage> | <xref:Microsoft.Maui.Handlers.TabbedViewHandler> | <xref:Microsoft.Maui.Handlers.TabbedViewHandler> | <xref:Microsoft.Maui.Handlers.TabbedViewHandler> | `Mapper` | <xref:Microsoft.Maui.CommandMapper> |
 | <xref:Microsoft.Maui.Controls.Shell> | `ShellHandler` | ShellRenderer | `ShellHandler` | `Mapper` | <xref:Microsoft.Maui.CommandMapper> |

--- a/docs/user-interface/pages/flyoutpage.md
+++ b/docs/user-interface/pages/flyoutpage.md
@@ -1,7 +1,7 @@
 ---
 title: "FlyoutPage"
 description: "The .NET MAUI FlyoutPage is a page that manages two related pages of information – a flyout page that presents items, and a detail page that presents details about items on the flyout page."
-ms.date: 09/30/2024
+ms.date: 09/02/2026
 ---
 
 # FlyoutPage
@@ -33,6 +33,30 @@ The `IsGestureEnabled`, `IsPresented`, and `FlyoutLayoutBehavior` properties are
 
 > [!WARNING]
 > <xref:Microsoft.Maui.Controls.FlyoutPage> is incompatible with .NET MAUI Shell apps, and an exception will be thrown if you attempt to use <xref:Microsoft.Maui.Controls.FlyoutPage> in a Shell app. For more information about Shell apps, see [Shell](~/fundamentals/shell/index.md).
+
+::: moniker range=">=net-maui-11.0"
+
+## FlyoutPage on iOS and Mac Catalyst
+
+Starting in .NET 11, <xref:Microsoft.Maui.Controls.FlyoutPage> uses <xref:Microsoft.Maui.Handlers.FlyoutViewHandler> by default on iOS and Mac Catalyst. In earlier releases, it used the `Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer` compatibility renderer.
+
+If your app has a custom renderer that derives from `PhoneFlyoutPageRenderer`, register your renderer explicitly with <xref:Microsoft.Maui.Hosting.HandlerMauiAppBuilderExtensions.ConfigureMauiHandlers%2A>:
+
+```csharp
+builder.ConfigureMauiHandlers(handlers =>
+{
+#if IOS || MACCATALYST
+    handlers.AddHandler<FlyoutPage, MyPhoneFlyoutPageRenderer>();
+#endif
+});
+```
+
+To use the built-in compatibility renderer during migration, replace `MyPhoneFlyoutPageRenderer` with `Microsoft.Maui.Controls.Handlers.Compatibility.PhoneFlyoutPageRenderer`.
+
+> [!IMPORTANT]
+> Compatibility renderer registration is a temporary migration step. Migrate custom renderers to the handler architecture. For more information, see [Migrate iOS FlyoutPage renderers](~/migration/custom-renderers.md#migrate-ios-flyoutpage-renderers).
+
+::: moniker-end
 
 ## Create a FlyoutPage
 

--- a/docs/user-interface/pages/tabbedpage.md
+++ b/docs/user-interface/pages/tabbedpage.md
@@ -1,7 +1,7 @@
 ---
 title: "TabbedPage"
 description: "The .NET MAUI TabbedPage consists of a series of pages that are navigable by tabs across the top or bottom of the page, with each tab loading the page content."
-ms.date: 08/11/2026
+ms.date: 09/02/2026
 ---
 
 # TabbedPage
@@ -110,6 +110,56 @@ The following example shows generating <xref:Microsoft.Maui.Controls.TabbedPage>
 In this example, each tab consists of a <xref:Microsoft.Maui.Controls.ContentPage> object that uses <xref:Microsoft.Maui.Controls.Image> and <xref:Microsoft.Maui.Controls.Label> objects to display data for the tab:
 
 :::image type="content" source="media/tabbedpage/tabbedpage.png" alt-text="Screenshot of a .NET MAUI TabbedPage.":::
+
+::: moniker range=">=net-maui-11.0"
+
+## Display badges on tabs
+
+In .NET 11, a badge can be displayed on each child page of a <xref:Microsoft.Maui.Controls.TabbedPage>. Set the following attached properties on the child page:
+
+- `TabbedPage.BadgeText`, of type `string`, is the text displayed on the badge. Set it to a non-empty value to show text, an empty string to show a dot, or `null` to hide the badge. The default value is `null`.
+- `TabbedPage.BadgeColor`, of type <xref:Microsoft.Maui.Graphics.Color>, is the background color of the badge. When this property is `null`, the platform default color is used.
+- `TabbedPage.BadgeTextColor`, of type <xref:Microsoft.Maui.Graphics.Color>, is the text color of the badge. When this property is `null`, the platform default color is used.
+
+The following example displays a badge on the **Inbox** tab:
+
+```xaml
+<TabbedPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+            xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+            x:Class="TabbedPageDemo.MainPage">
+    <ContentPage x:Name="inboxPage"
+                 Title="Inbox"
+                 IconImageSource="inbox.png"
+                 TabbedPage.BadgeText="3"
+                 TabbedPage.BadgeColor="Red"
+                 TabbedPage.BadgeTextColor="White" />
+    <ContentPage Title="Sent"
+                 IconImageSource="sent.png" />
+</TabbedPage>
+```
+
+These properties are backed by <xref:Microsoft.Maui.Controls.BindableProperty> objects. Therefore, they can be data-bound and updated at runtime. You can also update them with the `SetBadgeText`, `SetBadgeColor`, and `SetBadgeTextColor` methods:
+
+```csharp
+TabbedPage.SetBadgeText(inboxPage, "4");
+TabbedPage.SetBadgeColor(inboxPage, Colors.Orange);
+TabbedPage.SetBadgeTextColor(inboxPage, Colors.Black);
+```
+
+Set the badge text to `null` to remove the badge:
+
+```csharp
+TabbedPage.SetBadgeText(inboxPage, null);
+```
+
+Badge rendering varies by platform:
+
+- **Android** uses the Material Design badge APIs for top and bottom tabs. Numeric and text badges are supported. When bottom tabs use the **More** overflow item, badges aren't displayed on the **More** item or on pages in the overflow list.
+- **iOS and Mac Catalyst** use `UITabBarItem.BadgeValue`, `BadgeColor`, and `SetBadgeTextAttributes`. On iOS 18 and Mac Catalyst 18 or later, the system tab bar can retain custom badge colors but display the system red background and white text instead.
+- **Windows** uses the WinUI `InfoBadge` control. Numeric badge text displays as a count. Non-numeric text and an empty string display as a dot. When badge colors aren't set, the native theme defaults are used.
+- **Tizen** exposes the attached properties, but doesn't display badges.
+
+::: moniker-end
 
 ## Navigate within a tab
 

--- a/docs/user-interface/pages/tabbedpage.md
+++ b/docs/user-interface/pages/tabbedpage.md
@@ -154,9 +154,7 @@ TabbedPage.SetBadgeText(inboxPage, null);
 
 Badge rendering varies by platform:
 
-- **Android** uses the Material Design badge APIs for top and bottom tabs. Numeric and text badges are supported. When bottom tabs use the **More** overflow item, badges aren't displayed on the **More** item or on pages in the overflow list.
-- **iOS and Mac Catalyst** use `UITabBarItem.BadgeValue`, `BadgeColor`, and `SetBadgeTextAttributes`. On iOS 18 and Mac Catalyst 18 or later, the system tab bar can retain custom badge colors but display the system red background and white text instead.
-- **Windows** uses the WinUI `InfoBadge` control. Numeric badge text displays as a count. Non-numeric text and an empty string display as a dot. When badge colors aren't set, the native theme defaults are used.
+- **iOS and Mac Catalyst** use `UITabBarItem.BadgeValue`, `BadgeColor`, and `SetBadgeTextAttributes`. On iOS 18 and Mac Catalyst 18 or later, the system tab bar may ignore custom badge colors and instead display the system red background and white text.
 - **Tizen** exposes the attached properties, but doesn't display badges.
 
 ::: moniker-end


### PR DESCRIPTION
## Summary

- Document `TabbedPage` badges, runtime updates, and platform behavior.
- Document `SwipeItem.IconColor` and `SwipeItem.TextColor`, including the .NET 11 icon-color behavior change and platform limits.
- Document the iOS and Mac Catalyst `FlyoutViewHandler` default and compatibility renderer migration path.
- Correct the .NET 11 `FlyoutPage` handler table entry.

## Migration guidance

Apps with custom `PhoneFlyoutPageRenderer` subclasses must register the compatibility renderer explicitly while they migrate to `FlyoutViewHandler`. Existing content for .NET 10 and earlier is unchanged.

This PR does not change the Shell badge files in dotnet/docs-maui#3359. It is independent of the other RC 1 documentation work.

## Validation

- Targeted `markdownlint-cli2`: 0 issues in 5 files.
- `git diff --check`: passed.
- Factual review against the merged MAUI implementation PRs and the current `net11.0` API: no findings.

## Sources

- dotnet/maui#37755: https://github.com/dotnet/maui/pull/37755
- dotnet/maui#36884: https://github.com/dotnet/maui/pull/36884
- dotnet/maui#36676: https://github.com/dotnet/maui/pull/36676
- .NET 11 RC 1 release tracking: https://github.com/dotnet/core/pull/10552

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [docs/migration/custom-renderers.md](https://github.com/dotnet/docs-maui/blob/a163c58aaf42b6144b9c66b6b10d91277c8a1036/docs/migration/custom-renderers.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/maui/migration/custom-renderers?view=net-maui-11.0&branch=pr-en-us-3501) |
| [docs/user-interface/controls/swipeview.md](https://github.com/dotnet/docs-maui/blob/a163c58aaf42b6144b9c66b6b10d91277c8a1036/docs/user-interface/controls/swipeview.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/maui/user-interface/controls/swipeview?view=net-maui-11.0&branch=pr-en-us-3501) |
| [docs/user-interface/handlers/index.md](https://github.com/dotnet/docs-maui/blob/a163c58aaf42b6144b9c66b6b10d91277c8a1036/docs/user-interface/handlers/index.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/maui/user-interface/handlers/index?view=net-maui-11.0&branch=pr-en-us-3501) |
| [docs/user-interface/pages/flyoutpage.md](https://github.com/dotnet/docs-maui/blob/a163c58aaf42b6144b9c66b6b10d91277c8a1036/docs/user-interface/pages/flyoutpage.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/maui/user-interface/pages/flyoutpage?view=net-maui-11.0&branch=pr-en-us-3501) |
| [docs/user-interface/pages/tabbedpage.md](https://github.com/dotnet/docs-maui/blob/a163c58aaf42b6144b9c66b6b10d91277c8a1036/docs/user-interface/pages/tabbedpage.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/maui/user-interface/pages/tabbedpage?view=net-maui-11.0&branch=pr-en-us-3501) |


<!-- PREVIEW-TABLE-END -->

[Build report](https://buildapi.docs.microsoft.com/Output/PullRequest/a552e5fb-82af-ee54-cd17-c63b0b54d6f7/202609091404418523-3501/BuildReport?accessString=fcaf737da4ebc3ae49414872bbd68c669a14421f2ddf37a37c061a7bd919779f)