### PR TITLE
.NET 11 RC 1: document platform and asset features

### DIFF
--- a/docs/user-interface/controls/window.md
+++ b/docs/user-interface/controls/window.md
@@ -1,7 +1,7 @@
 ---
 title: "Window"
 description: "Learn how to use the .NET MAUI Window class to create, configure, show, and manage multi-window apps."
-ms.date: 08/06/2026
+ms.date: 09/02/2026
 ---
 
 # Window
@@ -78,6 +78,24 @@ protected override Window CreateWindow(IActivationState? activationState)
 ```
 
 This property has no effect on Android versions earlier than API 23, Mac Catalyst, Windows, or Tizen.
+
+::: moniker-end
+
+::: moniker range=">=net-maui-11.0"
+
+## Match Android system bar backgrounds to app chrome
+
+Set the `MauiAndroidSystemBarsUseMauiChrome` MSBuild property to opt in to matching Android system bar backgrounds to .NET MAUI app chrome:
+
+```xml
+<PropertyGroup>
+  <MauiAndroidSystemBarsUseMauiChrome>true</MauiAndroidSystemBarsUseMauiChrome>
+</PropertyGroup>
+```
+
+The default value is `false`. When the property is `true`, .NET MAUI matches the Android status bar and navigation bar background colors to the effective chrome colors for <xref:Microsoft.Maui.Controls.NavigationPage>, <xref:Microsoft.Maui.Controls.Shell>, <xref:Microsoft.Maui.Controls.TabbedPage>, and modal windows. When the property is omitted or set to `false`, the Android theme and platform continue to control the system bar backgrounds.
+
+This property changes background colors only and doesn't select the system bar icon appearance. Modal windows inherit the current system bar icon appearance from the main window. To select the status bar icon appearance, use `Window.StatusBarTheme`. For more information, see [Set the status bar theme](#set-the-status-bar-theme).
 
 ::: moniker-end
 

--- a/docs/user-interface/images/images.md
+++ b/docs/user-interface/images/images.md
@@ -1,7 +1,7 @@
 ---
 title: "Add images to a .NET MAUI app project"
 description: "Learn how to add images to your .NET MAUI app, and control their resizing."
-ms.date: 12/03/2024
+ms.date: 09/02/2026
 ---
 
 # Add images to a .NET MAUI app project
@@ -64,6 +64,33 @@ To stop vector images being resized, set the `Resize` attribute to `false`:
 ```xml
 <MauiImage Include="Resources\Images\logo.svg" Resize="false" />
 ```
+
+::: moniker range=">=net-maui-11.0"
+
+## Set resize quality
+
+Use the `ResizeQuality` metadata to select the resampling quality that Resizetizer uses when it scales an image. This metadata works with `MauiImage`, `MauiIcon`, and `MauiSplashScreen` items, and with bitmap and SVG source files. It also applies to adaptive and monochrome icon layers and dark splash screen variants.
+
+`ResizeQuality` supports the following values:
+
+- `Auto` is the default. It preserves the existing output and uses bilinear interpolation with mipmaps.
+- `Best` uses the Mitchell cubic resampler for raster images and downscaling. When it upscales an SVG image, Resizetizer renders the vector directly.
+- `Fastest` uses nearest-neighbor sampling without mipmaps. This option can decrease build time and can preserve pixel art, but scaled images can appear pixelated.
+
+The following example uses high-quality resizing for a photo and nearest-neighbor resizing for pixel art:
+
+```xml
+<ItemGroup>
+  <MauiImage Include="Resources\Images\photo.png"
+             BaseSize="800,600"
+             ResizeQuality="Best" />
+  <MauiImage Include="Resources\Images\pixelart.png"
+             BaseSize="128,128"
+             ResizeQuality="Fastest" />
+</ItemGroup>
+```
+
+::: moniker-end
 
 ## Add tint and background color
 

--- a/docs/user-interface/images/splashscreen.md
+++ b/docs/user-interface/images/splashscreen.md
@@ -1,7 +1,7 @@
 ---
 title: "Add a splash screen to a .NET MAUI app project"
 description: "A .NET MAUI splash screen can be displayed on Android and iOS when an app is launched, while the app's initialization process completes."
-ms.date: 08/30/2024
+ms.date: 09/02/2026
 ---
 
 # Add a splash screen to a .NET MAUI app project
@@ -88,6 +88,38 @@ A background color for your splash screen can also be specified:
 
 <!-- Valid color values are actually derived from the SKColor struct, rather than Microsoft.Maui.Graphics.Colors. This may change. -->
 Color values can be specified in hexadecimal, or as a .NET MAUI color. For example, `Color="Red"` is valid.
+
+::: moniker range=">=net-maui-11.0"
+
+## Add a dark theme splash screen
+
+Use the `DarkFile`, `DarkColor`, and `DarkTintColor` metadata on a `MauiSplashScreen` item to define a splash screen for dark mode:
+
+```xml
+<ItemGroup>
+  <MauiSplashScreen Include="Resources\Splash\splash.svg"
+                    Color="#FFFFFF"
+                    DarkFile="Resources\Splash\splash-dark.svg"
+                    DarkColor="#000000"
+                    DarkTintColor="#FFFFFF"
+                    BaseSize="128,128" />
+</ItemGroup>
+```
+
+The metadata has the following effects:
+
+- `DarkFile` specifies the image for dark mode. If you omit it, .NET MAUI uses the light-mode image.
+- `DarkColor` specifies the background color for dark mode. If you omit it, .NET MAUI uses the value of `Color`.
+- `DarkTintColor` specifies the image tint for dark mode. If you omit it and don't set `DarkFile`, .NET MAUI uses the value of `TintColor`. A separate `DarkFile` isn't tinted by default.
+
+On Android, .NET MAUI generates night-qualified resources. Resizetizer writes the dark image to `drawable-night-*` density folders, or to `drawable-night` when resizing is disabled. It also generates `drawable-night/maui_splash_image.xml` and `drawable-night-v31/maui_splash_image.xml`. If a background color is available, it generates `values-night/maui_colors.xml`. Android selects these resources when night mode is active.
+
+On iOS, iPadOS, and Mac Catalyst, .NET MAUI generates themed `UILaunchScreen` asset catalog resources when `SupportedOSPlatformVersion` is 14.0 or later.
+
+> [!WARNING]
+> Themed splash screens require iOS, iPadOS, or Mac Catalyst 14.0 or later. For an iOS or iPadOS target with a lower `SupportedOSPlatformVersion`, the build emits a warning and uses the existing launch storyboard splash screen. For a Mac Catalyst target with a lower version, the build emits a warning and doesn't generate themed splash screen assets.
+
+::: moniker-end
 
 ## Platform-specific configuration
 

--- a/docs/user-interface/images/splashscreen.md
+++ b/docs/user-interface/images/splashscreen.md
@@ -97,9 +97,9 @@ Use the `DarkFile`, `DarkColor`, and `DarkTintColor` metadata on a `MauiSplashSc
 
 ```xml
 <ItemGroup>
-  <MauiSplashScreen Include="Resources\Splash\splash.svg"
+  <MauiSplashScreen Include="Resources\Splash\splashscreen.svg"
                     Color="#FFFFFF"
-                    DarkFile="Resources\Splash\splash-dark.svg"
+                    DarkFile="Resources\Splash\splashscreen-dark.svg"
                     DarkColor="#000000"
                     DarkTintColor="#FFFFFF"
                     BaseSize="128,128" />
@@ -112,7 +112,7 @@ The metadata has the following effects:
 - `DarkColor` specifies the background color for dark mode. If you omit it, .NET MAUI uses the value of `Color`.
 - `DarkTintColor` specifies the image tint for dark mode. If you omit it and don't set `DarkFile`, .NET MAUI uses the value of `TintColor`. A separate `DarkFile` isn't tinted by default.
 
-On Android, .NET MAUI generates night-qualified resources. Resizetizer writes the dark image to `drawable-night-*` density folders, or to `drawable-night` when resizing is disabled. It also generates `drawable-night/maui_splash_image.xml` and `drawable-night-v31/maui_splash_image.xml`. If a background color is available, it generates `values-night/maui_colors.xml`. Android selects these resources when night mode is active.
+On Android, .NET MAUI generates night-qualified resources. Resizetizer writes the dark image to density-qualified `drawable-night-{density}` folders (for example, `drawable-night-hdpi` and `drawable-night-xhdpi`), or to `drawable-night` when resizing is disabled. It also generates `drawable-night/maui_splash_image.xml` and `drawable-night-v31/maui_splash_image.xml`. If a background color is available, it generates `values-night/maui_colors.xml`. Android selects these resources when night mode is active.
 
 On iOS, iPadOS, and Mac Catalyst, .NET MAUI generates themed `UILaunchScreen` asset catalog resources when `SupportedOSPlatformVersion` is 14.0 or later.
 


### PR DESCRIPTION
## Summary

- Add .NET 11 guidance for themed splash screens, including Android night resources and Apple platform version fallbacks.
- Document `ResizeQuality` values, defaults, supported assets, and Resizetizer effects.
- Document the opt-in Android system bar background synchronization property and its icon appearance boundary.

## Source verification

- [dotnet/maui#35710](https://github.com/dotnet/maui/pull/35710)
- [dotnet/maui#34559](https://github.com/dotnet/maui/pull/34559)
- [dotnet/maui#35463](https://github.com/dotnet/maui/pull/35463)
- [.NET 11 RC 1 release notes: dotnet/core#10552](https://github.com/dotnet/core/pull/10552)

All three MAUI merge commits are ancestors of the RC 1 source cut identified in dotnet/core#10552.

## Validation

- Targeted markdownlint: 0 errors
- Moniker balance, article date, and whitespace checks passed
- Independent factual review against PR bodies, diffs, merged source, and current `net11.0` source passed
- Local DocFX v3 validation was not available in this repository environment


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [docs/user-interface/controls/window.md](https://github.com/dotnet/docs-maui/blob/140551eeec7e727c99d303800af1e30221746056/docs/user-interface/controls/window.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/maui/user-interface/controls/window?view=net-maui-11.0&branch=pr-en-us-3502) |
| [docs/user-interface/images/images.md](https://github.com/dotnet/docs-maui/blob/140551eeec7e727c99d303800af1e30221746056/docs/user-interface/images/images.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/maui/user-interface/images/images?view=net-maui-11.0&branch=pr-en-us-3502) |
| [docs/user-interface/images/splashscreen.md](https://github.com/dotnet/docs-maui/blob/140551eeec7e727c99d303800af1e30221746056/docs/user-interface/images/splashscreen.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/maui/user-interface/images/splashscreen?view=net-maui-11.0&branch=pr-en-us-3502) |


<!-- PREVIEW-TABLE-END -->

[Build report](https://buildapi.docs.microsoft.com/Output/PullRequest/a552e5fb-82af-ee54-cd17-c63b0b54d6f7/202609091405012204-3502/BuildReport?accessString=33c19e2a3b8e3b6b24da885be7ded3b96ffa60db8676c105828049dbb171b41f)