### PR TITLE
.NET 11 RC 1: document BlazorWebView static content caching

### DIFF
--- a/docs/user-interface/controls/blazorwebview.md
+++ b/docs/user-interface/controls/blazorwebview.md
@@ -1,7 +1,7 @@
 ---
 title: "Host a Blazor web app in a .NET MAUI app using BlazorWebView"
 description: "The .NET MAUI BlazorWebView control enables you to host a Blazor web app in your .NET MAUI app, and integrate the app with device features."
-ms.date: 09/19/2025
+ms.date: 09/02/2026
 ---
 
 # Host a Blazor web app in a .NET MAUI app using BlazorWebView
@@ -13,6 +13,9 @@ The .NET Multi-platform App UI (.NET MAUI) <xref:Microsoft.AspNetCore.Components
 - <xref:Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.HostPage>, of type `string?`, which defines the root page of the Blazor web app.
 - <xref:Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.RootComponents>, of type `RootComponentsCollection`, which specifies the collection of root components that can be added to the control.
 - <xref:Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.StartPath>, of type `string`, which defines the path for initial navigation within the Blazor navigation context when the Blazor component is finished loading.
+::: moniker range=">=net-maui-11.0"
+- <xref:Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.StaticContentCacheControlProvider>, of type `Func<BlazorWebViewStaticContentRequest, string?>?`, which returns a `Cache-Control` header value for local static content.
+::: moniker-end
 
 The <xref:Microsoft.AspNetCore.Components.WebView.Maui.RootComponent> class defines the following properties:
 
@@ -255,6 +258,33 @@ static MauiProgram()
     AppContext.SetSwitch("BlazorWebView.AppHostAddressAlways0000", true);
 }
 ```
+
+::: moniker-end
+
+::: moniker range=">=net-maui-11.0"
+
+## Cache local static content
+
+By default, <xref:Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView> serves local static content with a `Cache-Control` value that includes `no-store`. To opt selected assets into caching, set <xref:Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebView.StaticContentCacheControlProvider>. This property is supported on Android, iOS, Mac Catalyst, Windows, and Tizen.
+
+The callback receives a <xref:Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewStaticContentRequest> that contains the absolute request URI and the resolved content type. The following example makes images in the *images/catalog* path eligible for caching with a maximum age of one day:
+
+```csharp
+blazorWebView.StaticContentCacheControlProvider = request =>
+    request.Uri.AbsolutePath.StartsWith("/images/catalog/", StringComparison.Ordinal) &&
+    request.ContentType.StartsWith("image/", StringComparison.Ordinal)
+        ? "public, max-age=86400"
+        : null;
+```
+
+When the provider runs, return `null`, an empty string, or whitespace to keep the default `no-store` behavior. If the provider throws an exception, .NET MAUI logs the exception and uses the default behavior. The provider also applies to apps that you publish with `dotnet publish`.
+
+Set the provider before the first static content request, and keep its policy stable for the lifetime of the control. Changing or clearing the provider does not invalidate existing cache entries. Use a versioned URI, such as `image.png?v=2`, when an asset changes.
+
+> [!IMPORTANT]
+> Opt in only local static assets that do not contain user-specific or sensitive data. The callback can run on a background thread and must not access UI state directly.
+
+Each `BlazorWebView` has a bounded managed cache, and entries can expire or be evicted. Only successful `GET` responses that have a positive `max-age` value are eligible for the cache. Responses that specify `no-cache` or `no-store` are not eligible. Non-`GET` requests, requests that have an `Authorization` or `Range` header, and requests that specify `Cache-Control: no-store` bypass the cache. A request refresh directive, such as `Cache-Control: no-cache`, refreshes the entry before the provider runs again.
 
 ::: moniker-end
 


### PR DESCRIPTION
## Summary

- Document the .NET 11 opt-in `BlazorWebView.StaticContentCacheControlProvider` API.
- Show how to make selected local static assets eligible for caching while preserving the default `no-store` behavior.
- Document the per-`BlazorWebView` bounded cache, lifecycle guidance, supported platforms, publish behavior, and request types that bypass or refresh the cache.

## Source

- Implementation: https://github.com/dotnet/maui/pull/35706
- Verified at the .NET 11 RC1 workload branch cutoff: `dotnet/maui` `release/11.0.1xx-rc1` commit `484132f9e51f4d1eae72dba038575d6102639730`
- RC1 release notes context: https://github.com/dotnet/core/pull/10552

## Validation

- `npx --yes markdownlint-cli2 'docs/user-interface/controls/blazorwebview.md' --config .markdownlint-cli2.jsonc` (0 issues)
- `git diff --check`
- DocFX moniker balance and `ms.date` checks
- Adversarial factual review against the RC1 source, followed by a clean review of the final staged diff

The MSDocs verifier, xref resolver, and OPS build-warning checks run in pull-request CI.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [docs/user-interface/controls/blazorwebview.md](https://github.com/dotnet/docs-maui/blob/4d47274045e4dd2970697caf8eb7013df07cd8b7/docs/user-interface/controls/blazorwebview.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/maui/user-interface/controls/blazorwebview?view=net-maui-11.0&branch=pr-en-us-3505) |

<!-- PREVIEW-TABLE-END -->

[Build report](https://buildapi.docs.microsoft.com/Output/PullRequest/a552e5fb-82af-ee54-cd17-c63b0b54d6f7/202609022016428637-3505/BuildReport?accessString=35771cfccfc8087550ef90e48f6adb503a9f195bc1a875c980dfbbf23bf62386)