### PR TITLE
Fix Duplicate BoxView Fill content in the .NET 11 what's new documentation

### DIFF
--- a/docs/whats-new/dotnet-11.md
+++ b/docs/whats-new/dotnet-11.md
@@ -48,8 +48,6 @@ In .NET 11 Preview 5, the underlying Material 3 helper types (`MauiMaterialEditT
 
 ### BoxView Fill property
 
-:::moniker range=">=net-maui-11.0"
-
 <xref:Microsoft.Maui.Controls.BoxView> now exposes a `Fill` bindable property of type <xref:Microsoft.Maui.Controls.Brush>, allowing it to be painted with any brush (including <xref:Microsoft.Maui.Controls.LinearGradientBrush> and <xref:Microsoft.Maui.Controls.RadialGradientBrush>) instead of just a solid color. When both `Fill` and `Color` are set, `Fill` takes priority; setting `Fill` back to `null` causes the <xref:Microsoft.Maui.Controls.BoxView> to render using `Color` again. For more information, see [Fill a BoxView with a brush](~/user-interface/controls/boxview.md#fill-a-boxview-with-a-brush) and [GitHub PR #31789](https://github.com/dotnet/maui/pull/31789).
 
 ```xaml
@@ -88,8 +86,6 @@ Or a <xref:Microsoft.Maui.Controls.RadialGradientBrush>:
 ```
 
 :::image type="content" source="../user-interface/controls/media/boxview/boxview-radial-fill.png" alt-text="Screenshot of a BoxView painted with a radial gradient brush.":::
-
-:::moniker-end
 
 ### LongPressGestureRecognizer
 
@@ -159,21 +155,6 @@ Apply a custom JSON style to the map on Android using the `MapStyle` property. T
 For more information, see GitHub PRs [#29101](https://github.com/dotnet/maui/pull/29101), [#33831](https://github.com/dotnet/maui/pull/33831), [#33950](https://github.com/dotnet/maui/pull/33950), [#33982](https://github.com/dotnet/maui/pull/33982), [#33985](https://github.com/dotnet/maui/pull/33985), [#33792](https://github.com/dotnet/maui/pull/33792), [#33799](https://github.com/dotnet/maui/pull/33799), [#33991](https://github.com/dotnet/maui/pull/33991), and [#33993](https://github.com/dotnet/maui/pull/33993).
 
 In .NET 11 Preview 5, the <xref:Microsoft.Maui.Controls.Maps.Map> control gains a Windows implementation backed by Azure Maps. To use it, call `UseMapServiceToken(...)` in `MauiProgram.cs` with an Azure Maps subscription key. The Windows implementation supports `MoveToRegion`, map types, traffic, scrolling, zooming, and standard pins; some platform-only features such as user location, custom pin info windows, and map elements/shapes aren't supported on Windows. For more information, see [GitHub PR #34138](https://github.com/dotnet/maui/pull/34138).
-
-### BoxView Fill
-
-Starting in .NET 11 Preview 5, <xref:Microsoft.Maui.Controls.BoxView> exposes a `Fill` property of type <xref:Microsoft.Maui.Controls.Brush>. This aligns <xref:Microsoft.Maui.Controls.BoxView> with the other shape primitives and means gradients and other brushes can paint a `BoxView` without a custom handler. `BackgroundColor` still works as before. For more information, see [GitHub PR #31789](https://github.com/dotnet/maui/pull/31789).
-
-```xaml
-<BoxView HeightRequest="120" CornerRadius="12">
-    <BoxView.Fill>
-        <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
-            <GradientStop Color="#512BD4" Offset="0.0" />
-            <GradientStop Color="#0099CC" Offset="1.0" />
-        </LinearGradientBrush>
-    </BoxView.Fill>
-</BoxView>
-```
 
 ### Windows CollectionView2 handler
 


### PR DESCRIPTION
This pull request cleans up the documentation for the new `Fill` property on `BoxView` in .NET 11 by consolidating and removing duplicate sections. The main summary and code sample for the `Fill` property are now presented only once, making the documentation clearer and less redundant.

Documentation cleanup:

* Removed a duplicate section about the `BoxView.Fill` property, including its code sample and explanation, from later in the file to avoid redundancy.
* Removed extra moniker range markers around the main `BoxView Fill property` section to streamline the documentation structure. 

Fixes #3508

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [docs/whats-new/dotnet-11.md](https://github.com/dotnet/docs-maui/blob/1088ea5f1b7bc3111a90418088a0985a2e8be680/docs/whats-new/dotnet-11.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/maui/whats-new/dotnet-11?view=net-maui-11.0&branch=pr-en-us-3509) |

<!-- PREVIEW-TABLE-END -->

[Build report](https://buildapi.docs.microsoft.com/Output/PullRequest/a552e5fb-82af-ee54-cd17-c63b0b54d6f7/202609040825430764-3509/BuildReport?accessString=6d58434bda044bb56a4c6596284d12fa275f6b4338588b231d3e36f9784aadee)