### PR TITLE
Docs (.NET 11): update MAUI runtime and compilation guidance

### DIFF
--- a/docs/deployment/runtimes-compilation.md
+++ b/docs/deployment/runtimes-compilation.md
@@ -1,7 +1,7 @@
 ---
 title: "Runtimes and compilation in .NET MAUI"
 description: "Learn about the runtimes and compilation strategies used by .NET MAUI apps, including CoreCLR, NativeAOT, ReadyToRun, and interpreters."
-ms.date: 09/08/2026
+ms.date: 09/10/2026
 ---
 
 # Runtimes and compilation in .NET MAUI
@@ -145,8 +145,8 @@ restrictions on the code patterns you can use.
 
 ::: moniker range=">=net-maui-11.0"
 
-- **Available on**: .NET MAUI apps targeting .NET 11 when explicitly enabled
-  for publishing
+- **Available on**: .NET MAUI iOS and Mac Catalyst apps, and experimentally
+  on Android, when explicitly enabled for publishing
 - **Advantages**: Small app size, fast startup, and a single native binary
 - **Disadvantages**: No dynamic code generation or dynamic loading; all code
   must be trim-safe and AOT-compatible
@@ -192,20 +192,21 @@ are packed inside the `.dll` files.
 - **Disadvantages**: Larger application and download sizes
 
 For Android apps, ReadyToRun is enabled by default in the `Release`
-configuration. The default is composite partial ReadyToRun. Full ReadyToRun
+configuration. The default is partial composite ReadyToRun. Full ReadyToRun
 can be enabled with `MauiEnableFullReadyToRun=true`. It can improve startup or
 runtime performance, but it increases package size, so measure the result for
 your app.
 
-For Apple apps, composite ReadyToRun is used with the CoreCLR
-interpreter for code that isn't precompiled. Apple device targets don't use
-JIT.
+For iOS and Mac Catalyst apps, full composite ReadyToRun is used. On iOS, the
+CoreCLR interpreter is always enabled and executes code where the operating
+system doesn't permit JIT compilation.
 
 ::: moniker-end
 
 *Composite* R2R compiles assemblies together, enabling cross-assembly
 optimizations. *Partial* R2R precompiles selected methods while leaving the
-remaining methods for runtime compilation.
+remaining methods for runtime compilation, while *full* R2R precompiles all
+methods.
 
 For more information, see [ReadyToRun compilation](/dotnet/core/deploying/ready-to-run).
 
@@ -255,10 +256,11 @@ For more information, see [Mono interpreter on iOS and Mac Catalyst](~/macios/in
 
 ### CoreCLR interpreter
 
-The CoreCLR interpreter is used on Apple device targets because those platforms
-don't allow JIT-generated code. Apple CoreCLR apps use ReadyToRun for most
-methods and the interpreter for code that isn't precompiled. This behavior is
-part of the runtime and doesn't require an interpreter MSBuild property.
+CoreCLR includes an interpreter on iOS and Mac Catalyst. On iOS, the
+interpreter is always enabled and executes code where the operating system
+doesn't permit JIT compilation. On Mac Catalyst, it provides a fallback when
+JIT compilation isn't permitted. This behavior is part of the runtime and
+doesn't require an interpreter MSBuild property.
 
 ::: moniker-end
 
@@ -296,9 +298,9 @@ The following table summarizes the runtime and compilation strategy used by
 
 | Platform | Debug | Release |
 |---|---|---|
-| **Android** | CoreCLR + JIT | CoreCLR + composite partial ReadyToRun + JIT |
-| **iOS** | CoreCLR + composite ReadyToRun + interpreter | CoreCLR + composite ReadyToRun + interpreter |
-| **Mac Catalyst** | CoreCLR + composite ReadyToRun + interpreter | CoreCLR + composite ReadyToRun + interpreter |
+| **Android** | CoreCLR + JIT | CoreCLR + partial composite ReadyToRun + JIT |
+| **iOS** | CoreCLR + full composite ReadyToRun + interpreter | CoreCLR + full composite ReadyToRun + interpreter |
+| **Mac Catalyst** | CoreCLR + full composite ReadyToRun + interpreter | CoreCLR + full composite ReadyToRun + interpreter |
 | **Windows** | CoreCLR + JIT | CoreCLR + JIT + ReadyToRun |
 
 > [!IMPORTANT]
@@ -367,13 +369,12 @@ MAUI apps targeting .NET 11:
 
 ::: moniker-end
 
-## CoreCLR on Android and Apple platforms
+## CoreCLR on Android and iOS
 
 ::: moniker range="<=net-maui-10.0"
 
 Starting in .NET 10, you can opt in to running an Android app on CoreCLR
-instead of Mono. CoreCLR is also available as an experimental option for
-selected Apple targets.
+instead of Mono.
 
 ```xml
 <PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
@@ -390,7 +391,8 @@ for production use.
 
 In .NET 11, CoreCLR is the supported runtime for Android, iOS, and Mac
 Catalyst apps unless NativeAOT is explicitly enabled for publishing. NativeAOT
-is an opt-in alternative that doesn't use CoreCLR. Don't set
+is an opt-in alternative that doesn't use CoreCLR and remains experimental on
+Android. Don't set
 `UseMonoRuntime=true`; Mono isn't supported for .NET 11, and setting the
 property produces a build error.
 
@@ -437,7 +439,7 @@ CoreCLR or NativeAOT:
 - `lib/arm64-v8a/libassemblies.arm64-v8a.so` — Packed MSIL with ReadyToRun
   images
 
-**NativeAOT:**
+**NativeAOT (experimental):**
 
 - `classes.dex` — Java/Kotlin code
 - `lib/arm64-v8a/libhellomaui.so` — Native library containing the runtime,

--- a/docs/deployment/runtimes-compilation.md
+++ b/docs/deployment/runtimes-compilation.md
@@ -192,13 +192,13 @@ are packed inside the `.dll` files.
 - **Disadvantages**: Larger application and download sizes
 
 For Android apps, ReadyToRun is enabled by default in the `Release`
-configuration. The default is partial composite ReadyToRun. Full ReadyToRun
+configuration. The default is composite partial ReadyToRun. Full ReadyToRun
 can be enabled with `MauiEnableFullReadyToRun=true`. It can improve startup or
 runtime performance, but it increases package size, so measure the result for
 your app.
 
-For iOS and Mac Catalyst apps, partial composite ReadyToRun is used in `Debug`
-builds and full composite ReadyToRun is used in `Release` builds. On iOS, the
+For iOS and Mac Catalyst apps, composite partial ReadyToRun is used in `Debug`
+builds and composite full ReadyToRun is used in `Release` builds. On iOS, the
 CoreCLR interpreter is always enabled and executes code where the operating
 system doesn't permit JIT compilation.
 
@@ -299,9 +299,9 @@ The following table summarizes the runtime and compilation strategy used by
 
 | Platform | Debug | Release |
 |---|---|---|
-| **Android** | CoreCLR + JIT | CoreCLR + partial composite ReadyToRun + JIT |
-| **iOS** | CoreCLR + partial composite ReadyToRun + interpreter | CoreCLR + full composite ReadyToRun + interpreter |
-| **Mac Catalyst** | CoreCLR + partial composite ReadyToRun + interpreter | CoreCLR + full composite ReadyToRun + interpreter |
+| **Android** | CoreCLR + JIT | CoreCLR + composite partial ReadyToRun + JIT |
+| **iOS** | CoreCLR + composite partial ReadyToRun + interpreter | CoreCLR + composite full ReadyToRun + interpreter |
+| **Mac Catalyst** | CoreCLR + composite partial ReadyToRun + interpreter | CoreCLR + composite full ReadyToRun + interpreter |
 | **Windows** | CoreCLR + JIT | CoreCLR + JIT + ReadyToRun |
 
 > [!IMPORTANT]

--- a/docs/deployment/runtimes-compilation.md
+++ b/docs/deployment/runtimes-compilation.md
@@ -198,9 +198,9 @@ runtime performance, but it increases package size, so measure the result for
 your app.
 
 For iOS and Mac Catalyst apps, composite partial ReadyToRun is used in `Debug`
-builds and composite full ReadyToRun is used in `Release` builds. On iOS, the
-CoreCLR interpreter is always enabled and executes code where the operating
-system doesn't permit JIT compilation.
+builds and composite full ReadyToRun is used in `Release` builds. The CoreCLR
+interpreter is always enabled and executes code that isn't precompiled because
+these platforms don't permit JIT compilation.
 
 ::: moniker-end
 
@@ -257,11 +257,10 @@ For more information, see [Mono interpreter on iOS and Mac Catalyst](~/macios/in
 
 ### CoreCLR interpreter
 
-CoreCLR includes an interpreter on iOS and Mac Catalyst. On iOS, the
-interpreter is always enabled and executes code where the operating system
-doesn't permit JIT compilation. On Mac Catalyst, it provides a fallback when
-JIT compilation isn't permitted. This behavior is part of the runtime and
-doesn't require an interpreter MSBuild property.
+CoreCLR includes an interpreter on iOS and Mac Catalyst. The interpreter is
+always enabled and executes code that isn't precompiled because these platforms
+don't permit JIT compilation. This behavior is part of the runtime and doesn't
+require an interpreter MSBuild property.
 
 ::: moniker-end
 

--- a/docs/deployment/runtimes-compilation.md
+++ b/docs/deployment/runtimes-compilation.md
@@ -17,9 +17,9 @@ A .NET *runtime* is the execution environment that manages your app's memory,
 type system, garbage collection, and code execution. .NET MAUI apps use one of
 the following runtimes:
 
-### Mono
-
 ::: moniker range="<=net-maui-10.0"
+
+### Mono
 
 [Mono](https://www.mono-project.com/docs/) is the cross-platform .NET runtime
 that has historically powered Xamarin apps and .NET MAUI apps on Android, iOS,
@@ -31,8 +31,7 @@ on mobile and Mac Catalyst platforms.
 
 ::: moniker range=">=net-maui-11.0"
 
-Mono isn't supported for .NET MAUI apps that target .NET 11. CoreCLR is the
-only supported runtime for .NET 11.
+Mono isn't supported for .NET MAUI apps that target .NET 11.
 
 ::: moniker-end
 
@@ -57,7 +56,7 @@ iOS, and Mac Catalyst. NativeAOT is an opt-in alternative for publishing.
 
 ::: moniker-end
 
-### NativeAOT runtime
+### NativeAOT
 
 When you publish with [Native AOT](nativeaot.md), your app doesn't run on the
 CoreCLR runtime. Instead, it runs on a minimal NativeAOT runtime that's
@@ -363,7 +362,7 @@ MAUI apps targeting .NET 11:
 | **Compilation time** | At runtime | At runtime | At build time | At build time |
 | **Startup speed** | Slower | Slower | Fast | Fastest |
 | **App size** | Smaller | Smaller | Larger | Smallest |
-| **Dynamic code** | Full support | Full support | Full support (retains CoreCLR runtime compilation) | Not supported |
+| **Dynamic code** | Full support | Full support | Full support (through either JIT or interpreter) | Not supported |
 | **Diagnostics** | Full | Full | Limited | Limited |
 
 ::: moniker-end
@@ -452,7 +451,7 @@ Trimming is a build step that removes unused code from your app to reduce its
 size. .NET MAUI uses the ILLink trimmer, which analyzes your code and removes
 types, methods, and fields that aren't statically referenced.
 
-For non-NativeAOT Release and publish builds, .NET MAUI uses
+For CoreCLR Release builds, .NET MAUI uses
 `TrimMode=partial` by default, which trims framework assemblies but not your
 code or NuGet references. To use full trimming, set `TrimMode` to `full`:
 

--- a/docs/deployment/runtimes-compilation.md
+++ b/docs/deployment/runtimes-compilation.md
@@ -479,7 +479,6 @@ compilation behavior:
 |---|---|---|
 | `PublishAot` | Enable NativeAOT compilation. | `false` |
 | `PublishReadyToRun` | Enable ReadyToRun precompilation for CoreCLR. | `true` (Windows Release and applicable CoreCLR builds) |
-| `PublishTrimmed` | Enable ILLink trimming. | `true` (Release) |
 | `TrimMode` | Set trimming aggressiveness (`partial` or `full`). | `partial` |
 | `UseInterpreter` | Enable the Mono interpreter. | `true` (iOS/Mac Catalyst Debug) |
 | `UseMonoRuntime` | Use Mono instead of CoreCLR. | `true` on supported Mono targets |

--- a/docs/deployment/runtimes-compilation.md
+++ b/docs/deployment/runtimes-compilation.md
@@ -1,113 +1,275 @@
 ---
 title: "Runtimes and compilation in .NET MAUI"
-description: "Learn about the runtimes and compilation strategies used by .NET MAUI apps, including Mono, CoreCLR, NativeAOT, ReadyToRun, and the Mono interpreter."
-ms.date: 03/09/2026
+description: "Learn about the runtimes and compilation strategies used by .NET MAUI apps, including CoreCLR, NativeAOT, ReadyToRun, and interpreters."
+ms.date: 09/08/2026
 ---
 
 # Runtimes and compilation in .NET MAUI
 
-.NET Multi-platform App UI (.NET MAUI) apps can run on different .NET runtimes and use different compilation strategies depending on the target platform, build configuration, and deployment model. This article explains the key terms, how they relate to each other, and what .NET MAUI uses by default on each platform.
+.NET Multi-platform App UI (.NET MAUI) apps can use different runtimes and
+compilation strategies depending on the target platform, build configuration,
+and deployment model. This article explains the key terms and the runtime and
+compilation strategies that .NET MAUI uses on each platform.
 
 ## Runtimes
 
-A .NET *runtime* is the execution environment that manages your app's memory, type system, garbage collection, and code execution. .NET MAUI apps can run on one of the following runtimes:
+A .NET *runtime* is the execution environment that manages your app's memory,
+type system, garbage collection, and code execution. .NET MAUI apps use one of
+the following runtimes:
 
 ### Mono
 
-[Mono](https://www.mono-project.com/docs/) is the cross-platform .NET runtime that has historically powered Xamarin apps and now powers .NET MAUI apps on Android, iOS, and Mac Catalyst. Mono is designed for a small footprint and supports both just-in-time (JIT) compilation and ahead-of-time (AOT) compilation. Mono is the default runtime for .NET MAUI apps on mobile and Mac Catalyst platforms.
+::: moniker range="<=net-maui-10.0"
+
+[Mono](https://www.mono-project.com/docs/) is the cross-platform .NET runtime
+that has historically powered Xamarin apps and .NET MAUI apps on Android, iOS,
+and Mac Catalyst. Mono supports both just-in-time (JIT) compilation and
+ahead-of-time (AOT) compilation. Mono is the default runtime for .NET MAUI apps
+on mobile and Mac Catalyst platforms.
+
+::: moniker-end
+
+::: moniker range=">=net-maui-11.0"
+
+Mono isn't supported for .NET MAUI apps that target .NET 11. CoreCLR is the
+only supported runtime for .NET 11.
+
+::: moniker-end
 
 ### CoreCLR
 
-CoreCLR is the .NET Common Language Runtime used by .NET on desktop and server platforms. It's the runtime that powers ASP.NET Core, console apps, and Windows desktop apps. CoreCLR features a highly optimizing JIT compiler, tiered compilation, and a full set of runtime diagnostics. In .NET MAUI, CoreCLR is the runtime used on Windows.
+CoreCLR is the .NET Common Language Runtime used by .NET on desktop and server
+platforms. It powers ASP.NET Core, console apps, and Windows desktop apps.
+CoreCLR features a highly optimizing JIT compiler, tiered compilation, and a
+full set of runtime diagnostics.
 
-> [!NOTE]
-> In .NET 10, CoreCLR is available as an experimental option for Android. In .NET 11, CoreCLR becomes the default runtime for Android `Release` builds and is available as an experimental option for iOS. For more information, see [CoreCLR on Android and iOS](#coreclr-on-android-and-ios).
+::: moniker range="<=net-maui-10.0"
+
+In .NET MAUI, CoreCLR is the runtime used on Windows. In .NET 10, CoreCLR is
+also available as an experimental option for Android.
+
+::: moniker-end
+
+::: moniker range=">=net-maui-11.0"
+
+In .NET 11, CoreCLR is the only supported runtime for .NET MAUI apps on
+Android, iOS, Mac Catalyst, and tvOS unless the app is published with
+NativeAOT.
+
+::: moniker-end
 
 ### NativeAOT runtime
 
-When you publish with [Native AOT](nativeaot.md), your app doesn't run on Mono or CoreCLR. Instead, it runs on a minimal NativeAOT runtime that's statically linked into your native binary. This runtime includes a garbage collector and type system but no JIT compiler — all code is compiled to native machine code at build time.
+When you publish with [Native AOT](nativeaot.md), your app doesn't run on the
+CoreCLR runtime. Instead, it runs on a minimal NativeAOT runtime that's
+statically linked into your native binary. This runtime includes a garbage
+collector and type system but no JIT compiler or interpreter. All code is
+compiled to native machine code at build time.
 
 ## Compilation strategies
 
-A *compilation strategy* determines how your C# code is turned into machine code that the processor can execute. .NET MAUI uses several compilation strategies, depending on the runtime and deployment scenario.
+A *compilation strategy* determines how your C# code is turned into machine code
+that the processor can execute. .NET MAUI uses several compilation strategies,
+depending on the runtime and deployment scenario.
 
 ### JIT (Just-in-Time) compilation
 
-JIT compilation translates Microsoft Intermediate Language (MSIL) into native machine code *at runtime*, as methods are called for the first time. JIT compilation is used during development because it supports fast build-deploy-debug cycles and features like Edit and Continue.
+JIT compilation translates Microsoft Intermediate Language (MSIL) into native
+machine code at runtime as methods are called for the first time. JIT
+compilation supports fast build-deploy-debug cycles and features such as Edit
+and Continue.
 
-- **Used by**: CoreCLR (Windows, Android experimental), Mono (debug builds on Android)
-- **Advantages**: Fast build times, full runtime diagnostics, dynamic code generation support
-- **Disadvantages**: Slower startup because code is compiled on the device at runtime
+::: moniker range="<=net-maui-10.0"
 
-> [!NOTE]
-> iOS and Mac Catalyst ARM64 builds can't use JIT compilation due to Apple's security restrictions on dynamically generated code. However, JIT is used in the x64 iOS simulator and on x64 Mac Catalyst during development.
+- **Used by**: CoreCLR on Windows and experimentally on Android; Mono in
+  Android debug builds
+- **Advantages**: Fast build times, full runtime diagnostics, and dynamic code
+  generation support
+- **Disadvantages**: Slower startup because code is compiled on the device at
+  runtime
+
+::: moniker-end
+
+::: moniker range=">=net-maui-11.0"
+
+- **Used by**: CoreCLR on Windows and Android
+- **Advantages**: Fast build times, full runtime diagnostics, and dynamic code
+  generation support
+- **Disadvantages**: Slower startup when code isn't already compiled by
+  ReadyToRun
+
+Apple CoreCLR device targets don't use JIT because Apple platform restrictions
+prevent dynamically generated code. They use the CoreCLR interpreter instead.
+
+::: moniker-end
+
+::: moniker range="<=net-maui-10.0"
 
 ### Mono AOT (Ahead-of-Time) compilation
 
-Mono AOT compilation pre-compiles your MSIL into native code at build time using Mono's AOT compiler. This is the default compilation mode for .NET MAUI release builds on iOS, Mac Catalyst, and Android. Mono AOT is a technology carried forward from Xamarin.
+Mono AOT compilation precompiles MSIL into native code at build time using
+Mono's AOT compiler. This is the default compilation mode for .NET MAUI release
+builds on iOS, Mac Catalyst, and Android.
 
-- **Used by**: Mono runtime (iOS, Mac Catalyst, Android release builds)
-- **Advantages**: Faster startup than JIT, required for platforms that restrict dynamic code generation
-- **Disadvantages**: Larger app size than JIT-only, limited support for some dynamic features
+- **Used by**: Mono runtime on iOS, Mac Catalyst, and Android
+- **Advantages**: Faster startup than JIT and required for platforms that
+  restrict dynamic code generation
+- **Disadvantages**: Larger app size than JIT-only builds and limited support
+  for some dynamic features
 
-Mono AOT is not the same as NativeAOT. With Mono AOT, your app still includes the Mono runtime and can optionally fall back to the Mono interpreter for code that wasn't AOT-compiled. NativeAOT compiles *all* code ahead of time and doesn't include a JIT or interpreter. Mono also supports a *Full AOT* mode where no interpreter or JIT is available — all code must be AOT-compiled. Full AOT is used by default for Mono release builds on iOS and Mac Catalyst.
+Mono AOT is not the same as NativeAOT. With Mono AOT, your app still includes
+the Mono runtime and can optionally use the Mono interpreter for code that
+wasn't AOT-compiled. NativeAOT compiles all code ahead of time and doesn't
+include a JIT or interpreter. Mono also supports a Full AOT mode where no
+interpreter or JIT is available. Full AOT is used by default for Mono release
+builds on iOS and Mac Catalyst.
+
+::: moniker-end
 
 ### NativeAOT (Native Ahead-of-Time) compilation
 
-NativeAOT compiles your entire app, all its dependencies, and a minimal runtime into a single native binary at build time. There's no JIT compiler or interpreter at runtime. NativeAOT performs full trimming and static analysis of your code, which produces the smallest app sizes and fastest startup times, but places the most restrictions on what code patterns you can use.
+NativeAOT compiles your entire app, its dependencies, and a minimal runtime
+into a native binary at build time. There is no JIT compiler or interpreter at
+runtime. NativeAOT performs full trimming and static analysis, which can
+produce smaller app sizes and faster startup times, but it places more
+restrictions on the code patterns you can use.
 
-- **Used by**: NativeAOT runtime (iOS and Mac Catalyst stable in .NET 9+, Android experimental)
-- **Advantages**: Smallest app size, fastest startup, single native binary
-- **Disadvantages**: No dynamic code generation (`System.Reflection.Emit`), no dynamic loading, requires all code to be trim-safe and AOT-compatible
+::: moniker range="<=net-maui-10.0"
+
+- **Available on**: .NET MAUI iOS and Mac Catalyst apps when explicitly
+  enabled for publishing
+- **Advantages**: Small app size, fast startup, and a single native binary
+- **Disadvantages**: No dynamic code generation or dynamic loading; all code
+  must be trim-safe and AOT-compatible
 - **MSBuild property**: `<PublishAot>true</PublishAot>`
 
-For more information, see [Native AOT deployment on iOS and Mac Catalyst](nativeaot.md) and [Native AOT deployment](/dotnet/core/deploying/native-aot).
+::: moniker-end
+
+::: moniker range=">=net-maui-11.0"
+
+- **Available on**: .NET MAUI apps targeting .NET 11 when explicitly enabled
+  for publishing
+- **Advantages**: Small app size, fast startup, and a single native binary
+- **Disadvantages**: No dynamic code generation or dynamic loading; all code
+  must be trim-safe and AOT-compatible
+- **MSBuild property**: `<PublishAot>true</PublishAot>`
+
+NativeAOT is a publish-only deployment model. Use `dotnet publish` to produce
+and validate a NativeAOT app. A regular debug build doesn't use NativeAOT.
+
+::: moniker-end
+
+For more information, see [Native AOT deployment on iOS and Mac
+Catalyst](nativeaot.md) and [Native AOT deployment](/dotnet/core/deploying/native-aot).
 
 ### ReadyToRun (R2R)
 
-ReadyToRun is a form of AOT compilation for CoreCLR that pre-compiles your assemblies into a format that includes *both* the original MSIL and a native code representation. At startup, the runtime uses the pre-compiled native code instead of JIT-compiling from MSIL, which improves startup time. For methods that are called frequently, tiered compilation eventually replaces the ReadyToRun code with fully optimized JIT-compiled code.
+ReadyToRun is a form of ahead-of-time compilation for CoreCLR that precompiles
+assemblies into a format containing both the original MSIL and a native code
+representation. At startup, the runtime can use the precompiled native code
+instead of compiling methods from MSIL. On platforms where JIT is available,
+the runtime can still JIT-compile methods that aren't precompiled and optimize
+frequently used methods at runtime.
 
-- **Used by**: CoreCLR (Windows, Android, and iOS release builds when using CoreCLR)
-- **Advantages**: Improved startup time while retaining full JIT compatibility
-- **Disadvantages**: Larger assembly sizes (assemblies contain both MSIL and native code)
+::: moniker range="<=net-maui-10.0"
+
+- **Used by**: CoreCLR on Windows and CoreCLR Android builds that opt into the
+  experimental runtime
+- **Advantages**: Improved startup time while retaining JIT compatibility
+- **Disadvantages**: Larger assembly sizes because assemblies contain both MSIL
+  and native code
 - **MSBuild property**: `<PublishReadyToRun>true</PublishReadyToRun>`
 
-ReadyToRun is enabled by default for .NET MAUI apps on Windows in `Release` mode, and for Android apps that use CoreCLR in `Release` mode. The R2R images are packed inside your `.dll` files, which is why you'll notice assemblies increase in size.
+ReadyToRun is enabled by default for .NET MAUI apps on Windows in `Release`
+mode and for Android apps that use CoreCLR in `Release` mode. The R2R images
+are packed inside the `.dll` files.
 
-On Android, .NET MAUI uses **composite partial ReadyToRun** by default for CoreCLR release builds. On iOS and Mac Catalyst, composite partial ReadyToRun is used for both debug and release builds when using CoreCLR, because there's no JIT on these platforms — CoreCLR's interpreter handles any code that isn't R2R-compiled, and relying solely on the interpreter would be too slow. *Composite* R2R compiles all assemblies together, enabling better cross-assembly optimizations. *Partial* R2R means only the methods identified by profile data are pre-compiled, while the remaining methods are left for the interpreter or JIT to handle at runtime. This combination keeps app sizes smaller without sacrificing startup time.
+::: moniker-end
+
+::: moniker range=">=net-maui-11.0"
+
+- **Used by**: CoreCLR on Windows, Android, iOS, Mac Catalyst, and tvOS
+- **Advantages**: Improved startup time while retaining the appropriate
+  runtime compilation behavior
+- **Disadvantages**: Larger application and download sizes
+
+For Android apps, ReadyToRun is enabled by default in the `Release`
+configuration. The default is composite partial ReadyToRun. Full ReadyToRun
+can be enabled with `MauiEnableFullReadyToRun=true`. It can improve startup or
+runtime performance, but it increases package size, so measure the result for
+your app.
+
+For Apple apps, composite ReadyToRun is used with the CoreCLR
+interpreter for code that isn't precompiled. Apple device targets don't use
+JIT.
+
+::: moniker-end
+
+*Composite* R2R compiles assemblies together, enabling cross-assembly
+optimizations. *Partial* R2R precompiles selected methods while leaving the
+remaining methods for runtime compilation.
 
 For more information, see [ReadyToRun compilation](/dotnet/core/deploying/ready-to-run).
 
+::: moniker range="<=net-maui-10.0"
+
 ### Profile-guided optimization (PGO)
 
-Profile-guided optimization (PGO) uses profiling data to guide the compiler toward producing more efficient code. In the context of .NET MAUI, there are two forms of PGO:
+Profile-guided optimization (PGO) uses profiling data to guide the compiler
+toward producing more efficient code. In the context of .NET MAUI, there are
+two forms of PGO:
 
-- **Static PGO with MIBC profiles**: .NET MAUI ships `.mibc` (Managed Intermediate Binary Code) profile files that contain data about which methods are most frequently called during typical app startup and usage. When ReadyToRun compilation is enabled, the R2R compiler uses these profiles to decide which methods to pre-compile (*partial R2R*), keeping app sizes small while still optimizing the hot paths that matter most for startup. On Android with CoreCLR, .NET MAUI includes default MIBC profiles automatically.
-- **Dynamic PGO**: On CoreCLR, the JIT compiler can instrument your code at runtime during Tier 0 compilation, collecting profile data about actual execution. When methods are recompiled at Tier 1, the JIT uses this data to produce better-optimized native code. Dynamic PGO is enabled by default starting in .NET 8.
+- **Static PGO with MIBC profiles**: .NET MAUI ships `.mibc` profile files
+  containing data about methods frequently called during typical app startup
+  and usage. When ReadyToRun compilation is enabled, the R2R compiler uses
+  these profiles to decide which methods to precompile.
+- **Dynamic PGO**: On CoreCLR, the JIT compiler can collect profile data at
+  runtime and use it when methods are recompiled with more optimizations.
 
-For mobile scenarios, static PGO with MIBC profiles is the key technique — it allows partial ReadyToRun to pre-compile only the methods that matter for startup, reducing the size overhead of R2R images while preserving fast startup times.
+For more information, see [Profile-guided optimization](/dotnet/core/runtime-config/compilation#profile-guided-optimization)
+and [ReadyToRun compilation](/dotnet/core/deploying/ready-to-run).
 
-For more information, see [Profile-guided optimization](/dotnet/core/runtime-config/compilation#profile-guided-optimization) and [ReadyToRun compilation](/dotnet/core/deploying/ready-to-run).
+::: moniker-end
+
+::: moniker range="<=net-maui-10.0"
 
 ### Mono interpreter
 
-The Mono interpreter enables your app to interpret MSIL at runtime without generating native code dynamically. This lets your app use dynamic features such as generics instantiations and limited reflection on platforms that don't allow JIT compilation, such as iOS devices. The interpreter is used alongside Mono AOT — most code is AOT-compiled, and the interpreter handles the portions that couldn't be compiled ahead of time.
+The Mono interpreter enables an app to interpret MSIL at runtime without
+generating native code dynamically. It is used alongside Mono AOT on platforms
+that don't allow JIT compilation, such as iOS devices.
 
-The Mono interpreter also enables .NET Hot Reload for apps running on the Mono runtime. Because the interpreter can apply code changes at runtime, it allows you to modify C# source code while the app is running and see changes immediately. For this reason, `UseInterpreter` is set to `true` by default in `Debug` mode on Android, iOS, and Mac Catalyst.
+The Mono interpreter also enables .NET Hot Reload for apps running on the Mono
+runtime. `UseInterpreter` is set to `true` by default in `Debug` mode on
+Android, iOS, and Mac Catalyst.
 
-> [!NOTE]
-> On CoreCLR (Windows and experimentally Android/iOS), Hot Reload is supported through [Edit and Continue](/visualstudio/debugger/edit-and-continue-visual-csharp) without needing the interpreter. CoreCLR supports Hot Reload by default when debugging.
-
-- **Used by**: Mono runtime (enabled by default in debug builds on Android, iOS, and Mac Catalyst)
-- **Advantages**: Supports dynamic features that AOT can't handle, enables .NET Hot Reload, can reduce app size
+- **Used by**: Mono runtime
+- **Advantages**: Supports dynamic features that AOT can't handle, enables
+  .NET Hot Reload, and can reduce app size
 - **Disadvantages**: Interpreted code runs slower than compiled code
 - **MSBuild property**: `<UseInterpreter>true</UseInterpreter>`
 
 For more information, see [Mono interpreter on iOS and Mac Catalyst](~/macios/interpreter.md).
 
+::: moniker-end
+
+::: moniker range=">=net-maui-11.0"
+
+### CoreCLR interpreter
+
+The CoreCLR interpreter is used on Apple device targets because those platforms
+don't allow JIT-generated code. Apple CoreCLR apps use ReadyToRun for most
+methods and the interpreter for code that isn't precompiled. This behavior is
+part of the runtime and doesn't require an interpreter MSBuild property.
+
+::: moniker-end
+
 ## What .NET MAUI uses by default
 
-The following table summarizes which runtime and compilation strategy .NET MAUI uses on each platform, by build configuration:
+::: moniker range="<=net-maui-10.0"
+
+The following table summarizes which runtime and compilation strategy .NET MAUI
+uses on each platform, by build configuration:
 
 | Platform | Debug | Release |
 |---|---|---|
@@ -117,14 +279,48 @@ The following table summarizes which runtime and compilation strategy .NET MAUI 
 | **Windows** | CoreCLR + JIT | CoreCLR + JIT + ReadyToRun |
 
 > [!NOTE]
-> When you opt in to CoreCLR on Android or iOS by setting `<UseMonoRuntime>false</UseMonoRuntime>` in your project file, builds use ReadyToRun by default. On iOS and Mac Catalyst with CoreCLR, composite ReadyToRun is always enabled for both debug and release builds.
+> When you opt in to CoreCLR on Android or iOS by setting
+> `<UseMonoRuntime>false</UseMonoRuntime>` in your project file, builds use
+> ReadyToRun by default. On iOS and Mac Catalyst with CoreCLR, composite
+> ReadyToRun is enabled for both debug and release builds.
 
 > [!TIP]
-> You can opt in to NativeAOT on iOS and Mac Catalyst by setting `<PublishAot>true</PublishAot>` in your project file. NativeAOT only takes effect when publishing — a plain debug build doesn't use NativeAOT, because NativeAOT doesn't support debugging. For more information, see [Native AOT deployment on iOS and Mac Catalyst](nativeaot.md).
+> You can opt in to NativeAOT on iOS and Mac Catalyst by setting
+> `<PublishAot>true</PublishAot>` in your project file. NativeAOT only takes
+> effect when publishing.
+
+::: moniker-end
+
+::: moniker range=">=net-maui-11.0"
+
+The following table summarizes the runtime and compilation strategy used by
+.NET MAUI on each platform:
+
+| Platform | Debug | Release |
+|---|---|---|
+| **Android** | CoreCLR + JIT | CoreCLR + composite partial ReadyToRun + JIT |
+| **iOS** | CoreCLR + composite ReadyToRun + interpreter | CoreCLR + composite ReadyToRun + interpreter |
+| **Mac Catalyst** | CoreCLR + composite ReadyToRun + interpreter | CoreCLR + composite ReadyToRun + interpreter |
+| **tvOS** | CoreCLR + composite ReadyToRun + interpreter | CoreCLR + composite ReadyToRun + interpreter |
+| **Windows** | CoreCLR + JIT | CoreCLR + JIT + ReadyToRun |
+
+> [!IMPORTANT]
+> Don't set `UseMonoRuntime` to `true` when targeting .NET 11. Mono isn't
+> supported, and setting this property produces a build error.
+
+> [!TIP]
+> NativeAOT is enabled with `<PublishAot>true</PublishAot>` and takes effect
+> when you use `dotnet publish`. NativeAOT has no JIT or interpreter and
+> requires full trimming.
+
+::: moniker-end
 
 ## Comparison
 
-The following table compares the compilation strategies available for .NET MAUI apps:
+::: moniker range="<=net-maui-10.0"
+
+The following table compares the compilation strategies available for .NET
+MAUI apps:
 
 | Strategy | JIT | Mono AOT | ReadyToRun | NativeAOT |
 |---|---|---|---|---|
@@ -138,7 +334,9 @@ The following table compares the compilation strategies available for .NET MAUI 
 
 ### Typical performance
 
-The following benchmarks are from a `dotnet new maui` app and are hardware-dependent. They illustrate the relative differences between runtimes and are not absolute guarantees.
+The following benchmarks are from a `dotnet new maui` app and are
+hardware-dependent. They illustrate relative differences between runtimes and
+aren't absolute guarantees.
 
 **Startup time (milliseconds):**
 
@@ -155,9 +353,30 @@ The following benchmarks are from a `dotnet new maui` app and are hardware-depen
 | Mono (full trimming) | ~11.5 |
 | NativeAOT | ~5.4 |
 
-## CoreCLR on Android and iOS
+::: moniker-end
 
-Starting in .NET 10, you can opt in to running your Android app on the CoreCLR runtime instead of Mono. In .NET 11, CoreCLR is also available as an experimental option for iOS.
+::: moniker range=">=net-maui-11.0"
+
+The following table compares the compilation strategies available for .NET
+MAUI apps targeting .NET 11:
+
+| Strategy | CoreCLR JIT | CoreCLR interpreter | ReadyToRun | NativeAOT |
+|---|---|---|---|---|
+| **Compilation time** | At runtime | At runtime | At build time | At build time |
+| **Startup speed** | Slower | Slower | Fast | Fastest |
+| **App size** | Smaller | Smaller | Larger | Smallest |
+| **Dynamic code** | Full support | Full support | Full support (retains CoreCLR runtime compilation) | Not supported |
+| **Diagnostics** | Full | Full | Limited | Limited |
+
+::: moniker-end
+
+## CoreCLR on Android and Apple platforms
+
+::: moniker range="<=net-maui-10.0"
+
+Starting in .NET 10, you can opt in to running an Android app on CoreCLR
+instead of Mono. CoreCLR is also available as an experimental option for
+selected Apple targets.
 
 ```xml
 <PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
@@ -165,46 +384,79 @@ Starting in .NET 10, you can opt in to running your Android app on the CoreCLR r
 </PropertyGroup>
 ```
 
-CoreCLR brings improved compatibility with the rest of .NET and shorter startup times. In .NET 10, CoreCLR on Android is an experimental feature and isn't intended for production use. In .NET 11, CoreCLR becomes the default runtime for Android `Release` builds, and is available as an experimental option for iOS.
+In .NET 10, CoreCLR on Android is an experimental feature and isn't intended
+for production use.
 
-To opt out of CoreCLR and continue using Mono in .NET 11 and later:
+::: moniker-end
 
-```xml
-<PropertyGroup>
-    <UseMonoRuntime>true</UseMonoRuntime>
-</PropertyGroup>
-```
+::: moniker range=">=net-maui-11.0"
+
+In .NET 11, CoreCLR is the supported runtime for Android, iOS, Mac Catalyst,
+and tvOS apps unless NativeAOT is explicitly enabled for publishing. NativeAOT
+is an opt-in alternative that doesn't use CoreCLR. Don't set
+`UseMonoRuntime=true`; Mono isn't supported for .NET 11, and setting the
+property produces a build error.
+
+::: moniker-end
 
 ### Inside an Android APK
 
-The contents of your APK differ depending on which runtime and compilation strategy your app uses:
+::: moniker range="<=net-maui-10.0"
 
-**Mono (default):**
+The contents of an APK differ depending on which runtime and compilation
+strategy the app uses:
+
+**Mono:**
 
 - `classes.dex` — Java/Kotlin code
 - `lib/arm64-v8a/libmonosgen-2.0.so` — Mono runtime
-- `lib/arm64-v8a/libmonodroid.so` — Android-specific glue code for starting the runtime
-- `lib/arm64-v8a/libassemblies.arm64-v8a.blob.so` — Compressed, packed MSIL assemblies
-- `lib/arm64-v8a/libaot-*.dll.so` — Mono AOT native images (release builds)
+- `lib/arm64-v8a/libmonodroid.so` — Android-specific runtime startup glue
+- `lib/arm64-v8a/libassemblies.arm64-v8a.blob.so` — Compressed, packed MSIL
+  assemblies
+- `lib/arm64-v8a/libaot-*.dll.so` — Mono AOT native images in release builds
 
-**CoreCLR (experimental):**
+**CoreCLR:**
 
 - `classes.dex` — Java/Kotlin code
 - `lib/arm64-v8a/libcoreclr.so` — CoreCLR runtime
 - `lib/arm64-v8a/libclrjit.so` — CoreCLR JIT compiler
-- `lib/arm64-v8a/libmonodroid.so` — Android-specific glue code for starting the runtime
-- `lib/arm64-v8a/libassemblies.arm64-v8a.so` — Compressed, packed MSIL with ReadyToRun images
+- `lib/arm64-v8a/libmonodroid.so` — Android-specific runtime startup glue
+- `lib/arm64-v8a/libassemblies.arm64-v8a.so` — Packed MSIL with ReadyToRun
+  images
 
-**NativeAOT (experimental):**
+::: moniker-end
+
+::: moniker range=">=net-maui-11.0"
+
+The contents of an Android APK differ depending on whether the app uses
+CoreCLR or NativeAOT:
+
+**CoreCLR:**
 
 - `classes.dex` — Java/Kotlin code
-- `lib/arm64-v8a/libhellomaui.so` — Single native library containing the runtime, all managed code, and glue code
+- `lib/arm64-v8a/libcoreclr.so` — CoreCLR runtime
+- `lib/arm64-v8a/libclrjit.so` — CoreCLR JIT compiler
+- `lib/arm64-v8a/libmonodroid.so` — Android-specific runtime startup glue
+- `lib/arm64-v8a/libassemblies.arm64-v8a.so` — Packed MSIL with ReadyToRun
+  images
+
+**NativeAOT:**
+
+- `classes.dex` — Java/Kotlin code
+- `lib/arm64-v8a/libhellomaui.so` — Native library containing the runtime,
+  managed code, and startup glue
+
+::: moniker-end
 
 ## Trimming
 
-Trimming is a build step that removes unused code from your app to reduce its size. Trimming is relevant to all compilation strategies but is *required* for NativeAOT. .NET MAUI uses the ILLink trimmer, which analyzes your code and removes types, methods, and fields that aren't statically referenced.
+Trimming is a build step that removes unused code from your app to reduce its
+size. .NET MAUI uses the ILLink trimmer, which analyzes your code and removes
+types, methods, and fields that aren't statically referenced.
 
-.NET MAUI uses `TrimMode=partial` by default, which trims framework assemblies but not your code or NuGet references. You can opt in to full trimming:
+For non-NativeAOT builds, .NET MAUI uses `TrimMode=partial` by default, which
+trims framework assemblies but not your code or NuGet references. You can opt
+in to full trimming:
 
 ```xml
 <PropertyGroup>
@@ -212,20 +464,41 @@ Trimming is a build step that removes unused code from your app to reduce its si
 </PropertyGroup>
 ```
 
+NativeAOT automatically performs full trimming. Don't set `TrimMode` to select
+a different trimming mode when using NativeAOT.
+
 For more information, see [Trim a .NET MAUI app](trimming.md).
 
 ## MSBuild property reference
 
-The following table summarizes the MSBuild properties that control runtime and compilation behavior:
+::: moniker range="<=net-maui-10.0"
+
+The following table summarizes the MSBuild properties that control runtime and
+compilation behavior:
 
 | Property | Description | Default |
 |---|---|---|
 | `PublishAot` | Enable NativeAOT compilation. | `false` |
-| `PublishReadyToRun` | Enable ReadyToRun pre-compilation for CoreCLR. | `true` (Windows Release, iOS, Mac Catalyst) |
+| `PublishReadyToRun` | Enable ReadyToRun precompilation for CoreCLR. | `true` (Windows Release and applicable CoreCLR builds) |
 | `PublishTrimmed` | Enable ILLink trimming. | `true` (Release) |
 | `TrimMode` | Set trimming aggressiveness (`partial` or `full`). | `partial` |
 | `UseInterpreter` | Enable the Mono interpreter. | `true` (iOS/Mac Catalyst Debug) |
-| `UseMonoRuntime` | Use Mono instead of CoreCLR. | `true` (Android .NET 10, iOS, Mac Catalyst), `false` (Android .NET 11) |
+| `UseMonoRuntime` | Use Mono instead of CoreCLR. | `true` on supported Mono targets |
+
+::: moniker-end
+
+::: moniker range=">=net-maui-11.0"
+
+The following table summarizes the MSBuild properties relevant to .NET 11
+runtime and compilation behavior:
+
+| Property | Description | Default |
+|---|---|---|
+| `PublishAot` | Enable NativeAOT compilation during `dotnet publish`. | `false` |
+| `MauiEnableFullReadyToRun` | Enable full ReadyToRun for Android CoreCLR apps. | `false` |
+| `TrimMode` | Set trimming aggressiveness for non-NativeAOT builds. | `partial` |
+
+::: moniker-end
 
 ## See also
 

--- a/docs/deployment/runtimes-compilation.md
+++ b/docs/deployment/runtimes-compilation.md
@@ -479,6 +479,7 @@ compilation behavior:
 |---|---|---|
 | `PublishAot` | Enable NativeAOT compilation. | `false` |
 | `PublishReadyToRun` | Enable ReadyToRun precompilation for CoreCLR. | `true` (Windows Release and applicable CoreCLR builds) |
+| `PublishTrimmed` | Enable ILLink trimming. | `true` (Release) |
 | `TrimMode` | Set trimming aggressiveness (`partial` or `full`). | `partial` |
 | `UseInterpreter` | Enable the Mono interpreter. | `true` (iOS/Mac Catalyst Debug) |
 | `UseMonoRuntime` | Use Mono instead of CoreCLR. | `true` on supported Mono targets |
@@ -494,7 +495,6 @@ runtime and compilation behavior:
 |---|---|---|
 | `PublishAot` | Enable NativeAOT compilation during `dotnet publish`. | `false` |
 | `MauiEnableFullReadyToRun` | Enable full ReadyToRun for Android CoreCLR apps. | `false` |
-| `PublishTrimmed` | Enable ILLink trimming. | `true` (Release) |
 | `TrimMode` | Set trimming aggressiveness for non-NativeAOT builds. | `partial` |
 
 ::: moniker-end

--- a/docs/deployment/runtimes-compilation.md
+++ b/docs/deployment/runtimes-compilation.md
@@ -31,7 +31,7 @@ on mobile and Mac Catalyst platforms.
 
 ::: moniker range=">=net-maui-11.0"
 
-Mono isn't supported for .NET MAUI apps that target .NET 11.
+Mono isn't supported for .NET MAUI apps that target .NET 11+.
 
 ::: moniker-end
 
@@ -51,7 +51,7 @@ also available as an experimental option for Android.
 
 ::: moniker range=">=net-maui-11.0"
 
-In .NET 11, CoreCLR is the runtime for .NET MAUI apps on Windows, Android,
+In .NET 11+, CoreCLR is the runtime for .NET MAUI apps on Windows, Android,
 iOS, and Mac Catalyst. NativeAOT is an opt-in alternative for publishing.
 
 ::: moniker-end
@@ -137,8 +137,8 @@ restrictions on the code patterns you can use.
 - **Available on**: .NET MAUI iOS and Mac Catalyst apps when explicitly
   enabled for publishing
 - **Advantages**: Small app size, fast startup, and a single native binary
-- **Disadvantages**: No dynamic code generation or dynamic loading; all code
-  must be trim-safe and AOT-compatible
+- **Disadvantages**: Longer build times, no dynamic code generation or dynamic
+  loading, and all code must be trim-safe and AOT-compatible
 - **MSBuild property**: `<PublishAot>true</PublishAot>`
 
 ::: moniker-end
@@ -148,8 +148,8 @@ restrictions on the code patterns you can use.
 - **Available on**: .NET MAUI iOS and Mac Catalyst apps, and experimentally
   on Android, when explicitly enabled for publishing
 - **Advantages**: Small app size, fast startup, and a single native binary
-- **Disadvantages**: No dynamic code generation or dynamic loading; all code
-  must be trim-safe and AOT-compatible
+- **Disadvantages**: Longer build times, no dynamic code generation or dynamic
+  loading, and all code must be trim-safe and AOT-compatible
 - **MSBuild property**: `<PublishAot>true</PublishAot>`
 
 NativeAOT is a publish-only deployment model. Use `dotnet publish` to produce
@@ -197,7 +197,8 @@ can be enabled with `MauiEnableFullReadyToRun=true`. It can improve startup or
 runtime performance, but it increases package size, so measure the result for
 your app.
 
-For iOS and Mac Catalyst apps, full composite ReadyToRun is used. On iOS, the
+For iOS and Mac Catalyst apps, partial composite ReadyToRun is used in `Debug`
+builds and full composite ReadyToRun is used in `Release` builds. On iOS, the
 CoreCLR interpreter is always enabled and executes code where the operating
 system doesn't permit JIT compilation.
 
@@ -299,12 +300,12 @@ The following table summarizes the runtime and compilation strategy used by
 | Platform | Debug | Release |
 |---|---|---|
 | **Android** | CoreCLR + JIT | CoreCLR + partial composite ReadyToRun + JIT |
-| **iOS** | CoreCLR + full composite ReadyToRun + interpreter | CoreCLR + full composite ReadyToRun + interpreter |
-| **Mac Catalyst** | CoreCLR + full composite ReadyToRun + interpreter | CoreCLR + full composite ReadyToRun + interpreter |
+| **iOS** | CoreCLR + partial composite ReadyToRun + interpreter | CoreCLR + full composite ReadyToRun + interpreter |
+| **Mac Catalyst** | CoreCLR + partial composite ReadyToRun + interpreter | CoreCLR + full composite ReadyToRun + interpreter |
 | **Windows** | CoreCLR + JIT | CoreCLR + JIT + ReadyToRun |
 
 > [!IMPORTANT]
-> Don't set `UseMonoRuntime` to `true` when targeting .NET 11. Mono isn't
+> Don't set `UseMonoRuntime` to `true` when targeting .NET 11+. Mono isn't
 > supported, and setting this property produces a build error.
 
 > [!TIP]
@@ -389,11 +390,11 @@ for production use.
 
 ::: moniker range=">=net-maui-11.0"
 
-In .NET 11, CoreCLR is the supported runtime for Android, iOS, and Mac
+In .NET 11+, CoreCLR is the supported runtime for Android, iOS, and Mac
 Catalyst apps unless NativeAOT is explicitly enabled for publishing. NativeAOT
 is an opt-in alternative that doesn't use CoreCLR and remains experimental on
 Android. Don't set
-`UseMonoRuntime=true`; Mono isn't supported for .NET 11, and setting the
+`UseMonoRuntime=true`; Mono isn't supported for .NET 11+, and setting the
 property produces a build error.
 
 ::: moniker-end
@@ -495,6 +496,7 @@ runtime and compilation behavior:
 |---|---|---|
 | `PublishAot` | Enable NativeAOT compilation during `dotnet publish`. | `false` |
 | `MauiEnableFullReadyToRun` | Enable full ReadyToRun for Android CoreCLR apps. | `false` |
+| `PublishTrimmed` | Enable ILLink trimming. | `true` (Release) |
 | `TrimMode` | Set trimming aggressiveness for non-NativeAOT builds. | `partial` |
 
 ::: moniker-end

--- a/docs/deployment/runtimes-compilation.md
+++ b/docs/deployment/runtimes-compilation.md
@@ -52,9 +52,8 @@ also available as an experimental option for Android.
 
 ::: moniker range=">=net-maui-11.0"
 
-In .NET 11, CoreCLR is the only supported runtime for .NET MAUI apps on
-Android, iOS, Mac Catalyst, and tvOS unless the app is published with
-NativeAOT.
+In .NET 11, CoreCLR is the runtime for .NET MAUI apps on Windows, Android,
+iOS, and Mac Catalyst. NativeAOT is an opt-in alternative for publishing.
 
 ::: moniker-end
 
@@ -188,7 +187,7 @@ are packed inside the `.dll` files.
 
 ::: moniker range=">=net-maui-11.0"
 
-- **Used by**: CoreCLR on Windows, Android, iOS, Mac Catalyst, and tvOS
+- **Used by**: CoreCLR on Windows, Android, iOS, and Mac Catalyst
 - **Advantages**: Improved startup time while retaining the appropriate
   runtime compilation behavior
 - **Disadvantages**: Larger application and download sizes
@@ -301,7 +300,6 @@ The following table summarizes the runtime and compilation strategy used by
 | **Android** | CoreCLR + JIT | CoreCLR + composite partial ReadyToRun + JIT |
 | **iOS** | CoreCLR + composite ReadyToRun + interpreter | CoreCLR + composite ReadyToRun + interpreter |
 | **Mac Catalyst** | CoreCLR + composite ReadyToRun + interpreter | CoreCLR + composite ReadyToRun + interpreter |
-| **tvOS** | CoreCLR + composite ReadyToRun + interpreter | CoreCLR + composite ReadyToRun + interpreter |
 | **Windows** | CoreCLR + JIT | CoreCLR + JIT + ReadyToRun |
 
 > [!IMPORTANT]
@@ -391,8 +389,8 @@ for production use.
 
 ::: moniker range=">=net-maui-11.0"
 
-In .NET 11, CoreCLR is the supported runtime for Android, iOS, Mac Catalyst,
-and tvOS apps unless NativeAOT is explicitly enabled for publishing. NativeAOT
+In .NET 11, CoreCLR is the supported runtime for Android, iOS, and Mac
+Catalyst apps unless NativeAOT is explicitly enabled for publishing. NativeAOT
 is an opt-in alternative that doesn't use CoreCLR. Don't set
 `UseMonoRuntime=true`; Mono isn't supported for .NET 11, and setting the
 property produces a build error.
@@ -454,9 +452,9 @@ Trimming is a build step that removes unused code from your app to reduce its
 size. .NET MAUI uses the ILLink trimmer, which analyzes your code and removes
 types, methods, and fields that aren't statically referenced.
 
-For non-NativeAOT builds, .NET MAUI uses `TrimMode=partial` by default, which
-trims framework assemblies but not your code or NuGet references. You can opt
-in to full trimming:
+For non-NativeAOT Release and publish builds, .NET MAUI uses
+`TrimMode=partial` by default, which trims framework assemblies but not your
+code or NuGet references. To use full trimming, set `TrimMode` to `full`:
 
 ```xml
 <PropertyGroup>

--- a/docs/deployment/runtimes-compilation.md
+++ b/docs/deployment/runtimes-compilation.md
@@ -439,7 +439,7 @@ CoreCLR or NativeAOT:
 - `lib/arm64-v8a/libassemblies.arm64-v8a.so` — Packed MSIL with ReadyToRun
   images
 
-**NativeAOT (experimental):**
+**NativeAOT on Android (experimental):**
 
 - `classes.dex` — Java/Kotlin code
 - `lib/arm64-v8a/libhellomaui.so` — Native library containing the runtime,

--- a/docs/supported-platforms.md
+++ b/docs/supported-platforms.md
@@ -1,7 +1,7 @@
 ---
 title: "Supported platforms for .NET MAUI apps"
 description: ".NET MAUI supports developing apps for Android, iOS, Mac Catalyst, and Windows."
-ms.date: 04/02/2026
+ms.date: 09/08/2026
 ---
 
 # Supported platforms for .NET MAUI apps
@@ -46,7 +46,8 @@ ms.date: 04/02/2026
 - Windows 11 and Windows 10 version 1809 or higher, using [Windows UI Library (WinUI) 3](/windows/apps/winui/winui3/).
 
 > [!NOTE]
-> Android API levels 21–23 are still supported when using the Mono runtime. For more information, see [Minimum supported Android API](whats-new/dotnet-11.md#minimum-supported-android-api).
+> .NET MAUI apps that target .NET 11 require Android API level 24 or higher.
+> For more information, see [Minimum supported Android API](whats-new/dotnet-11.md#minimum-supported-android-api).
 
 .NET MAUI Blazor apps have the following additional platform requirements:
 

--- a/docs/whats-new/dotnet-11.md
+++ b/docs/whats-new/dotnet-11.md
@@ -600,9 +600,9 @@ In .NET 11 Preview 4, CoreCLR became the default runtime for .NET for iOS,
 Mac Catalyst, and macOS, while Mono remained available. Starting in .NET 11
 Preview 7, CoreCLR is the only supported runtime for these platforms.
 On iOS and Mac Catalyst, CoreCLR uses composite partial ReadyToRun in `Debug`
-builds and composite full ReadyToRun in `Release` builds. On iOS, the CoreCLR
-interpreter is always enabled and executes code where the operating system
-doesn't permit JIT compilation.
+builds and composite full ReadyToRun in `Release` builds. The CoreCLR
+interpreter is always enabled and executes code that isn't precompiled because
+these platforms don't permit JIT compilation.
 For more information, see [CoreCLR is the only runtime](#coreclr-is-the-only-runtime)
 and [dotnet/macios #25050](https://github.com/dotnet/macios/pull/25050).
 

--- a/docs/whats-new/dotnet-11.md
+++ b/docs/whats-new/dotnet-11.md
@@ -483,7 +483,7 @@ For more information, see [Supported platforms](~/supported-platforms.md).
 
 ### CoreCLR runtime
 
-In `Release` builds, the runtime uses partial composite ReadyToRun by default.
+In `Release` builds, the runtime uses composite partial ReadyToRun by default.
 `Debug` builds don't enable ReadyToRun by default.
 
 ### Faster and more reliable Android builds
@@ -599,8 +599,8 @@ Starting in .NET 11 Preview 4, HTTP digest authentication is supported in <xref:
 In .NET 11 Preview 4, CoreCLR became the default runtime for .NET for iOS,
 Mac Catalyst, and macOS, while Mono remained available. Starting in .NET 11
 Preview 7, CoreCLR is the only supported runtime for these platforms.
-On iOS and Mac Catalyst, CoreCLR uses partial composite ReadyToRun in `Debug`
-builds and full composite ReadyToRun in `Release` builds. On iOS, the CoreCLR
+On iOS and Mac Catalyst, CoreCLR uses composite partial ReadyToRun in `Debug`
+builds and composite full ReadyToRun in `Release` builds. On iOS, the CoreCLR
 interpreter is always enabled and executes code where the operating system
 doesn't permit JIT compilation.
 For more information, see [CoreCLR is the only runtime](#coreclr-is-the-only-runtime)

--- a/docs/whats-new/dotnet-11.md
+++ b/docs/whats-new/dotnet-11.md
@@ -596,8 +596,8 @@ Starting in .NET 11 Preview 4, HTTP digest authentication is supported in <xref:
 ### CoreCLR for Apple platforms
 
 In .NET 11 Preview 4, CoreCLR became the default runtime for .NET for iOS,
-Mac Catalyst, macOS, and tvOS, while Mono remained available. Starting in
-.NET 11 Preview 7, CoreCLR is the only supported runtime for these platforms.
+Mac Catalyst, and macOS, while Mono remained available. Starting in .NET 11
+Preview 7, CoreCLR is the only supported runtime for these platforms.
 Apple CoreCLR uses ReadyToRun and the CoreCLR interpreter; it doesn't use JIT.
 For more information, see [CoreCLR is the only runtime](#coreclr-is-the-only-runtime)
 and [dotnet/macios #25050](https://github.com/dotnet/macios/pull/25050).

--- a/docs/whats-new/dotnet-11.md
+++ b/docs/whats-new/dotnet-11.md
@@ -1,7 +1,7 @@
 ---
 title: What's new in .NET MAUI for .NET 11
 description: Learn about the new features introduced in .NET MAUI for .NET 11.
-ms.date: 09/08/2026
+ms.date: 09/10/2026
 ---
 
 # What's new in .NET MAUI for .NET 11
@@ -456,7 +456,8 @@ Starting in .NET 11 Preview 7, the XAML source generator compiles a binding that
 ## .NET for Android
 
 .NET for Android in .NET 11 uses CoreCLR as the supported runtime for
-standard apps. NativeAOT is also available as an opt-in publishing alternative.
+standard apps. NativeAOT is also available as an experimental, opt-in
+publishing alternative.
 This release includes work to improve performance. For more information about
 .NET for Android in .NET 11, see the following release notes:
 
@@ -482,7 +483,7 @@ For more information, see [Supported platforms](~/supported-platforms.md).
 
 ### CoreCLR runtime
 
-In `Release` builds, the runtime uses composite partial ReadyToRun by default.
+In `Release` builds, the runtime uses partial composite ReadyToRun by default.
 `Debug` builds don't enable ReadyToRun by default.
 
 ### Faster and more reliable Android builds
@@ -598,7 +599,9 @@ Starting in .NET 11 Preview 4, HTTP digest authentication is supported in <xref:
 In .NET 11 Preview 4, CoreCLR became the default runtime for .NET for iOS,
 Mac Catalyst, and macOS, while Mono remained available. Starting in .NET 11
 Preview 7, CoreCLR is the only supported runtime for these platforms.
-Apple CoreCLR uses ReadyToRun and the CoreCLR interpreter; it doesn't use JIT.
+On iOS and Mac Catalyst, CoreCLR uses full composite ReadyToRun. On iOS, the
+CoreCLR interpreter is always enabled and executes code where the operating
+system doesn't permit JIT compilation.
 For more information, see [CoreCLR is the only runtime](#coreclr-is-the-only-runtime)
 and [dotnet/macios #25050](https://github.com/dotnet/macios/pull/25050).
 

--- a/docs/whats-new/dotnet-11.md
+++ b/docs/whats-new/dotnet-11.md
@@ -1,7 +1,7 @@
 ---
 title: What's new in .NET MAUI for .NET 11
 description: Learn about the new features introduced in .NET MAUI for .NET 11.
-ms.date: 09/02/2026
+ms.date: 09/08/2026
 ---
 
 # What's new in .NET MAUI for .NET 11
@@ -21,9 +21,15 @@ The focus of .NET Multi-platform App UI (.NET MAUI) in .NET 11 is to improve pro
 
 In .NET 11, .NET MAUI ships as a .NET workload and multiple NuGet packages. The advantage of this approach is that it enables you to easily pin your projects to specific versions, while also enabling you to easily preview unreleased or experimental builds.
 
-## CoreCLR is the default runtime
+## CoreCLR is the only runtime
 
-Starting in .NET 11 Preview 4, CoreCLR is the default runtime on all .NET MAUI platforms for projects built with and targeting .NET 11. This unifies the runtime across .NET MAUI with benefits for debugging, profiling, Hot Reload, app size, and app performance. For a detailed overview of this transition, see the [announcement blog post](https://aka.ms/maui-coreclr).
+In .NET 11 Preview 4, CoreCLR became the default runtime on all .NET MAUI
+platforms for projects built with and targeting .NET 11, while Mono remained
+available. Starting in .NET 11 Preview 7, CoreCLR is the only supported
+runtime for .NET 11 applications. This unifies the runtime across .NET MAUI
+and provides benefits for debugging, profiling, Hot Reload, app size, and app
+performance. For a detailed overview of this transition, see the
+[announcement blog post](https://aka.ms/maui-coreclr).
 
 ## Testing
 
@@ -449,7 +455,10 @@ Starting in .NET 11 Preview 7, the XAML source generator compiles a binding that
 
 ## .NET for Android
 
-.NET for Android in .NET 11 makes CoreCLR the default runtime for `Release` builds, and includes work to improve performance. For more information about .NET for Android in .NET 11, see the following release notes:
+.NET for Android in .NET 11 uses CoreCLR as the supported runtime for
+standard apps. NativeAOT is also available as an opt-in publishing alternative.
+This release includes work to improve performance. For more information about
+.NET for Android in .NET 11, see the following release notes:
 
 - [.NET for Android 11 Preview 1](https://github.com/dotnet/android/releases/)
 - [.NET for Android 11 Preview 3](https://github.com/dotnet/android/releases/)
@@ -466,10 +475,15 @@ If your project explicitly sets `$(SupportedOSPlatformVersion)` to a value lower
 </PropertyGroup>
 ```
 
+Android x86 isn't supported in .NET 11. Android arm32 (`armeabi-v7a`) remains
+supported.
+
 For more information, see [Supported platforms](~/supported-platforms.md).
 
-> [!NOTE]
-> Android API levels 21, 22, and 23 are only supported when using the Mono runtime.
+### CoreCLR runtime
+
+In `Release` builds, the runtime uses composite partial ReadyToRun by default.
+`Debug` builds don't enable ReadyToRun by default.
 
 ### Faster and more reliable Android builds
 
@@ -500,7 +514,7 @@ A single-page Shell app also defers unused tab infrastructure. In a matched 80-l
 - `Java.Lang.Object.JavaFinalize()` is obsolete. Override `Dispose(bool)` or use a C# finalizer instead. For more information, see [GitHub PR #11424](https://github.com/dotnet/android/pull/11424).
 - If an Android manifest has a partial `<uses-sdk>` element without `android:targetSdkVersion`, the build now writes the value from `$(TargetSdkVersion)`. Android previously used the minimum SDK as the target SDK in this case. Test behavior that Android gates by target SDK, or set `android:targetSdkVersion` explicitly. For more information, see [GitHub PR #12290](https://github.com/dotnet/android/pull/12290).
 
-## CoreCLR by Default
+### CoreCLR by Default
 
 CoreCLR is now the default runtime for `Release` builds. This should
 improve compatibility with the rest of .NET as well as shorter startup
@@ -581,7 +595,12 @@ Starting in .NET 11 Preview 4, HTTP digest authentication is supported in <xref:
 
 ### CoreCLR for Apple platforms
 
-Starting in .NET 11 Preview 4, CoreCLR is the default runtime for .NET for iOS, Mac Catalyst, macOS, and tvOS. For more information, see [CoreCLR is the default runtime](#coreclr-is-the-default-runtime) and [dotnet/macios #25050](https://github.com/dotnet/macios/pull/25050).
+In .NET 11 Preview 4, CoreCLR became the default runtime for .NET for iOS,
+Mac Catalyst, macOS, and tvOS, while Mono remained available. Starting in
+.NET 11 Preview 7, CoreCLR is the only supported runtime for these platforms.
+Apple CoreCLR uses ReadyToRun and the CoreCLR interpreter; it doesn't use JIT.
+For more information, see [CoreCLR is the only runtime](#coreclr-is-the-only-runtime)
+and [dotnet/macios #25050](https://github.com/dotnet/macios/pull/25050).
 
 Preview 4 also includes a broad reliability and packaging pass across `NSUrlSessionHandler`, MSBuild, the linker, and runtime internals. For the complete list of changes, see the [Preview 4 changelog](https://github.com/dotnet/macios/compare/release/11.0.1xx-preview3...release/11.0.1xx-preview4).
 

--- a/docs/whats-new/dotnet-11.md
+++ b/docs/whats-new/dotnet-11.md
@@ -599,9 +599,10 @@ Starting in .NET 11 Preview 4, HTTP digest authentication is supported in <xref:
 In .NET 11 Preview 4, CoreCLR became the default runtime for .NET for iOS,
 Mac Catalyst, and macOS, while Mono remained available. Starting in .NET 11
 Preview 7, CoreCLR is the only supported runtime for these platforms.
-On iOS and Mac Catalyst, CoreCLR uses full composite ReadyToRun. On iOS, the
-CoreCLR interpreter is always enabled and executes code where the operating
-system doesn't permit JIT compilation.
+On iOS and Mac Catalyst, CoreCLR uses partial composite ReadyToRun in `Debug`
+builds and full composite ReadyToRun in `Release` builds. On iOS, the CoreCLR
+interpreter is always enabled and executes code where the operating system
+doesn't permit JIT compilation.
 For more information, see [CoreCLR is the only runtime](#coreclr-is-the-only-runtime)
 and [dotnet/macios #25050](https://github.com/dotnet/macios/pull/25050).
 


### PR DESCRIPTION
## Summary

Updates the .NET MAUI runtime and compilation guidance for .NET 11 while
preserving the existing .NET 10 and earlier Mono guidance.

- Documents CoreCLR as the supported runtime for normal .NET 11 MAUI apps.
- Clarifies that NativeAOT is an explicit, opt-in publishing alternative.
- Removes .NET 11 Mono and `UseMonoRuntime` guidance.
- Documents Android .NET 11 platform and runtime behavior:
  - Android API 24 or higher.
  - Android x86 is unsupported; arm32 remains supported.
  - Release builds use composite partial ReadyToRun with JIT support.
  - Full ReadyToRun is enabled with `MauiEnableFullReadyToRun=true`.
- Documents Apple CoreCLR behavior:
  - ReadyToRun is used with the CoreCLR interpreter.
  - Apple device targets do not use JIT.
- Clarifies NativeAOT, trimming, ReadyToRun, diagnostics, and compilation
  strategy comparisons.
- Updates the .NET 11 release notes.

## Migration guidance

- Existing .NET 10 and earlier Mono guidance is unchanged.
- Projects targeting .NET 11 must not set `UseMonoRuntime=true`.
- NativeAOT must be explicitly enabled with `PublishAot=true` and takes effect
  during `dotnet publish`.
- NativeAOT requires full trimming and does not use a JIT or interpreter.

The standalone interpreter, profiling, and detailed NativeAOT pages remain
outside this focused update.

## Validation

- Built and previewed the documentation locally with DocFX.
- Checked moniker block balance and diff whitespace.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [docs/deployment/runtimes-compilation.md](https://github.com/dotnet/docs-maui/blob/4976b386999ac72c4d2ad859b63b2c0a79b83556/docs/deployment/runtimes-compilation.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/maui/deployment/runtimes-compilation?view=net-maui-11.0&branch=pr-en-us-3511) |
| [docs/supported-platforms.md](https://github.com/dotnet/docs-maui/blob/4976b386999ac72c4d2ad859b63b2c0a79b83556/docs/supported-platforms.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/maui/supported-platforms?view=net-maui-11.0&branch=pr-en-us-3511) |
| [docs/whats-new/dotnet-11.md](https://github.com/dotnet/docs-maui/blob/4976b386999ac72c4d2ad859b63b2c0a79b83556/docs/whats-new/dotnet-11.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/maui/whats-new/dotnet-11?view=net-maui-11.0&branch=pr-en-us-3511) |


<!-- PREVIEW-TABLE-END -->

[Build report](https://buildapi.docs.microsoft.com/Output/PullRequest/a552e5fb-82af-ee54-cd17-c63b0b54d6f7/202609141147039842-3511/BuildReport?accessString=0f86502ac30519b94bf8eab4b7695b21f144dd83b876710e10dbbbac609c7581)