### PR TITLE
Refine .NET 11 runtime guidance on top of #3511

### DIFF
--- a/docs/deployment/runtimes-compilation.md
+++ b/docs/deployment/runtimes-compilation.md
@@ -1,7 +1,7 @@
 ---
 title: "Runtimes and compilation in .NET MAUI"
 description: "Learn about the runtimes and compilation strategies used by .NET MAUI apps, including CoreCLR, NativeAOT, ReadyToRun, and interpreters."
-ms.date: 09/08/2026
+ms.date: 09/10/2026
 ---
 
 # Runtimes and compilation in .NET MAUI
@@ -145,8 +145,8 @@ restrictions on the code patterns you can use.
 
 ::: moniker range=">=net-maui-11.0"
 
-- **Available on**: .NET MAUI apps targeting .NET 11 when explicitly enabled
-  for publishing
+- **Available on**: .NET MAUI iOS and Mac Catalyst apps, and experimentally
+  on Android, when explicitly enabled for publishing
 - **Advantages**: Small app size, fast startup, and a single native binary
 - **Disadvantages**: No dynamic code generation or dynamic loading; all code
   must be trim-safe and AOT-compatible
@@ -192,20 +192,21 @@ are packed inside the `.dll` files.
 - **Disadvantages**: Larger application and download sizes
 
 For Android apps, ReadyToRun is enabled by default in the `Release`
-configuration. The default is composite partial ReadyToRun. Full ReadyToRun
+configuration. The default is partial composite ReadyToRun. Full ReadyToRun
 can be enabled with `MauiEnableFullReadyToRun=true`. It can improve startup or
 runtime performance, but it increases package size, so measure the result for
 your app.
 
-For Apple apps, composite ReadyToRun is used with the CoreCLR
-interpreter for code that isn't precompiled. Apple device targets don't use
-JIT.
+For iOS and Mac Catalyst apps, full composite ReadyToRun is used. On iOS, the
+CoreCLR interpreter is always enabled and executes code where the operating
+system doesn't permit JIT compilation.
 
 ::: moniker-end
 
 *Composite* R2R compiles assemblies together, enabling cross-assembly
 optimizations. *Partial* R2R precompiles selected methods while leaving the
-remaining methods for runtime compilation.
+remaining methods for runtime compilation, while *full* R2R precompiles all
+methods.
 
 For more information, see [ReadyToRun compilation](/dotnet/core/deploying/ready-to-run).
 
@@ -255,10 +256,11 @@ For more information, see [Mono interpreter on iOS and Mac Catalyst](~/macios/in
 
 ### CoreCLR interpreter
 
-The CoreCLR interpreter is used on Apple device targets because those platforms
-don't allow JIT-generated code. Apple CoreCLR apps use ReadyToRun for most
-methods and the interpreter for code that isn't precompiled. This behavior is
-part of the runtime and doesn't require an interpreter MSBuild property.
+CoreCLR includes an interpreter on iOS and Mac Catalyst. On iOS, the
+interpreter is always enabled and executes code where the operating system
+doesn't permit JIT compilation. On Mac Catalyst, it provides a fallback when
+JIT compilation isn't permitted. This behavior is part of the runtime and
+doesn't require an interpreter MSBuild property.
 
 ::: moniker-end
 
@@ -296,9 +298,9 @@ The following table summarizes the runtime and compilation strategy used by
 
 | Platform | Debug | Release |
 |---|---|---|
-| **Android** | CoreCLR + JIT | CoreCLR + composite partial ReadyToRun + JIT |
-| **iOS** | CoreCLR + composite ReadyToRun + interpreter | CoreCLR + composite ReadyToRun + interpreter |
-| **Mac Catalyst** | CoreCLR + composite ReadyToRun + interpreter | CoreCLR + composite ReadyToRun + interpreter |
+| **Android** | CoreCLR + JIT | CoreCLR + partial composite ReadyToRun + JIT |
+| **iOS** | CoreCLR + full composite ReadyToRun + interpreter | CoreCLR + full composite ReadyToRun + interpreter |
+| **Mac Catalyst** | CoreCLR + full composite ReadyToRun + interpreter | CoreCLR + full composite ReadyToRun + interpreter |
 | **Windows** | CoreCLR + JIT | CoreCLR + JIT + ReadyToRun |
 
 > [!IMPORTANT]
@@ -367,13 +369,12 @@ MAUI apps targeting .NET 11:
 
 ::: moniker-end
 
-## CoreCLR on Android and Apple platforms
+## CoreCLR on Android and iOS
 
 ::: moniker range="<=net-maui-10.0"
 
 Starting in .NET 10, you can opt in to running an Android app on CoreCLR
-instead of Mono. CoreCLR is also available as an experimental option for
-selected Apple targets.
+instead of Mono.
 
 ```xml
 <PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
@@ -390,7 +391,8 @@ for production use.
 
 In .NET 11, CoreCLR is the supported runtime for Android, iOS, and Mac
 Catalyst apps unless NativeAOT is explicitly enabled for publishing. NativeAOT
-is an opt-in alternative that doesn't use CoreCLR. Don't set
+is an opt-in alternative that doesn't use CoreCLR and remains experimental on
+Android. Don't set
 `UseMonoRuntime=true`; Mono isn't supported for .NET 11, and setting the
 property produces a build error.
 
@@ -437,7 +439,7 @@ CoreCLR or NativeAOT:
 - `lib/arm64-v8a/libassemblies.arm64-v8a.so` — Packed MSIL with ReadyToRun
   images
 
-**NativeAOT:**
+**NativeAOT (experimental):**
 
 - `classes.dex` — Java/Kotlin code
 - `lib/arm64-v8a/libhellomaui.so` — Native library containing the runtime,

--- a/docs/deployment/runtimes-compilation.md
+++ b/docs/deployment/runtimes-compilation.md
@@ -192,13 +192,13 @@ are packed inside the `.dll` files.
 - **Disadvantages**: Larger application and download sizes
 
 For Android apps, ReadyToRun is enabled by default in the `Release`
-configuration. The default is partial composite ReadyToRun. Full ReadyToRun
+configuration. The default is composite partial ReadyToRun. Full ReadyToRun
 can be enabled with `MauiEnableFullReadyToRun=true`. It can improve startup or
 runtime performance, but it increases package size, so measure the result for
 your app.
 
-For iOS and Mac Catalyst apps, partial composite ReadyToRun is used in `Debug`
-builds and full composite ReadyToRun is used in `Release` builds. On iOS, the
+For iOS and Mac Catalyst apps, composite partial ReadyToRun is used in `Debug`
+builds and composite full ReadyToRun is used in `Release` builds. On iOS, the
 CoreCLR interpreter is always enabled and executes code where the operating
 system doesn't permit JIT compilation.
 
@@ -299,9 +299,9 @@ The following table summarizes the runtime and compilation strategy used by
 
 | Platform | Debug | Release |
 |---|---|---|
-| **Android** | CoreCLR + JIT | CoreCLR + partial composite ReadyToRun + JIT |
-| **iOS** | CoreCLR + partial composite ReadyToRun + interpreter | CoreCLR + full composite ReadyToRun + interpreter |
-| **Mac Catalyst** | CoreCLR + partial composite ReadyToRun + interpreter | CoreCLR + full composite ReadyToRun + interpreter |
+| **Android** | CoreCLR + JIT | CoreCLR + composite partial ReadyToRun + JIT |
+| **iOS** | CoreCLR + composite partial ReadyToRun + interpreter | CoreCLR + composite full ReadyToRun + interpreter |
+| **Mac Catalyst** | CoreCLR + composite partial ReadyToRun + interpreter | CoreCLR + composite full ReadyToRun + interpreter |
 | **Windows** | CoreCLR + JIT | CoreCLR + JIT + ReadyToRun |
 
 > [!IMPORTANT]

--- a/docs/deployment/runtimes-compilation.md
+++ b/docs/deployment/runtimes-compilation.md
@@ -31,7 +31,7 @@ on mobile and Mac Catalyst platforms.
 
 ::: moniker range=">=net-maui-11.0"
 
-Mono isn't supported for .NET MAUI apps that target .NET 11.
+Mono isn't supported for .NET MAUI apps that target .NET 11+.
 
 ::: moniker-end
 
@@ -51,7 +51,7 @@ also available as an experimental option for Android.
 
 ::: moniker range=">=net-maui-11.0"
 
-In .NET 11, CoreCLR is the runtime for .NET MAUI apps on Windows, Android,
+In .NET 11+, CoreCLR is the runtime for .NET MAUI apps on Windows, Android,
 iOS, and Mac Catalyst. NativeAOT is an opt-in alternative for publishing.
 
 ::: moniker-end
@@ -137,8 +137,8 @@ restrictions on the code patterns you can use.
 - **Available on**: .NET MAUI iOS and Mac Catalyst apps when explicitly
   enabled for publishing
 - **Advantages**: Small app size, fast startup, and a single native binary
-- **Disadvantages**: No dynamic code generation or dynamic loading; all code
-  must be trim-safe and AOT-compatible
+- **Disadvantages**: Longer build times, no dynamic code generation or dynamic
+  loading, and all code must be trim-safe and AOT-compatible
 - **MSBuild property**: `<PublishAot>true</PublishAot>`
 
 ::: moniker-end
@@ -148,8 +148,8 @@ restrictions on the code patterns you can use.
 - **Available on**: .NET MAUI iOS and Mac Catalyst apps, and experimentally
   on Android, when explicitly enabled for publishing
 - **Advantages**: Small app size, fast startup, and a single native binary
-- **Disadvantages**: No dynamic code generation or dynamic loading; all code
-  must be trim-safe and AOT-compatible
+- **Disadvantages**: Longer build times, no dynamic code generation or dynamic
+  loading, and all code must be trim-safe and AOT-compatible
 - **MSBuild property**: `<PublishAot>true</PublishAot>`
 
 NativeAOT is a publish-only deployment model. Use `dotnet publish` to produce
@@ -197,7 +197,8 @@ can be enabled with `MauiEnableFullReadyToRun=true`. It can improve startup or
 runtime performance, but it increases package size, so measure the result for
 your app.
 
-For iOS and Mac Catalyst apps, full composite ReadyToRun is used. On iOS, the
+For iOS and Mac Catalyst apps, partial composite ReadyToRun is used in `Debug`
+builds and full composite ReadyToRun is used in `Release` builds. On iOS, the
 CoreCLR interpreter is always enabled and executes code where the operating
 system doesn't permit JIT compilation.
 
@@ -299,12 +300,12 @@ The following table summarizes the runtime and compilation strategy used by
 | Platform | Debug | Release |
 |---|---|---|
 | **Android** | CoreCLR + JIT | CoreCLR + partial composite ReadyToRun + JIT |
-| **iOS** | CoreCLR + full composite ReadyToRun + interpreter | CoreCLR + full composite ReadyToRun + interpreter |
-| **Mac Catalyst** | CoreCLR + full composite ReadyToRun + interpreter | CoreCLR + full composite ReadyToRun + interpreter |
+| **iOS** | CoreCLR + partial composite ReadyToRun + interpreter | CoreCLR + full composite ReadyToRun + interpreter |
+| **Mac Catalyst** | CoreCLR + partial composite ReadyToRun + interpreter | CoreCLR + full composite ReadyToRun + interpreter |
 | **Windows** | CoreCLR + JIT | CoreCLR + JIT + ReadyToRun |
 
 > [!IMPORTANT]
-> Don't set `UseMonoRuntime` to `true` when targeting .NET 11. Mono isn't
+> Don't set `UseMonoRuntime` to `true` when targeting .NET 11+. Mono isn't
 > supported, and setting this property produces a build error.
 
 > [!TIP]
@@ -389,11 +390,11 @@ for production use.
 
 ::: moniker range=">=net-maui-11.0"
 
-In .NET 11, CoreCLR is the supported runtime for Android, iOS, and Mac
+In .NET 11+, CoreCLR is the supported runtime for Android, iOS, and Mac
 Catalyst apps unless NativeAOT is explicitly enabled for publishing. NativeAOT
 is an opt-in alternative that doesn't use CoreCLR and remains experimental on
 Android. Don't set
-`UseMonoRuntime=true`; Mono isn't supported for .NET 11, and setting the
+`UseMonoRuntime=true`; Mono isn't supported for .NET 11+, and setting the
 property produces a build error.
 
 ::: moniker-end
@@ -495,6 +496,7 @@ runtime and compilation behavior:
 |---|---|---|
 | `PublishAot` | Enable NativeAOT compilation during `dotnet publish`. | `false` |
 | `MauiEnableFullReadyToRun` | Enable full ReadyToRun for Android CoreCLR apps. | `false` |
+| `PublishTrimmed` | Enable ILLink trimming. | `true` (Release) |
 | `TrimMode` | Set trimming aggressiveness for non-NativeAOT builds. | `partial` |
 
 ::: moniker-end

--- a/docs/whats-new/dotnet-11.md
+++ b/docs/whats-new/dotnet-11.md
@@ -483,7 +483,7 @@ For more information, see [Supported platforms](~/supported-platforms.md).
 
 ### CoreCLR runtime
 
-In `Release` builds, the runtime uses partial composite ReadyToRun by default.
+In `Release` builds, the runtime uses composite partial ReadyToRun by default.
 `Debug` builds don't enable ReadyToRun by default.
 
 ### Faster and more reliable Android builds
@@ -599,8 +599,8 @@ Starting in .NET 11 Preview 4, HTTP digest authentication is supported in <xref:
 In .NET 11 Preview 4, CoreCLR became the default runtime for .NET for iOS,
 Mac Catalyst, and macOS, while Mono remained available. Starting in .NET 11
 Preview 7, CoreCLR is the only supported runtime for these platforms.
-On iOS and Mac Catalyst, CoreCLR uses partial composite ReadyToRun in `Debug`
-builds and full composite ReadyToRun in `Release` builds. On iOS, the CoreCLR
+On iOS and Mac Catalyst, CoreCLR uses composite partial ReadyToRun in `Debug`
+builds and composite full ReadyToRun in `Release` builds. On iOS, the CoreCLR
 interpreter is always enabled and executes code where the operating system
 doesn't permit JIT compilation.
 For more information, see [CoreCLR is the only runtime](#coreclr-is-the-only-runtime)

--- a/docs/whats-new/dotnet-11.md
+++ b/docs/whats-new/dotnet-11.md
@@ -1,7 +1,7 @@
 ---
 title: What's new in .NET MAUI for .NET 11
 description: Learn about the new features introduced in .NET MAUI for .NET 11.
-ms.date: 09/08/2026
+ms.date: 09/10/2026
 ---
 
 # What's new in .NET MAUI for .NET 11
@@ -456,7 +456,8 @@ Starting in .NET 11 Preview 7, the XAML source generator compiles a binding that
 ## .NET for Android
 
 .NET for Android in .NET 11 uses CoreCLR as the supported runtime for
-standard apps. NativeAOT is also available as an opt-in publishing alternative.
+standard apps. NativeAOT is also available as an experimental, opt-in
+publishing alternative.
 This release includes work to improve performance. For more information about
 .NET for Android in .NET 11, see the following release notes:
 
@@ -482,7 +483,7 @@ For more information, see [Supported platforms](~/supported-platforms.md).
 
 ### CoreCLR runtime
 
-In `Release` builds, the runtime uses composite partial ReadyToRun by default.
+In `Release` builds, the runtime uses partial composite ReadyToRun by default.
 `Debug` builds don't enable ReadyToRun by default.
 
 ### Faster and more reliable Android builds
@@ -598,7 +599,9 @@ Starting in .NET 11 Preview 4, HTTP digest authentication is supported in <xref:
 In .NET 11 Preview 4, CoreCLR became the default runtime for .NET for iOS,
 Mac Catalyst, and macOS, while Mono remained available. Starting in .NET 11
 Preview 7, CoreCLR is the only supported runtime for these platforms.
-Apple CoreCLR uses ReadyToRun and the CoreCLR interpreter; it doesn't use JIT.
+On iOS and Mac Catalyst, CoreCLR uses full composite ReadyToRun. On iOS, the
+CoreCLR interpreter is always enabled and executes code where the operating
+system doesn't permit JIT compilation.
 For more information, see [CoreCLR is the only runtime](#coreclr-is-the-only-runtime)
 and [dotnet/macios #25050](https://github.com/dotnet/macios/pull/25050).
 

--- a/docs/whats-new/dotnet-11.md
+++ b/docs/whats-new/dotnet-11.md
@@ -599,9 +599,10 @@ Starting in .NET 11 Preview 4, HTTP digest authentication is supported in <xref:
 In .NET 11 Preview 4, CoreCLR became the default runtime for .NET for iOS,
 Mac Catalyst, and macOS, while Mono remained available. Starting in .NET 11
 Preview 7, CoreCLR is the only supported runtime for these platforms.
-On iOS and Mac Catalyst, CoreCLR uses full composite ReadyToRun. On iOS, the
-CoreCLR interpreter is always enabled and executes code where the operating
-system doesn't permit JIT compilation.
+On iOS and Mac Catalyst, CoreCLR uses partial composite ReadyToRun in `Debug`
+builds and full composite ReadyToRun in `Release` builds. On iOS, the CoreCLR
+interpreter is always enabled and executes code where the operating system
+doesn't permit JIT compilation.
 For more information, see [CoreCLR is the only runtime](#coreclr-is-the-only-runtime)
 and [dotnet/macios #25050](https://github.com/dotnet/macios/pull/25050).
 


### PR DESCRIPTION
## Summary

Builds on #3511 and refines the .NET 11 RC 1 runtime guidance:

- Preserves the established ReadyToRun terminology.
- Documents partial ReadyToRun for Apple `Debug` builds and full ReadyToRun for `Release` builds.
- Clarifies that the iOS CoreCLR interpreter is always enabled and runs code where the OS disallows JIT compilation.
- Preserves NativeAOT's experimental status on Android.
- Preserves the existing `coreclr-on-android-and-ios` section anchor and removes unsupported .NET 10 Apple CoreCLR guidance.

## Dependency

This PR is based on a temporary upstream mirror of the current #3511 head because #3511 originates from a fork. After #3511 merges, this branch should be rebased onto `main` and the temporary mirror can be removed.

## Files changed

- `docs/deployment/runtimes-compilation.md`
- `docs/whats-new/dotnet-11.md`

## Upstream references

- dotnet/macios#25050
- dotnet/maui#37094
- dotnet/android#12299

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [docs/deployment/runtimes-compilation.md](https://github.com/dotnet/docs-maui/blob/4a3ff27b13afbdbf1f30a991bedfcce152543c6e/docs/deployment/runtimes-compilation.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/maui/deployment/runtimes-compilation?view=net-maui-11.0&branch=pr-en-us-3515) |
| [docs/whats-new/dotnet-11.md](https://github.com/dotnet/docs-maui/blob/4a3ff27b13afbdbf1f30a991bedfcce152543c6e/docs/whats-new/dotnet-11.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/maui/whats-new/dotnet-11?view=net-maui-11.0&branch=pr-en-us-3515) |


<!-- PREVIEW-TABLE-END -->

[Build report](https://buildapi.docs.microsoft.com/Output/PullRequest/a552e5fb-82af-ee54-cd17-c63b0b54d6f7/202609101320513761-3515/BuildReport?accessString=9b68598fc4316f663da9e8b6c564a9b2bae4ae5300c812d46f63d099bec9e929)